### PR TITLE
Phase 3 — Full Mode (WireGuard) [WIP]

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -92,6 +92,9 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.zxing.core)
+    // Official WireGuard key generation + crypto (Full Mode, ADR-0008). The
+    // userspace forwarder AAR is added by the wg-forwarder build in CI.
+    implementation(libs.wireguard.tunnel)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/android/app/src/main/kotlin/io/relay/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/relay/app/MainActivity.kt
@@ -52,11 +52,14 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
+                    val transportMode by viewModel.transportMode.collectAsState()
+
                     HomeScreen(
                         state = state,
                         batteryExempt = batteryExempt,
                         warnings = warnings,
                         themeMode = themeMode,
+                        transportMode = transportMode,
                         preferredPort = preferredPort,
                         logs = logs,
                         onStart = {
@@ -72,6 +75,7 @@ class MainActivity : ComponentActivity() {
                         onAllowBattery = ::requestBatteryExemption,
                         onDismissWarning = viewModel::dismissWarning,
                         onSetTheme = viewModel::setThemeMode,
+                        onSetMode = viewModel::setTransportMode,
                         onSetPort = viewModel::setPreferredPort,
                         onClearLogs = viewModel::clearLogs,
                     )

--- a/android/app/src/main/kotlin/io/relay/app/core/ConnectionState.kt
+++ b/android/app/src/main/kotlin/io/relay/app/core/ConnectionState.kt
@@ -48,6 +48,7 @@ enum class ErrorCode {
     HOTSPOT_LOST,
     PORT_IN_USE,
     SERVICE_FAILED,
+    WG_START_FAILED,
 }
 
 /** Non-blocking, dismissible advisories shown as a banner (docs/errors.md → Warning). */

--- a/android/app/src/main/kotlin/io/relay/app/core/PairingStrategy.kt
+++ b/android/app/src/main/kotlin/io/relay/app/core/PairingStrategy.kt
@@ -7,8 +7,17 @@ package io.relay.app.core
  * bump the payload version — transport code never changes.
  */
 interface PairingStrategy {
-    /** Builds the payload advertised to clients for the current session. */
-    fun issuePayload(mode: String, host: String, port: Int, deviceName: String?): QrPayload
+    /**
+     * Builds the payload advertised to clients. [wg] is present only for Full
+     * Mode (mode == wireguard) and carries the per-pairing key material.
+     */
+    fun issuePayload(
+        mode: String,
+        host: String,
+        port: Int,
+        deviceName: String?,
+        wg: WgParams? = null,
+    ): QrPayload
 
     /** The 8-char typed-code fallback, or null when unavailable (see /shared/typed-code.md). */
     fun issueTypedCode(payload: QrPayload): String?
@@ -18,7 +27,13 @@ class DirectPairingStrategy(
     private val clock: () -> Long = { System.currentTimeMillis() / 1000 },
 ) : PairingStrategy {
 
-    override fun issuePayload(mode: String, host: String, port: Int, deviceName: String?): QrPayload =
+    override fun issuePayload(
+        mode: String,
+        host: String,
+        port: Int,
+        deviceName: String?,
+        wg: WgParams?,
+    ): QrPayload =
         QrPayload(
             v = QrPayloadCodec.SUPPORTED_VERSION,
             mode = mode,
@@ -26,8 +41,10 @@ class DirectPairingStrategy(
             port = port,
             name = deviceName,
             issuedAt = clock(),
+            wg = wg,
         )
 
+    /** Full Mode key material doesn't fit a human code — typed codes are Fast Mode only. */
     override fun issueTypedCode(payload: QrPayload): String? =
-        TypedCode.encode(payload.host, payload.port)
+        if (payload.mode == QrPayload.MODE_SOCKS5) TypedCode.encode(payload.host, payload.port) else null
 }

--- a/android/app/src/main/kotlin/io/relay/app/core/QrPayloadCodec.kt
+++ b/android/app/src/main/kotlin/io/relay/app/core/QrPayloadCodec.kt
@@ -32,6 +32,9 @@ object QrPayloadCodec {
         "^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$"
     )
 
+    /** base64 of a 32-byte Curve25519 key (matches /shared/qr-payload.schema.json). */
+    private val wgKeyRegex = Regex("^[A-Za-z0-9+/]{42}[AEIMQUYcgkosw480]=$")
+
     fun encode(payload: QrPayload): String {
         val bytes = json.encodeToString(QrPayload.serializer(), payload).toByteArray(Charsets.UTF_8)
         return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
@@ -82,6 +85,10 @@ object QrPayloadCodec {
         if (mode == QrPayload.MODE_SOCKS5 && hasWg) {
             return DecodeResult.Invalid("unexpected-wg-block")
         }
+        if (mode == QrPayload.MODE_WIREGUARD) {
+            val wgResult = validateWg(obj["wg"] as? JsonObject)
+            if (wgResult != null) return wgResult
+        }
 
         val payload = try {
             json.decodeFromJsonElement(QrPayload.serializer(), obj)
@@ -89,5 +96,20 @@ object QrPayloadCodec {
             return DecodeResult.Invalid("decode-error")
         }
         return DecodeResult.Ok(payload)
+    }
+
+    /** Validates the wg sub-object; returns an Invalid result on the first problem, else null. */
+    private fun validateWg(wg: JsonObject?): DecodeResult? {
+        if (wg == null) return DecodeResult.Invalid("missing-wg-block")
+        for (field in listOf("serverPublicKey", "clientPrivateKey", "allowedIps", "endpointPort", "dns")) {
+            if (!wg.containsKey(field)) return DecodeResult.Invalid("missing-wg-field")
+        }
+        val serverKey = wg["serverPublicKey"]?.jsonPrimitive?.contentOrNull
+        val clientKey = wg["clientPrivateKey"]?.jsonPrimitive?.contentOrNull
+        if (serverKey == null || !wgKeyRegex.matches(serverKey)) return DecodeResult.Invalid("invalid-wg-key")
+        if (clientKey == null || !wgKeyRegex.matches(clientKey)) return DecodeResult.Invalid("invalid-wg-key")
+        val endpointPort = wg["endpointPort"]?.jsonPrimitive?.intOrNull
+        if (endpointPort == null || endpointPort !in 1..65535) return DecodeResult.Invalid("invalid-wg-port")
+        return null
     }
 }

--- a/android/app/src/main/kotlin/io/relay/app/core/TransportMode.kt
+++ b/android/app/src/main/kotlin/io/relay/app/core/TransportMode.kt
@@ -1,0 +1,16 @@
+package io.relay.app.core
+
+/**
+ * The two transport modes (§4.1). The selected mode decides which server the
+ * phone brings up and which `mode` the QR carries; it is not a state-machine
+ * state, so switching needs no restart (ADR-0008, AC3.3).
+ */
+enum class TransportMode(val payloadMode: String) {
+    FAST(QrPayload.MODE_SOCKS5),
+    FULL(QrPayload.MODE_WIREGUARD);
+
+    companion object {
+        fun fromSetting(value: String?): TransportMode =
+            entries.firstOrNull { it.name.equals(value, ignoreCase = true) } ?: FAST
+    }
+}

--- a/android/app/src/main/kotlin/io/relay/app/core/WgConfig.kt
+++ b/android/app/src/main/kotlin/io/relay/app/core/WgConfig.kt
@@ -1,0 +1,53 @@
+package io.relay.app.core
+
+/**
+ * Pure assembly of WireGuard configuration from a generated key set. Kept free
+ * of any Android/crypto dependency so it is unit-tested on the JVM; key
+ * generation itself lives in [io.relay.app.net.wg.WgKeys].
+ *
+ * Addressing is fixed and private to the tunnel: the phone (server) is
+ * 10.7.0.1, the single client (laptop) is 10.7.0.2.
+ */
+object WgConfig {
+    const val SERVER_TUNNEL_IP = "10.7.0.1"
+    const val CLIENT_TUNNEL_IP = "10.7.0.2"
+    const val CLIENT_ALLOWED_IPS = "0.0.0.0/0"
+    const val DEFAULT_DNS = "1.1.1.1"
+    const val DEFAULT_ENDPOINT_PORT = 51820
+
+    /** Keys and parameters for one pairing. Private keys never leave the intended device. */
+    data class KeySet(
+        val serverPrivateKey: String,
+        val serverPublicKey: String,
+        val clientPrivateKey: String,
+        val clientPublicKey: String,
+        val endpointPort: Int = DEFAULT_ENDPOINT_PORT,
+        val dns: String = DEFAULT_DNS,
+    )
+
+    /** What goes into the QR `wg` block: the client needs the server's *public* key and its own *private* key. */
+    fun toWgParams(keys: KeySet): WgParams = WgParams(
+        serverPublicKey = keys.serverPublicKey,
+        clientPrivateKey = keys.clientPrivateKey,
+        allowedIps = CLIENT_ALLOWED_IPS,
+        endpointPort = keys.endpointPort,
+        dns = keys.dns,
+    )
+
+    /**
+     * The phone-side (server) config the userspace forwarder consumes
+     * (ADR-0008). It listens on [KeySet.endpointPort] and accepts the single
+     * client peer routed at 10.7.0.2/32; the netstack forwards its traffic out
+     * over the phone's default network.
+     */
+    fun serverConfig(keys: KeySet): String = buildString {
+        appendLine("[Interface]")
+        appendLine("PrivateKey = ${keys.serverPrivateKey}")
+        appendLine("Address = $SERVER_TUNNEL_IP/24")
+        appendLine("ListenPort = ${keys.endpointPort}")
+        appendLine()
+        appendLine("[Peer]")
+        appendLine("PublicKey = ${keys.clientPublicKey}")
+        appendLine("AllowedIPs = $CLIENT_TUNNEL_IP/32")
+    }
+}

--- a/android/app/src/main/kotlin/io/relay/app/net/wg/WgForwarder.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/wg/WgForwarder.kt
@@ -1,0 +1,19 @@
+package io.relay.app.net.wg
+
+/**
+ * The phone-side userspace WireGuard endpoint + netstack forwarder (ADR-0008).
+ * The concrete implementation is backed by the gomobile-built wireguard-go AAR
+ * ([GoWgForwarder]); this interface keeps the service decoupled from it and
+ * lets the rest of the app compile and be tested without the native library.
+ */
+interface WgForwarder {
+    /**
+     * Brings up the endpoint from a server [config] (see [io.relay.app.core.WgConfig]).
+     * @throws WgForwarderException if the endpoint could not start.
+     */
+    fun start(config: String)
+
+    fun stop()
+}
+
+class WgForwarderException(message: String, cause: Throwable? = null) : Exception(message, cause)

--- a/android/app/src/main/kotlin/io/relay/app/net/wg/WgForwarderProvider.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/wg/WgForwarderProvider.kt
@@ -1,0 +1,18 @@
+package io.relay.app.net.wg
+
+/**
+ * Supplies the concrete [WgForwarder]. The real implementation ([GoWgForwarder])
+ * is backed by the gomobile-built wireguard-go AAR; it is constructed
+ * reflectively so the rest of the app compiles and runs even when the native
+ * library is absent (in which case Full Mode reports it can't start rather than
+ * failing the build).
+ */
+object WgForwarderProvider {
+    fun create(): WgForwarder? = try {
+        Class.forName("io.relay.app.net.wg.GoWgForwarder")
+            .getDeclaredConstructor()
+            .newInstance() as WgForwarder
+    } catch (_: Throwable) {
+        null
+    }
+}

--- a/android/app/src/main/kotlin/io/relay/app/net/wg/WgKeys.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/wg/WgKeys.kt
@@ -1,0 +1,29 @@
+package io.relay.app.net.wg
+
+import com.wireguard.crypto.KeyPair
+import io.relay.app.core.WgConfig
+
+/**
+ * Per-pairing WireGuard key generation using the official WireGuard crypto
+ * (`com.wireguard.crypto`, no hand-rolled crypto — ADR-0008). The phone mints
+ * both key pairs — its own (server) and the client's — so the QR can carry the
+ * server public key and the client private key. All of it is discarded on
+ * disconnect (§4.2).
+ */
+object WgKeys {
+    fun generate(
+        endpointPort: Int = WgConfig.DEFAULT_ENDPOINT_PORT,
+        dns: String = WgConfig.DEFAULT_DNS,
+    ): WgConfig.KeySet {
+        val server = KeyPair()
+        val client = KeyPair()
+        return WgConfig.KeySet(
+            serverPrivateKey = server.privateKey.toBase64(),
+            serverPublicKey = server.publicKey.toBase64(),
+            clientPrivateKey = client.privateKey.toBase64(),
+            clientPublicKey = client.publicKey.toBase64(),
+            endpointPort = endpointPort,
+            dns = dns,
+        )
+    }
+}

--- a/android/app/src/main/kotlin/io/relay/app/service/Settings.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/Settings.kt
@@ -19,8 +19,14 @@ class Settings(context: Context) {
         get() = prefs.getString(KEY_THEME, "system") ?: "system"
         set(value) = prefs.edit().putString(KEY_THEME, value).apply()
 
+    /** "FAST" | "FULL" — the selected transport mode (TransportMode.name). */
+    var transportMode: String
+        get() = prefs.getString(KEY_MODE, "FAST") ?: "FAST"
+        set(value) = prefs.edit().putString(KEY_MODE, value).apply()
+
     companion object {
         private const val KEY_PORT = "preferred_port"
         private const val KEY_THEME = "theme_mode"
+        private const val KEY_MODE = "transport_mode"
     }
 }

--- a/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
@@ -20,10 +20,16 @@ import io.relay.app.core.DirectPairingStrategy
 import io.relay.app.core.ErrorCode
 import io.relay.app.core.QrPayload
 import io.relay.app.core.ReconnectPolicy
+import io.relay.app.core.TransportMode
 import io.relay.app.core.WarningCode
+import io.relay.app.core.WgConfig
 import io.relay.app.net.HotspotInfo
 import io.relay.app.net.Socks5Server
 import io.relay.app.net.VpnStatus
+import io.relay.app.net.wg.WgForwarder
+import io.relay.app.net.wg.WgForwarderException
+import io.relay.app.net.wg.WgForwarderProvider
+import io.relay.app.net.wg.WgKeys
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -50,6 +56,11 @@ class SharingService : Service() {
     private var lastTrafficPush = 0L
     private var currentHost: String? = null
     private var hotspotWatcher: Job? = null
+
+    // Full Mode session (ADR-0008): the userspace forwarder + this pairing's keys.
+    private var mode = TransportMode.FAST
+    private var wgForwarder: WgForwarder? = WgForwarderProvider.create()
+    private var wgKeys: WgConfig.KeySet? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -116,25 +127,57 @@ class SharingService : Service() {
             return
         }
 
-        val boundPort = bindServer()
-        if (boundPort < 0) {
-            LocalLog.add("All candidate ports busy")
-            ConnectionRepository.dispatch("failure") { ConnectionState.Error(ErrorCode.PORT_IN_USE) }
-            return
-        }
-        currentHost = host
+        mode = TransportMode.fromSetting(settings.transportMode)
+        LocalLog.add("Mode: ${mode.name}")
+        val payload = when (mode) {
+            TransportMode.FAST -> prepareFast(host)
+            TransportMode.FULL -> prepareFull(host)
+        } ?: return // preparation dispatched the appropriate error
 
-        val payload = pairing.issuePayload(
-            mode = QrPayload.MODE_SOCKS5,
-            host = host,
-            port = boundPort,
-            deviceName = Build.MODEL.take(64),
-        )
-        LocalLog.add("Advertising on $host:$boundPort")
+        currentHost = host
         ConnectionRepository.dispatch("ready") {
             ConnectionState.Advertising(payload, pairing.issueTypedCode(payload))
         }
         startHotspotWatcher()
+    }
+
+    /** Fast Mode: bind the SOCKS server and return its socks5 payload, or null on failure. */
+    private fun prepareFast(host: String): QrPayload? {
+        val boundPort = bindServer()
+        if (boundPort < 0) {
+            LocalLog.add("All candidate ports busy")
+            ConnectionRepository.dispatch("failure") { ConnectionState.Error(ErrorCode.PORT_IN_USE) }
+            return null
+        }
+        LocalLog.add("Advertising SOCKS on $host:$boundPort")
+        return pairing.issuePayload(
+            mode = QrPayload.MODE_SOCKS5, host = host, port = boundPort,
+            deviceName = Build.MODEL.take(64),
+        )
+    }
+
+    /** Full Mode: mint per-pairing keys, start the userspace WG endpoint, return its wireguard payload. */
+    private fun prepareFull(host: String): QrPayload? {
+        val forwarder = wgForwarder
+        if (forwarder == null) {
+            LocalLog.add("WireGuard forwarder unavailable")
+            ConnectionRepository.dispatch("failure") { ConnectionState.Error(ErrorCode.WG_START_FAILED) }
+            return null
+        }
+        val keys = WgKeys.generate()
+        try {
+            forwarder.start(WgConfig.serverConfig(keys))
+        } catch (e: WgForwarderException) {
+            LocalLog.add("WireGuard endpoint failed: ${e.message}")
+            ConnectionRepository.dispatch("failure") { ConnectionState.Error(ErrorCode.WG_START_FAILED) }
+            return null
+        }
+        wgKeys = keys
+        LocalLog.add("WireGuard endpoint up on $host:${keys.endpointPort}")
+        return pairing.issuePayload(
+            mode = QrPayload.MODE_WIREGUARD, host = host, port = keys.endpointPort,
+            deviceName = Build.MODEL.take(64), wg = WgConfig.toWgParams(keys),
+        )
     }
 
     /** Binds the SOCKS server; preferred port (Advanced) first, then the fallback list. Returns the bound port or -1. */
@@ -194,26 +237,39 @@ class SharingService : Service() {
         return false
     }
 
-    /** Hotspot returned on a different IP: restart the server and re-issue the QR/code. */
+    /** Hotspot returned on a different IP: re-advertise (and, for Fast, rebind the socket). */
     private fun rebind(host: String) {
-        server?.stop()
-        server = null
-        val boundPort = bindServer()
-        if (boundPort < 0) {
-            teardown()
-            ConnectionRepository.dispatch("failure") { ConnectionState.Error(ErrorCode.PORT_IN_USE) }
-            return
-        }
         currentHost = host
-        val payload = pairing.issuePayload(
-            mode = QrPayload.MODE_SOCKS5, host = host, port = boundPort,
-            deviceName = Build.MODEL.take(64),
-        )
-        val code = pairing.issueTypedCode(payload)
-        LocalLog.add("Re-advertising on $host:$boundPort")
+        val payload = when (mode) {
+            TransportMode.FAST -> {
+                server?.stop()
+                server = null
+                val boundPort = bindServer()
+                if (boundPort < 0) {
+                    teardown()
+                    ConnectionRepository.dispatch("failure") { ConnectionState.Error(ErrorCode.PORT_IN_USE) }
+                    return
+                }
+                LocalLog.add("Re-advertising SOCKS on $host:$boundPort")
+                pairing.issuePayload(
+                    mode = QrPayload.MODE_SOCKS5, host = host, port = boundPort,
+                    deviceName = Build.MODEL.take(64),
+                )
+            }
+            // Full Mode: the endpoint listens on a UDP port regardless of interface,
+            // so it stays up; only the advertised host changes, keys unchanged.
+            TransportMode.FULL -> {
+                val keys = wgKeys ?: return
+                LocalLog.add("Re-advertising WireGuard on $host:${keys.endpointPort}")
+                pairing.issuePayload(
+                    mode = QrPayload.MODE_WIREGUARD, host = host, port = keys.endpointPort,
+                    deviceName = Build.MODEL.take(64), wg = WgConfig.toWgParams(keys),
+                )
+            }
+        }
         // Present the fresh payload in place; the client count (if any) is stale
         // after a rebind, so drop back to Advertising until a client reconnects.
-        ConnectionRepository.reissue(payload, code)
+        ConnectionRepository.reissue(payload, pairing.issueTypedCode(payload))
     }
 
     private fun stopSharing() {
@@ -228,6 +284,9 @@ class SharingService : Service() {
         hotspotWatcher = null
         server?.stop()
         server = null
+        // Full Mode: stop the endpoint and drop the per-pairing keys (§4.2).
+        runCatching { wgForwarder?.stop() }
+        wgKeys = null
         currentHost = null
         releaseWakeLock()
         ConnectionRepository.clearWarnings()

--- a/android/app/src/main/kotlin/io/relay/app/ui/HomeScreen.kt
+++ b/android/app/src/main/kotlin/io/relay/app/ui/HomeScreen.kt
@@ -60,6 +60,7 @@ import io.relay.app.R
 import io.relay.app.core.ConnectionState
 import io.relay.app.core.ErrorCode
 import io.relay.app.core.QrPayloadCodec
+import io.relay.app.core.TransportMode
 import io.relay.app.core.WarningCode
 import io.relay.app.service.LocalLog
 import io.relay.app.ui.theme.LocalGlass
@@ -72,6 +73,7 @@ fun HomeScreen(
     batteryExempt: Boolean,
     warnings: Set<WarningCode>,
     themeMode: String,
+    transportMode: TransportMode,
     preferredPort: Int,
     logs: List<LocalLog.Entry>,
     onStart: () -> Unit,
@@ -81,6 +83,7 @@ fun HomeScreen(
     onAllowBattery: () -> Unit,
     onDismissWarning: (WarningCode) -> Unit,
     onSetTheme: (String) -> Unit,
+    onSetMode: (TransportMode) -> Unit,
     onSetPort: (Int) -> Unit,
     onClearLogs: () -> Unit,
 ) {
@@ -104,7 +107,7 @@ fun HomeScreen(
                 label = "state",
             ) { current ->
                 when (current) {
-                    is ConnectionState.Idle -> IdlePanel(onStart)
+                    is ConnectionState.Idle -> IdlePanel(transportMode, onSetMode, onStart)
                     is ConnectionState.Preparing -> PreparingPanel()
                     is ConnectionState.Advertising ->
                         PairingPanel(
@@ -225,7 +228,11 @@ private fun WarningBanners(warnings: Set<WarningCode>, onDismiss: (WarningCode) 
 // --- panels ------------------------------------------------------------------
 
 @Composable
-private fun IdlePanel(onStart: () -> Unit) {
+private fun IdlePanel(
+    transportMode: TransportMode,
+    onSetMode: (TransportMode) -> Unit,
+    onStart: () -> Unit,
+) {
     val glass = LocalGlass.current
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         Text(
@@ -233,13 +240,55 @@ private fun IdlePanel(onStart: () -> Unit) {
             style = MaterialTheme.typography.bodyMedium,
             color = glass.textSecondary,
         )
-        Spacer(Modifier.height(24.dp))
+        Spacer(Modifier.height(20.dp))
+        ModeToggle(transportMode, onSetMode)
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text = stringResource(
+                if (transportMode == TransportMode.FAST) R.string.mode_fast_desc
+                else R.string.mode_full_desc
+            ),
+            style = MaterialTheme.typography.labelSmall,
+            color = glass.textTertiary,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(Modifier.height(20.dp))
         PrimaryButton(text = stringResource(R.string.action_start), onClick = onStart)
         Spacer(Modifier.height(16.dp))
         Text(
             text = stringResource(R.string.tagline),
             style = MaterialTheme.typography.labelSmall,
             color = glass.textTertiary,
+        )
+    }
+}
+
+/** Segmented Fast/Full selector — one glass pill with the active segment in accent. */
+@Composable
+private fun ModeToggle(mode: TransportMode, onSet: (TransportMode) -> Unit) {
+    Row(
+        modifier = Modifier.clip(RoundedCornerShape(999.dp)).glassPanel(radius = 999.dp).padding(4.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+    ) {
+        ModeSegment(stringResource(R.string.mode_fast), mode == TransportMode.FAST) { onSet(TransportMode.FAST) }
+        ModeSegment(stringResource(R.string.mode_full), mode == TransportMode.FULL) { onSet(TransportMode.FULL) }
+    }
+}
+
+@Composable
+private fun ModeSegment(label: String, selected: Boolean, onClick: () -> Unit) {
+    val glass = LocalGlass.current
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(999.dp))
+            .background(if (selected) glass.accent else Color.Transparent)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 22.dp, vertical = 8.dp),
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (selected) glass.onAccent else glass.textSecondary,
         )
     }
 }
@@ -342,6 +391,7 @@ private fun ErrorPanel(code: ErrorCode, onRetry: () -> Unit, onDismiss: () -> Un
         ErrorCode.HOTSPOT_LOST -> R.string.error_hotspot_lost_title to R.string.error_hotspot_lost_body
         ErrorCode.PORT_IN_USE -> R.string.error_port_in_use_title to R.string.error_port_in_use_body
         ErrorCode.SERVICE_FAILED -> R.string.error_service_failed_title to R.string.error_service_failed_body
+        ErrorCode.WG_START_FAILED -> R.string.error_wg_start_title to R.string.error_wg_start_body
     }
     Column(
         modifier = Modifier.fillMaxWidth().glassPanel().padding(24.dp),

--- a/android/app/src/main/kotlin/io/relay/app/ui/MainViewModel.kt
+++ b/android/app/src/main/kotlin/io/relay/app/ui/MainViewModel.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.os.PowerManager
 import androidx.lifecycle.AndroidViewModel
 import io.relay.app.core.ConnectionState
+import io.relay.app.core.TransportMode
 import io.relay.app.core.WarningCode
 import io.relay.app.service.ConnectionRepository
 import io.relay.app.service.LocalLog
@@ -29,6 +30,9 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     private val _preferredPort = MutableStateFlow(settings.preferredPort)
     val preferredPort: StateFlow<Int> = _preferredPort
+
+    private val _transportMode = MutableStateFlow(TransportMode.fromSetting(settings.transportMode))
+    val transportMode: StateFlow<TransportMode> = _transportMode
 
     fun refreshBatteryExempt() {
         _batteryExempt.value = readBatteryExempt()
@@ -60,6 +64,12 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
         val clamped = port.takeIf { it in 1..65535 } ?: 0
         settings.preferredPort = clamped
         _preferredPort.value = clamped
+    }
+
+    /** Selects the transport mode; applied on the next start (choose while idle — AC3.3, no restart). */
+    fun setTransportMode(mode: TransportMode) {
+        settings.transportMode = mode.name
+        _transportMode.value = mode
     }
 
     fun clearLogs() = LocalLog.clear()

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -18,6 +18,12 @@
     <string name="traffic_format">↑ %1$s   ↓ %2$s</string>
     <string name="status_reconnecting">در حال اتصال مجدد…</string>
 
+    <!-- Transport modes -->
+    <string name="mode_fast">سریع</string>
+    <string name="mode_full">کامل</string>
+    <string name="mode_fast_desc">بهترین برای مرور و پخش.</string>
+    <string name="mode_full_desc">بهترین برای بازی و تماس تصویری.</string>
+
     <!-- Warnings (non-blocking banners) -->
     <string name="warning_no_vpn_title">هیچ VPN فعالی نیست</string>
     <string name="warning_no_vpn_body">در حال اشتراک اتصال معمولی خود هستید. اگر می‌خواستید VPN را به‌اشتراک بگذارید، ابتدا آن را روشن کنید.</string>
@@ -45,6 +51,8 @@
     <string name="error_service_failed_body">اشتراک‌گذاری به‌طور غیرمنتظره متوقف شد. دوباره شروع کنید.</string>
     <string name="error_hotspot_lost_title">اتصال هات‌اسپات قطع شد</string>
     <string name="error_hotspot_lost_body">هات‌اسپات قطع شد و بازنگشت. مطمئن شوید روشن است و دوباره اشتراک‌گذاری را شروع کنید.</string>
+    <string name="error_wg_start_title">حالت کامل شروع نشد</string>
+    <string name="error_wg_start_body">تونل WireGuard روی این گوشی شروع نشد. حالت سریع را امتحان کنید یا دوباره شروع کنید.</string>
     <string name="action_retry">تلاش دوباره</string>
     <string name="action_dismiss">بستن</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -18,6 +18,12 @@
     <string name="traffic_format">↑ %1$s   ↓ %2$s</string>
     <string name="status_reconnecting">Reconnecting…</string>
 
+    <!-- Transport modes -->
+    <string name="mode_fast">Fast</string>
+    <string name="mode_full">Full</string>
+    <string name="mode_fast_desc">Best for browsing and streaming.</string>
+    <string name="mode_full_desc">Best for games and video calls.</string>
+
     <!-- Warnings (non-blocking banners) -->
     <string name="warning_no_vpn_title">No VPN is active</string>
     <string name="warning_no_vpn_body">You\'re sharing your regular connection. Turn on your VPN first if you meant to share it.</string>
@@ -45,6 +51,8 @@
     <string name="error_service_failed_body">Sharing stopped unexpectedly. Try starting it again.</string>
     <string name="error_hotspot_lost_title">Hotspot connection lost</string>
     <string name="error_hotspot_lost_body">The hotspot dropped and didn\'t come back. Check it\'s still on, then start sharing again.</string>
+    <string name="error_wg_start_title">Couldn\'t start Full Mode</string>
+    <string name="error_wg_start_body">The WireGuard tunnel couldn\'t start on this phone. Try Fast Mode, or start sharing again.</string>
     <string name="action_retry">Try Again</string>
     <string name="action_dismiss">Dismiss</string>
 

--- a/android/app/src/test/kotlin/io/relay/app/WgConfigTest.kt
+++ b/android/app/src/test/kotlin/io/relay/app/WgConfigTest.kt
@@ -1,0 +1,62 @@
+package io.relay.app
+
+import io.relay.app.core.DirectPairingStrategy
+import io.relay.app.core.QrPayload
+import io.relay.app.core.QrPayloadCodec
+import io.relay.app.core.DecodeResult
+import io.relay.app.core.WgConfig
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WgConfigTest {
+
+    // Format-valid keys (from /shared/test-vectors.json), not real ones.
+    private val keys = WgConfig.KeySet(
+        serverPrivateKey = "P2GJ1aWQb5UrrLNLl/iwYX/AA8K6C/BS9L1e2Jnewpo=",
+        serverPublicKey = "a1yn3fwDEBl6ZPc+KD67rwGn0oia5dlFElp9lkWxGI4=",
+        clientPrivateKey = "6dE0jvo6/PbUqznG29Xkno78HyGGwtH1UYl3WXQEkZQ=",
+        clientPublicKey = "alMc1KaITw/vbYW3PmNUub6swP8d+rw3I0fu01FVefc=",
+    )
+
+    @Test
+    fun `wg params carry the server public and client private keys`() {
+        val params = WgConfig.toWgParams(keys)
+        assertEquals(keys.serverPublicKey, params.serverPublicKey)
+        assertEquals(keys.clientPrivateKey, params.clientPrivateKey)
+        assertEquals(WgConfig.CLIENT_ALLOWED_IPS, params.allowedIps)
+        assertEquals(WgConfig.DEFAULT_ENDPOINT_PORT, params.endpointPort)
+    }
+
+    @Test
+    fun `server config lists the client peer at its tunnel ip`() {
+        val config = WgConfig.serverConfig(keys)
+        assertTrue(config.contains("PrivateKey = ${keys.serverPrivateKey}"))
+        assertTrue(config.contains("ListenPort = ${keys.endpointPort}"))
+        assertTrue(config.contains("PublicKey = ${keys.clientPublicKey}"))
+        assertTrue(config.contains("AllowedIPs = ${WgConfig.CLIENT_TUNNEL_IP}/32"))
+    }
+
+    @Test
+    fun `issued wireguard payload passes the shared codec validation`() {
+        val payload = DirectPairingStrategy { 1730000000L }.issuePayload(
+            mode = QrPayload.MODE_WIREGUARD,
+            host = "192.168.43.1",
+            port = WgConfig.DEFAULT_ENDPOINT_PORT,
+            deviceName = "Pixel",
+            wg = WgConfig.toWgParams(keys),
+        )
+        val roundTrip = QrPayloadCodec.decode(QrPayloadCodec.encode(payload))
+        assertTrue(roundTrip is DecodeResult.Ok)
+        assertEquals(payload, (roundTrip as DecodeResult.Ok).payload)
+    }
+
+    @Test
+    fun `typed code is not offered for full mode`() {
+        val payload = DirectPairingStrategy().issuePayload(
+            QrPayload.MODE_WIREGUARD, "192.168.43.1", 51820, "Pixel", WgConfig.toWgParams(keys),
+        )
+        assertNull(DirectPairingStrategy().issueTypedCode(payload))
+    }
+}

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ junit = "4.13.2"
 kotlinxSerialization = "1.7.3"
 kotlinxCoroutines = "1.9.0"
 zxing = "3.5.3"
+wireguard = "1.0.20230706"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -24,6 +25,7 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 kotlinx-coroutines-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinxCoroutines" }
 kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxing" }
+wireguard-tunnel = { group = "com.wireguard.android", name = "tunnel", version.ref = "wireguard" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 
 [plugins]

--- a/docs/adr/0008-full-mode-wireguard-forwarder.md
+++ b/docs/adr/0008-full-mode-wireguard-forwarder.md
@@ -1,0 +1,56 @@
+# ADR-0008: Full Mode — phone as a userspace WireGuard forwarding endpoint
+
+**Status:** Accepted · **Date:** 2026-07-07
+
+## Context
+
+Full Mode (§4.1) needs the **phone** to be a WireGuard endpoint that the Windows
+client dials, with the phone forwarding the client's TCP **and** UDP out through
+the phone's active VPN. The spec names `com.wireguard.android` and
+WinTun/`wireguard-go` (§5.1–5.2).
+
+Two realities shape the design:
+
+1. **The phone is the server, and it's unrooted.** `com.wireguard.android`'s
+   `GoBackend` is *client*-shaped: it stands up a `VpnService` that routes the
+   **device's own** traffic to a remote peer. It does not expose "accept a peer
+   and NAT its traffic to the internet," and unrooted Android has no iptables/NAT
+   to forward packets from a WireGuard interface upstream.
+2. **No local test loop.** The live tunnel can only be verified on real hardware
+   (the user accepted this when choosing the full build).
+
+## Decision
+
+- **Phone (server):** embed **`wireguard-go`** with its **`tun/netstack`**
+  (gVisor userspace network stack) as a small Go module, compiled to an Android
+  library via **gomobile**. wireguard-go terminates the WireGuard tunnel in
+  userspace (official WireGuard crypto — no hand-rolled crypto, satisfying §5.1)
+  and the netstack turns inbound IP packets from the client into ordinary
+  outbound **sockets on the phone** — which ride the phone's default network, and
+  therefore its VPN, exactly like the Fast-Mode SOCKS path (ADR-0006). No
+  `VpnService`, no root, no NAT tables required.
+- **Windows (client):** bundle the official **`wintun.dll`** and run a userspace
+  **`wireguard-go`** tunnel that dials the phone's endpoint using the per-pairing
+  keys from the QR `wg` block; the app sets the adapter address, DNS, and routes,
+  all inside the existing transactional teardown (safety invariant #2).
+- **Keys are per-pairing and ephemeral:** the phone generates both key pairs at
+  advertise time using `com.wireguard.android`'s `KeyPair` (official), embeds the
+  server public key + the client private key in the QR, and **discards them on
+  disconnect** (§4.2).
+- **Mode is a payload/UI concern, not a new state:** the Fast/Full toggle selects
+  which server the phone brings up and which `mode` the QR carries; the shared
+  five-state machine is unchanged, so switching modes needs no app restart
+  (AC3.3) — stop the current server, start the other, re-advertise.
+
+## Consequences
+
+- Crypto and the WireGuard protocol come entirely from official `wireguard-go`;
+  Relay's code is glue (config, lifecycle, netstack dial-out).
+- **CI proves** the Go module + AAR build, the tunnel config assembly, key
+  handling, the toggle, and the state machine. **Only hardware proves** the live
+  UDP tunnel and latency (AC3.1/AC3.2) — documented as such in `docs/testing.md`.
+- Windows Full Mode requires elevation to create the WinTun adapter and set
+  routes — a genuine difference from Fast Mode's per-user proxy; surfaced in the
+  UI and `docs/release.md`.
+- gomobile + NDK and bundling `wintun.dll`/`wireguard-go` add real weight to CI;
+  the build steps live in `ci.yml` and the release workflows.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,3 +11,4 @@ Short, immutable records of significant decisions. New decision → new numbered
 | [0005](0005-windows-stack-winui3.md) | Windows stack — .NET 8 + WinUI 3, unpackaged, EXE installer | Accepted |
 | [0006](0006-in-repo-socks5-server.md) | In-repo minimal SOCKS5 server on Android | Accepted |
 | [0007](0007-bounded-auto-reconnect.md) | Bounded auto-reconnect as an internal policy, not a new state | Accepted |
+| [0008](0008-full-mode-wireguard-forwarder.md) | Full Mode — phone as a userspace WireGuard forwarding endpoint | Accepted |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -18,6 +18,7 @@ Codes are **never renamed or reused**. This is the complete Phase 2 taxonomy; ne
 | `HOTSPOT_LOST` | Transient → Error | Hotspot interface dropped and did not return within the reconnect bound | Check the hotspot is still on, then start sharing again |
 | `PORT_IN_USE` | Error | Every candidate SOCKS port is bound by another app | Close the other app using those ports, then try again |
 | `SERVICE_FAILED` | Error | Foreground service stopped unexpectedly | Start sharing again |
+| `WG_START_FAILED` | Error | Full Mode WireGuard endpoint could not start on the phone | Try Fast Mode, or start sharing again |
 | `NO_VPN_ACTIVE` | Warning | No VPN is active on the phone when sharing starts | Informational: you're sharing your regular connection. Turn on your VPN first if you meant to share it |
 | `BATTERY_UNRESTRICTED_DENIED` | Warning | Battery-optimization exemption not granted | Allow it so sharing survives screen-off (button opens the exemption dialog) |
 

--- a/shared/test-vectors.json
+++ b/shared/test-vectors.json
@@ -91,6 +91,22 @@
         "wg": { "serverPublicKey": "a1yn3fwDEBl6ZPc+KD67rwGn0oia5dlFElp9lkWxGI4=", "clientPrivateKey": "P2GJ1aWQb5UrrLNLl/iwYX/AA8K6C/BS9L1e2Jnewpo=", "allowedIps": "0.0.0.0/0", "endpointPort": 51820, "dns": "1.1.1.1" }
       },
       "reason": "unexpected-wg-block"
+    },
+    {
+      "description": "wireguard mode missing a wg sub-field (dns)",
+      "payload": {
+        "v": 1, "mode": "wireguard", "host": "192.168.43.1", "port": 51820,
+        "wg": { "serverPublicKey": "a1yn3fwDEBl6ZPc+KD67rwGn0oia5dlFElp9lkWxGI4=", "clientPrivateKey": "P2GJ1aWQb5UrrLNLl/iwYX/AA8K6C/BS9L1e2Jnewpo=", "allowedIps": "0.0.0.0/0", "endpointPort": 51820 }
+      },
+      "reason": "missing-wg-field"
+    },
+    {
+      "description": "wireguard mode with a malformed key",
+      "payload": {
+        "v": 1, "mode": "wireguard", "host": "192.168.43.1", "port": 51820,
+        "wg": { "serverPublicKey": "not-a-valid-key", "clientPrivateKey": "P2GJ1aWQb5UrrLNLl/iwYX/AA8K6C/BS9L1e2Jnewpo=", "allowedIps": "0.0.0.0/0", "endpointPort": 51820, "dns": "1.1.1.1" }
+      },
+      "reason": "invalid-wg-key"
     }
   ],
   "invalidEncoded": [

--- a/windows/Relay.Core/QrPayloadCodec.cs
+++ b/windows/Relay.Core/QrPayloadCodec.cs
@@ -36,6 +36,10 @@ public static partial class QrPayloadCodec
     [GeneratedRegex(@"^((25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])\.){3}(25[0-5]|2[0-4][0-9]|1[0-9]{2}|[1-9]?[0-9])$")]
     private static partial Regex Ipv4Regex();
 
+    /// <summary>base64 of a 32-byte Curve25519 key (matches /shared/qr-payload.schema.json).</summary>
+    [GeneratedRegex(@"^[A-Za-z0-9+/]{42}[AEIMQUYcgkosw480]=$")]
+    private static partial Regex WgKeyRegex();
+
     public static string Encode(QrPayload payload)
     {
         var json = JsonSerializer.Serialize(payload, SerializeOptions);
@@ -100,9 +104,14 @@ public static partial class QrPayloadCodec
         if (port is < 1 or > 65535) return DecodeResult.Invalid("invalid-port");
         if (!Ipv4Regex().IsMatch(host)) return DecodeResult.Invalid("invalid-host");
 
-        var hasWg = obj.TryGetProperty("wg", out _);
+        var hasWg = obj.TryGetProperty("wg", out var wgElement);
         if (mode == QrPayload.ModeWireguard && !hasWg) return DecodeResult.Invalid("missing-wg-block");
         if (mode == QrPayload.ModeSocks5 && hasWg) return DecodeResult.Invalid("unexpected-wg-block");
+        if (mode == QrPayload.ModeWireguard)
+        {
+            var wgResult = ValidateWg(wgElement);
+            if (wgResult is not null) return wgResult;
+        }
 
         try
         {
@@ -115,6 +124,29 @@ public static partial class QrPayloadCodec
         {
             return DecodeResult.Invalid("decode-error");
         }
+    }
+
+    /// <summary>Validates the wg sub-object; returns an Invalid result on the first problem, else null.</summary>
+    private static DecodeResult? ValidateWg(JsonElement wg)
+    {
+        if (wg.ValueKind != JsonValueKind.Object) return DecodeResult.Invalid("missing-wg-block");
+        foreach (var field in new[] { "serverPublicKey", "clientPrivateKey", "allowedIps", "endpointPort", "dns" })
+        {
+            if (!wg.TryGetProperty(field, out _)) return DecodeResult.Invalid("missing-wg-field");
+        }
+        if (!TryGetString(wg, "serverPublicKey", out var serverKey) || !WgKeyRegex().IsMatch(serverKey))
+        {
+            return DecodeResult.Invalid("invalid-wg-key");
+        }
+        if (!TryGetString(wg, "clientPrivateKey", out var clientKey) || !WgKeyRegex().IsMatch(clientKey))
+        {
+            return DecodeResult.Invalid("invalid-wg-key");
+        }
+        if (!TryGetInt(wg, "endpointPort", out var endpointPort) || endpointPort is < 1 or > 65535)
+        {
+            return DecodeResult.Invalid("invalid-wg-port");
+        }
+        return null;
     }
 
     private static bool TryGetInt(JsonElement obj, string name, out int value)


### PR DESCRIPTION
## Phase 3 — Full Mode (WireGuard) · WORK IN PROGRESS (draft)

Implements Full Mode per **[ADR-0008](docs/adr/0008-full-mode-wireguard-forwarder.md)**: the phone runs a userspace `wireguard-go` endpoint with a gVisor netstack that forwards the laptop's TCP+UDP out through the phone's VPN (official WireGuard crypto — no hand-rolled crypto); the Windows client brings up a WinTun tunnel that dials the phone.

**Decision (agreed):** full build, with the live UDP tunnel (AC3.1/AC3.2) verified on hardware since CI cannot exercise a real tunnel. This PR is a **draft** so CI runs incrementally as the native layers land.

### Landed so far
- **Shared:** wg sub-field validation in both codecs (`missing-wg-field`, `invalid-wg-key`, `invalid-wg-port`) + vectors; ADR-0008.
- **Android control layer:** Fast/Full toggle (persisted, no-restart switch — AC3.3), per-pairing key generation via official `com.wireguard.crypto`, pure unit-tested `WgConfig` assembly, mode-aware `SharingService`, `WG_START_FAILED` error (EN+FA).

### Still to land in this PR
- Android: `wireguard-go` + netstack forwarder built via gomobile → AAR, Kotlin bridge, `ci.yml` step.
- Windows: WinTun + `wireguard-go` tunnel client, mode toggle, config from the wg QR block.
- Docs: AC3.1–3.3 test matrix, vpn-compat Full column, roadmap.

### Reviewer notes
- CI proves builds + codec/config/state unit tests. The real tunnel is hardware-verified (documented in `docs/testing.md`).
- Full Mode on Windows will require elevation (WinTun adapter + routes) — a genuine difference from Fast Mode; surfaced in-app and in `docs/release.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
