### PR TITLE
fix(ci): release notes via --notes-file (injection-safe)

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -78,8 +78,9 @@ jobs:
         run: |
           PREV=$(git tag -l 'android-v*' --sort=-v:refname | sed -n 2p)
           RANGE=$([ -n "$PREV" ] && echo "$PREV..HEAD" || echo "HEAD")
+          # Write to a file (never interpolated into a shell command) so commit
+          # messages with quotes/backticks/parens can't break release creation.
           {
-            echo 'body<<CHANGELOG_EOF'
             echo "## Relay for Android ${{ steps.version.outputs.version }}"
             echo
             echo "### How to install"
@@ -89,8 +90,7 @@ jobs:
             echo
             echo "### Changes"
             git log $RANGE --no-merges --pretty='- %s' -- ../android ../shared . | head -100
-            echo 'CHANGELOG_EOF'
-          } >> "$GITHUB_OUTPUT"
+          } > "$RUNNER_TEMP/notes.md"
 
       - name: Upload dry-run artifacts
         if: github.event_name == 'workflow_dispatch'
@@ -106,4 +106,4 @@ jobs:
         run: |
           gh release create "${GITHUB_REF#refs/tags/}" dist/* \
             --title "Relay for Android ${{ steps.version.outputs.version }}" \
-            --notes "${{ steps.changelog.outputs.body }}"
+            --notes-file "$RUNNER_TEMP/notes.md"

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -72,8 +72,9 @@ jobs:
         run: |
           PREV=$(git tag -l 'windows-v*' --sort=-v:refname | sed -n 2p)
           RANGE=$([ -n "$PREV" ] && echo "$PREV..HEAD" || echo "HEAD")
+          # Write to a file (never interpolated into a shell command) so commit
+          # messages with quotes/backticks/parens can't break release creation.
           {
-            echo 'body<<CHANGELOG_EOF'
             echo "## Relay for Windows ${{ steps.version.outputs.version }}"
             echo
             echo "### How to install"
@@ -83,8 +84,7 @@ jobs:
             echo
             echo "### Changes"
             git log $RANGE --no-merges --pretty='- %s' -- windows shared .github | head -100
-            echo 'CHANGELOG_EOF'
-          } >> "$GITHUB_OUTPUT"
+          } > "$RUNNER_TEMP/notes.md"
 
       - name: Upload dry-run artifacts
         if: github.event_name == 'workflow_dispatch'
@@ -101,4 +101,4 @@ jobs:
         run: |
           gh release create "${GITHUB_REF#refs/tags/}" windows/installer/output/*.exe \
             --title "Relay for Windows ${{ steps.version.outputs.version }}" \
-            --notes "${{ steps.changelog.outputs.body }}"
+            --notes-file "$RUNNER_TEMP/notes.md"


### PR DESCRIPTION
The android-v1.0.0 signed build succeeded but 'Create GitHub Release' failed with 'no matches found for from' — the changelog body was interpolated straight into the bash command, so commit messages with quotes/parens/backticks broke it. Now written to a file and passed via --notes-file. Fixes both release workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)