### PR TITLE
fix(windows): generate resources.pri (root cause of launch crash)

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -40,15 +40,28 @@ jobs:
       - name: Publish x64 and x86 (self-contained)
         shell: pwsh
         run: |
+          $proj = "windows/Relay.App/Relay.App.csproj"
           foreach ($arch in @('x64', 'x86')) {
-            msbuild windows/Relay.App/Relay.App.csproj /restore /t:Publish /v:minimal `
-              /p:Configuration=Release `
-              /p:Platform=$arch `
-              /p:RuntimeIdentifier=win-$arch `
-              /p:SelfContained=true `
-              /p:WindowsAppSDKSelfContained=true `
-              /p:PublishDir="$env:GITHUB_WORKSPACE\publish-$arch\"
+            $pub = "$env:GITHUB_WORKSPACE\publish-$arch"
+            $props = "/p:Configuration=Release /p:Platform=$arch /p:RuntimeIdentifier=win-$arch /p:SelfContained=true /p:WindowsAppSDKSelfContained=true"
+            # Build first: this runs the MRT PRI generation that produces the app's
+            # resources.pri (which indexes ms-appx:///MainWindow.xaml). A bare
+            # /t:Publish skips it, and the window then fails to load at runtime.
+            msbuild $proj /restore /t:Build /v:minimal $props.Split(' ')
             if ($LASTEXITCODE -ne 0) { exit 1 }
+            msbuild $proj /t:Publish /v:minimal $props.Split(' ') /p:PublishDir="$pub\"
+            if ($LASTEXITCODE -ne 0) { exit 1 }
+            # Safety net + guard: publish to a custom dir can drop resources.pri.
+            if (-not (Test-Path "$pub\resources.pri")) {
+              $bin = "windows/Relay.App/bin/$arch/Release/net8.0-windows10.0.19041.0/win-$arch"
+              $pri = Get-ChildItem $bin -Filter resources.pri -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+              if ($pri) { Copy-Item $pri.FullName "$pub\resources.pri" }
+            }
+            if (-not (Test-Path "$pub\resources.pri")) {
+              Write-Error "resources.pri missing from publish output for $arch — the app would crash at launch."
+              exit 1
+            }
+            Write-Host "resources.pri present for $arch"
           }
 
       - name: Build installers (Inno Setup)

--- a/windows/Relay.App/Relay.App.csproj
+++ b/windows/Relay.App/Relay.App.csproj
@@ -13,7 +13,11 @@
     <UseWinUI>true</UseWinUI>
     <!-- Unpackaged deployment: EXE installer, not MSIX (ADR-0005). -->
     <WindowsPackageType>None</WindowsPackageType>
-    <EnableMsixTooling>false</EnableMsixTooling>
+    <!-- MUST stay true even though unpackaged: this pulls in the MakePri targets
+         that generate the app's resources.pri, which indexes ms-appx:///*.xaml.
+         With it false, no resources.pri was produced and every window failed to
+         load at runtime (XamlParseException). -->
+    <EnableMsixTooling>true</EnableMsixTooling>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>latest</LangVersion>


### PR DESCRIPTION
The Windows app never shipped its resources.pri, so LoadComponent(ms-appx:///MainWindow.xaml) threw XamlParseException on every launch (v1.0.0-1.0.4). Root cause: EnableMsixTooling=false disabled the MakePri targets. Set it true, and the release workflow now builds-then-publishes and fails fast if resources.pri is absent. Dry-run confirmed the pri is now produced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)