### PR TITLE
fix(windows): app crashed on launch (unpackaged MRT/ms-appx)

### DIFF
--- a/windows/Relay.App/App.xaml.cs
+++ b/windows/Relay.App/App.xaml.cs
@@ -21,28 +21,84 @@ public partial class App : Application
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
-        _singleInstance = new Mutex(initiallyOwned: true, @"Local\RelayAppSingleton", out var isFirst);
-        if (!isFirst)
-        {
-            Exit();
-            return;
-        }
-
-        // Safety invariant #2: undo a crashed session before anything else.
-        AppController.Instance.RecoverIfCrashed();
-
-        _window = new MainWindow();
-        CreateTrayIcon();
-        _window.ShowNearTray();
-
-        // Best-effort restore on abnormal shutdown; a hard crash is covered
-        // by RecoverIfCrashed on the next start.
-        AppDomain.CurrentDomain.ProcessExit += (_, _) => Cleanup();
+        // Attach the crash handler FIRST so any startup failure is written to a
+        // log instead of dying silently (this app is unpackaged; a stowed COM
+        // exception during startup would otherwise leave no trace).
         UnhandledException += (_, e) =>
         {
+            LogStartupError(e.Exception);
             Cleanup();
             e.Handled = false;
         };
+
+        try
+        {
+            _singleInstance = new Mutex(initiallyOwned: true, @"Local\RelayAppSingleton", out var isFirst);
+            if (!isFirst)
+            {
+                Exit();
+                return;
+            }
+
+            // Safety invariant #2: undo a crashed session before anything else.
+            AppController.Instance.RecoverIfCrashed();
+
+            _window = new MainWindow();
+            _window.ShowNearTray();
+            // Tray creation is best-effort: a failure here must not stop the
+            // window (which is already shown) from being usable.
+            try
+            {
+                CreateTrayIcon();
+            }
+            catch (Exception ex)
+            {
+                LogStartupError(ex);
+            }
+
+            // Best-effort restore on abnormal shutdown; a hard crash is covered
+            // by RecoverIfCrashed on the next start.
+            AppDomain.CurrentDomain.ProcessExit += (_, _) => Cleanup();
+        }
+        catch (Exception ex)
+        {
+            LogStartupError(ex);
+            throw;
+        }
+    }
+
+    /// <summary>Writes a startup failure to %LOCALAPPDATA%\Relay\startup-error.log; never throws.</summary>
+    private static void LogStartupError(Exception ex)
+    {
+        try
+        {
+            var dir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Relay");
+            Directory.CreateDirectory(dir);
+            File.WriteAllText(Path.Combine(dir, "startup-error.log"), $"{DateTime.Now:o}\n{ex}");
+        }
+        catch
+        {
+            // logging must never throw
+        }
+    }
+
+    /// <summary>
+    /// Loads the tray icon from the app folder by absolute path. Unpackaged apps
+    /// cannot resolve ms-appx:// image URIs reliably (it throws a stowed COM
+    /// E_FAIL at startup), so we never use ms-appx here.
+    /// </summary>
+    private static BitmapImage? LoadTrayIconSource()
+    {
+        try
+        {
+            var path = Path.Combine(AppContext.BaseDirectory, "Assets", "TrayIcon.ico");
+            return File.Exists(path) ? new BitmapImage(new Uri(path)) : null;
+        }
+        catch
+        {
+            return null;
+        }
     }
 
     private void CreateTrayIcon()
@@ -76,7 +132,7 @@ public partial class App : Application
             ContextFlyout = menu,
             LeftClickCommand = openCommand,
             NoLeftClickDelay = true,
-            IconSource = new BitmapImage(new Uri("ms-appx:///Assets/TrayIcon.ico")),
+            IconSource = LoadTrayIconSource(),
         };
         _tray.ForceCreate();
 

--- a/windows/Relay.App/Strings.cs
+++ b/windows/Relay.App/Strings.cs
@@ -1,42 +1,26 @@
-using Microsoft.Windows.ApplicationModel.Resources;
+using System.Globalization;
 
 namespace Relay.App;
 
 /// <summary>
-/// Localized strings with a hard English fallback: a resource-loading failure
-/// must never crash the tray app or leave blank UI.
+/// Localized strings held entirely in code (English + Persian). This app is
+/// unpackaged, where the MRT <c>ResourceLoader</c> can throw a stowed COM
+/// exception at startup that escapes managed try/catch; keeping strings in
+/// code removes that failure mode entirely. Selection follows the OS UI
+/// language; anything missing falls back to English, then to the key itself.
 /// </summary>
 public static class Strings
 {
-    private static readonly ResourceLoader? Loader = Create();
-
-    private static ResourceLoader? Create()
-    {
-        try
-        {
-            return new ResourceLoader();
-        }
-        catch (Exception)
-        {
-            return null;
-        }
-    }
+    private static readonly bool IsPersian =
+        CultureInfo.CurrentUICulture.TwoLetterISOLanguageName.Equals("fa", StringComparison.OrdinalIgnoreCase);
 
     public static string Get(string key)
     {
-        try
-        {
-            var value = Loader?.GetString(key);
-            if (!string.IsNullOrEmpty(value)) return value;
-        }
-        catch (Exception)
-        {
-            // fall through to the fallback table
-        }
-        return Fallback.TryGetValue(key, out var english) ? english : key;
+        if (IsPersian && Fa.TryGetValue(key, out var fa)) return fa;
+        return En.TryGetValue(key, out var en) ? en : key;
     }
 
-    private static readonly Dictionary<string, string> Fallback = new()
+    private static readonly Dictionary<string, string> En = new()
     {
         ["AppName"] = "Relay",
         ["Tagline"] = "Share your connection. Instantly.",
@@ -70,5 +54,41 @@ public static class Strings
         ["ErrProxyApply"] = "Windows refused the proxy change. Close other proxy/VPN managers and try again.",
         ["ErrRollback"] = "Relay couldn't fully restore your proxy settings. Disconnect again to retry.",
         ["ErrCameraDenied"] = "Relay can't use the camera. Allow camera access for desktop apps in Windows Settings > Privacy, or enter the code manually.",
+    };
+
+    private static readonly Dictionary<string, string> Fa = new()
+    {
+        ["AppName"] = "رله",
+        ["Tagline"] = "اتصالت را به‌اشتراک بگذار. در یک لحظه.",
+        ["StatusIdle"] = "متصل نیست",
+        ["StatusConnecting"] = "در حال اتصال…",
+        ["StatusConnected"] = "متصل شد",
+        ["ScanQr"] = "اسکن کد QR",
+        ["EnterCode"] = "واردکردن دستی کد",
+        ["ScanHint"] = "دوربین را به‌سمت کد QR روی گوشی بگیرید",
+        ["CodeHint"] = "کد ۸ حرفی زیر کد QR در گوشی شما",
+        ["Connect"] = "اتصال",
+        ["Cancel"] = "انصراف",
+        ["Disconnect"] = "قطع اتصال",
+        ["Dismiss"] = "بستن",
+        ["Reconnecting"] = "در حال اتصال مجدد…",
+        ["TrayOpen"] = "بازکردن رله",
+        ["TrayExit"] = "خروج",
+        ["ConnectedVia"] = "متصل از طریق {0}",
+        ["Advanced"] = "پیشرفته",
+        ["AdvancedAddress"] = "نشانی هات‌اسپات",
+        ["AdvancedLogs"] = "گزارش فعالیت (روی همین رایانه می‌ماند)",
+        ["AdvancedLogsClear"] = "پاک‌کردن",
+        ["AdvancedLogsEmpty"] = "هنوز فعالیتی نیست",
+        ["ErrQrInvalid"] = "این کدِ رله نیست. کد QR را از برنامه رله روی گوشی نمایش دهید و دوباره تلاش کنید.",
+        ["ErrQrNewer"] = "این کد با نسخه جدیدتری از رله ساخته شده — لطفاً این برنامه را به‌روزرسانی کنید.",
+        ["ErrCodeInvalid"] = "این کد درست به‌نظر نمی‌رسد. ۸ حرف روی گوشی را بررسی کنید و دوباره تلاش کنید.",
+        ["ErrHostUnreachable"] = "گوشی در دسترس نیست. این رایانه را به وای‌فای هات‌اسپات گوشی وصل کنید و دوباره تلاش کنید.",
+        ["ErrWrongNetwork"] = "این رایانه روی هات‌اسپات گوشی نیست. به وای‌فای گوشی وصل شوید و دوباره تلاش کنید.",
+        ["ErrConnectionLost"] = "گوشی از دسترس خارج شد. هات‌اسپات را بررسی کنید و دوباره وصل شوید.",
+        ["ErrFirewall"] = "اتصال مسدود شد. به رله در فایروال ویندوز (یا نرم‌افزار امنیتی) اجازه دهید و دوباره تلاش کنید.",
+        ["ErrProxyApply"] = "ویندوز تغییر پراکسی را نپذیرفت. مدیریت‌کننده‌های دیگر پراکسی/VPN را ببندید و دوباره تلاش کنید.",
+        ["ErrRollback"] = "رله نتوانست تنظیمات پراکسی را کاملاً بازگرداند. برای تلاش دوباره، دوباره «قطع اتصال» را بزنید.",
+        ["ErrCameraDenied"] = "رله به دوربین دسترسی ندارد. در تنظیمات ویندوز > حریم خصوصی، دسترسی دوربین برنامه‌های دسکتاپ را فعال کنید، یا کد را دستی وارد کنید.",
     };
 }


### PR DESCRIPTION
The installed Windows app died immediately at startup (stowed COM E_FAIL in combase.dll, MRT resource DLLs loaded). Unpackaged WinUI 3 can't reliably resolve ms-appx:// or ResourceLoader through MRT. Fixes: tray icon from absolute file path (not ms-appx), ResourceLoader removed (strings in-code EN+FA), and UnhandledException attached first + OnLaunched wrapped with a startup-error.log. Diagnosed from the on-machine crash dump + WER report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)