### PR TITLE
fix(windows): XAML parse crash on launch (flatten ThemeResource, code-set backdrop)

### DIFF
--- a/windows/Relay.App/App.xaml
+++ b/windows/Relay.App/App.xaml
@@ -8,39 +8,24 @@
                 <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
             </ResourceDictionary.MergedDictionaries>
 
-            <!-- Theme-aware glass tokens. These MUST live at the application level:
-                 the {ThemeResource} markup extension only resolves against
-                 Application.Resources theme dictionaries, not element-level ones. -->
-            <ResourceDictionary.ThemeDictionaries>
-                <ResourceDictionary x:Key="Default">
-                    <SolidColorBrush x:Key="TextPrimary" Color="#F5FFFFFF" />
-                    <SolidColorBrush x:Key="TextSecondary" Color="#9EFFFFFF" />
-                    <SolidColorBrush x:Key="TextTertiary" Color="#61FFFFFF" />
-                    <SolidColorBrush x:Key="Accent" Color="#45D6B8" />
-                    <SolidColorBrush x:Key="AccentText" Color="#0A0C10" />
-                    <SolidColorBrush x:Key="GlassFill" Color="#14FFFFFF" />
-                    <SolidColorBrush x:Key="GlassStroke" Color="#1FFFFFFF" />
-                    <SolidColorBrush x:Key="ErrorBrush" Color="#E5645F" />
-                    <SolidColorBrush x:Key="WarningBrush" Color="#E0A458" />
-                    <SolidColorBrush x:Key="PreviewBg" Color="#14171D" />
-                </ResourceDictionary>
-                <ResourceDictionary x:Key="Light">
-                    <SolidColorBrush x:Key="TextPrimary" Color="#F00C0E12" />
-                    <SolidColorBrush x:Key="TextSecondary" Color="#940C0E12" />
-                    <SolidColorBrush x:Key="TextTertiary" Color="#5C0C0E12" />
-                    <SolidColorBrush x:Key="Accent" Color="#17A98C" />
-                    <SolidColorBrush x:Key="AccentText" Color="#FFFFFF" />
-                    <SolidColorBrush x:Key="GlassFill" Color="#8CFFFFFF" />
-                    <SolidColorBrush x:Key="GlassStroke" Color="#14000000" />
-                    <SolidColorBrush x:Key="ErrorBrush" Color="#C7433E" />
-                    <SolidColorBrush x:Key="WarningBrush" Color="#B37417" />
-                    <SolidColorBrush x:Key="PreviewBg" Color="#DCE1E8" />
-                </ResourceDictionary>
-            </ResourceDictionary.ThemeDictionaries>
+            <!-- Dark-first glass tokens, referenced via {StaticResource}. Kept flat
+                 (not in ThemeDictionaries): {ThemeResource} on custom keys throws a
+                 XamlParseException when the window loads. Brushes are declared before
+                 the styles that use them so StaticResource resolves in order. -->
+            <SolidColorBrush x:Key="TextPrimary" Color="#F5FFFFFF" />
+            <SolidColorBrush x:Key="TextSecondary" Color="#9EFFFFFF" />
+            <SolidColorBrush x:Key="TextTertiary" Color="#61FFFFFF" />
+            <SolidColorBrush x:Key="Accent" Color="#45D6B8" />
+            <SolidColorBrush x:Key="AccentText" Color="#0A0C10" />
+            <SolidColorBrush x:Key="GlassFill" Color="#14FFFFFF" />
+            <SolidColorBrush x:Key="GlassStroke" Color="#1FFFFFFF" />
+            <SolidColorBrush x:Key="ErrorBrush" Color="#E5645F" />
+            <SolidColorBrush x:Key="WarningBrush" Color="#E0A458" />
+            <SolidColorBrush x:Key="PreviewBg" Color="#14171D" />
 
             <Style x:Key="PrimaryButton" TargetType="Button">
-                <Setter Property="Background" Value="{ThemeResource Accent}" />
-                <Setter Property="Foreground" Value="{ThemeResource AccentText}" />
+                <Setter Property="Background" Value="{StaticResource Accent}" />
+                <Setter Property="Foreground" Value="{StaticResource AccentText}" />
                 <Setter Property="CornerRadius" Value="20" />
                 <Setter Property="Padding" Value="24,10" />
                 <Setter Property="HorizontalAlignment" Value="Stretch" />
@@ -48,9 +33,9 @@
                 <Setter Property="BorderThickness" Value="0" />
             </Style>
             <Style x:Key="SubtleButton" TargetType="Button">
-                <Setter Property="Background" Value="{ThemeResource GlassFill}" />
-                <Setter Property="Foreground" Value="{ThemeResource TextPrimary}" />
-                <Setter Property="BorderBrush" Value="{ThemeResource GlassStroke}" />
+                <Setter Property="Background" Value="{StaticResource GlassFill}" />
+                <Setter Property="Foreground" Value="{StaticResource TextPrimary}" />
+                <Setter Property="BorderBrush" Value="{StaticResource GlassStroke}" />
                 <Setter Property="BorderThickness" Value="1" />
                 <Setter Property="CornerRadius" Value="20" />
                 <Setter Property="Padding" Value="24,10" />

--- a/windows/Relay.App/MainWindow.xaml
+++ b/windows/Relay.App/MainWindow.xaml
@@ -3,11 +3,7 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Window.SystemBackdrop>
-        <DesktopAcrylicBackdrop />
-    </Window.SystemBackdrop>
-
-    <Grid x:Name="Root" Padding="24">
+    <Grid x:Name="Root" Padding="24" Background="#0A0C10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -17,22 +13,22 @@
         <!-- Header -->
         <Grid Grid.Row="0" Margin="0,4,0,20">
             <TextBlock x:Name="TitleText" Text="Relay" FontSize="20" FontWeight="SemiBold"
-                       Foreground="{ThemeResource TextPrimary}" />
+                       Foreground="{StaticResource TextPrimary}" />
             <Ellipse x:Name="StatusDot" Width="10" Height="10"
                      HorizontalAlignment="Right" VerticalAlignment="Center"
-                     Fill="{ThemeResource TextTertiary}" />
+                     Fill="{StaticResource TextTertiary}" />
         </Grid>
 
         <!-- Idle -->
         <StackPanel x:Name="IdlePanel" Grid.Row="1" VerticalAlignment="Center" Spacing="12">
             <TextBlock x:Name="IdleStatusText" HorizontalAlignment="Center"
-                       Foreground="{ThemeResource TextSecondary}" />
+                       Foreground="{StaticResource TextSecondary}" />
             <Button x:Name="ScanButton" Style="{StaticResource PrimaryButton}" Margin="0,16,0,0"
                     Click="OnScanClick" />
             <Button x:Name="EnterCodeButton" Style="{StaticResource SubtleButton}"
                     Click="OnEnterCodeClick" />
             <TextBlock x:Name="TaglineText" HorizontalAlignment="Center" Margin="0,12,0,0"
-                       FontSize="12" Foreground="{ThemeResource TextTertiary}" />
+                       FontSize="12" Foreground="{StaticResource TextTertiary}" />
         </StackPanel>
 
         <!-- Scanning -->
@@ -43,13 +39,13 @@
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
             <Border Grid.Row="0" CornerRadius="16"
-                    Background="{ThemeResource PreviewBg}"
-                    BorderBrush="{ThemeResource GlassStroke}" BorderThickness="1">
+                    Background="{StaticResource PreviewBg}"
+                    BorderBrush="{StaticResource GlassStroke}" BorderThickness="1">
                 <Image x:Name="PreviewImage" Stretch="UniformToFill" />
             </Border>
             <TextBlock x:Name="ScanHintText" Grid.Row="1" Margin="0,12,0,12"
                        TextWrapping="Wrap" TextAlignment="Center"
-                       FontSize="12" Foreground="{ThemeResource TextTertiary}" />
+                       FontSize="12" Foreground="{StaticResource TextTertiary}" />
             <Button x:Name="ScanCancelButton" Grid.Row="2" Style="{StaticResource SubtleButton}"
                     Click="OnCancelClick" />
         </Grid>
@@ -61,7 +57,7 @@
                      FontSize="24" TextAlignment="Center" CharacterSpacing="150"
                      MaxLength="9" />
             <TextBlock x:Name="CodeHintText" TextWrapping="Wrap" TextAlignment="Center"
-                       FontSize="12" Foreground="{ThemeResource TextTertiary}" />
+                       FontSize="12" Foreground="{StaticResource TextTertiary}" />
             <Button x:Name="CodeConnectButton" Style="{StaticResource PrimaryButton}"
                     Click="OnCodeConnectClick" />
             <Button x:Name="CodeCancelButton" Style="{StaticResource SubtleButton}"
@@ -72,24 +68,24 @@
         <StackPanel x:Name="BusyPanel" Grid.Row="1" VerticalAlignment="Center" Spacing="16"
                     Visibility="Collapsed">
             <ProgressRing IsActive="True" Width="36" Height="36"
-                          Foreground="{ThemeResource Accent}" />
+                          Foreground="{StaticResource Accent}" />
             <TextBlock x:Name="BusyText" HorizontalAlignment="Center"
-                       Foreground="{ThemeResource TextSecondary}" />
+                       Foreground="{StaticResource TextSecondary}" />
         </StackPanel>
 
         <!-- Connected -->
         <StackPanel x:Name="ConnectedPanel" Grid.Row="1" VerticalAlignment="Center" Spacing="8"
                     Visibility="Collapsed">
-            <Ellipse x:Name="ConnectedDot" Width="12" Height="12" Fill="{ThemeResource Accent}"
+            <Ellipse x:Name="ConnectedDot" Width="12" Height="12" Fill="{StaticResource Accent}"
                      HorizontalAlignment="Center" />
             <TextBlock x:Name="ConnectedText" HorizontalAlignment="Center"
                        FontSize="16" FontWeight="SemiBold"
-                       Foreground="{ThemeResource TextPrimary}" TextAlignment="Center"
+                       Foreground="{StaticResource TextPrimary}" TextAlignment="Center"
                        TextWrapping="Wrap" />
             <TextBlock x:Name="ConnectedDetailText" HorizontalAlignment="Center"
-                       FontSize="12" Foreground="{ThemeResource TextTertiary}" />
+                       FontSize="12" Foreground="{StaticResource TextTertiary}" />
             <TextBlock x:Name="ReconnectingText" HorizontalAlignment="Center" Visibility="Collapsed"
-                       FontSize="12" Foreground="{ThemeResource WarningBrush}" />
+                       FontSize="12" Foreground="{StaticResource WarningBrush}" />
             <Button x:Name="DisconnectButton" Style="{StaticResource SubtleButton}" Margin="0,20,0,0"
                     Click="OnDisconnectClick" />
         </StackPanel>
@@ -97,10 +93,10 @@
         <!-- Error -->
         <StackPanel x:Name="ErrorPanel" Grid.Row="1" VerticalAlignment="Center" Spacing="12"
                     Visibility="Collapsed">
-            <Ellipse Width="12" Height="12" Fill="{ThemeResource ErrorBrush}"
+            <Ellipse Width="12" Height="12" Fill="{StaticResource ErrorBrush}"
                      HorizontalAlignment="Center" />
             <TextBlock x:Name="ErrorText" TextWrapping="Wrap" TextAlignment="Center"
-                       Foreground="{ThemeResource TextSecondary}" />
+                       Foreground="{StaticResource TextSecondary}" />
             <Button x:Name="ErrorDismissButton" Style="{StaticResource SubtleButton}" Margin="0,12,0,0"
                     Click="OnDismissClick" />
         </StackPanel>
@@ -110,24 +106,24 @@
                   HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
             <Expander.Header>
                 <TextBlock x:Name="AdvancedHeader" FontSize="12"
-                           Foreground="{ThemeResource TextSecondary}" />
+                           Foreground="{StaticResource TextSecondary}" />
             </Expander.Header>
             <StackPanel Spacing="10">
                 <Grid>
                     <TextBlock x:Name="AdvancedAddressLabel" FontSize="12"
-                               Foreground="{ThemeResource TextSecondary}" />
+                               Foreground="{StaticResource TextSecondary}" />
                     <TextBlock x:Name="AdvancedAddressValue" HorizontalAlignment="Right"
-                               FontFamily="Consolas" Foreground="{ThemeResource TextPrimary}" />
+                               FontFamily="Consolas" Foreground="{StaticResource TextPrimary}" />
                 </Grid>
                 <Grid>
                     <TextBlock x:Name="AdvancedLogsLabel" FontSize="12"
-                               Foreground="{ThemeResource TextSecondary}" />
+                               Foreground="{StaticResource TextSecondary}" />
                     <HyperlinkButton x:Name="AdvancedLogsClear" HorizontalAlignment="Right"
                                      Padding="0" Click="OnClearLogsClick" />
                 </Grid>
                 <ScrollViewer Height="140" VerticalScrollBarVisibility="Auto">
                     <TextBlock x:Name="LogText" FontFamily="Consolas" FontSize="11"
-                               TextWrapping="NoWrap" Foreground="{ThemeResource TextTertiary}" />
+                               TextWrapping="NoWrap" Foreground="{StaticResource TextTertiary}" />
                 </ScrollViewer>
             </StackPanel>
         </Expander>

--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -25,6 +25,9 @@ public sealed partial class MainWindow : Window
     public MainWindow()
     {
         InitializeComponent();
+        // Acrylic is cosmetic and can fault on some setups; set it in code so a
+        // failure degrades to the solid Grid background instead of crashing load.
+        try { SystemBackdrop = new Microsoft.UI.Xaml.Media.DesktopAcrylicBackdrop(); } catch { }
         Title = Strings.Get("AppName");
         ConfigureAppWindow();
         ApplyStrings();
@@ -84,12 +87,8 @@ public sealed partial class MainWindow : Window
     }
 
     /// <summary>Resolves a theme-dictionary brush by key for the effective theme.</summary>
-    private Microsoft.UI.Xaml.Media.Brush ThemeBrush(string key)
-    {
-        var themeKey = Root.ActualTheme == ElementTheme.Light ? "Light" : "Default";
-        var dict = (ResourceDictionary)Application.Current.Resources.ThemeDictionaries[themeKey];
-        return (Microsoft.UI.Xaml.Media.Brush)dict[key];
-    }
+    private static Microsoft.UI.Xaml.Media.Brush ThemeBrush(string key) =>
+        (Microsoft.UI.Xaml.Media.Brush)Application.Current.Resources[key];
 
     private void RefreshLogs()
     {


### PR DESCRIPTION
v1.0.2 still crashed at MainWindow.InitializeComponent (startup-error.log = XamlParseException). Root causes: custom {ThemeResource} keys against app ThemeDictionaries fault at window load, and DesktopAcrylicBackdrop set in XAML. Fixed: flat {StaticResource} dark tokens, backdrop set in code with try/catch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)