### PR TITLE
fix(windows): full-app review — 9 defects fixed

### DIFF
--- a/windows/Relay.App/App.xaml.cs
+++ b/windows/Relay.App/App.xaml.cs
@@ -10,6 +10,8 @@ namespace Relay.App;
 public partial class App : Application
 {
     private static Mutex? _singleInstance;
+    private static EventWaitHandle? _showSignal;
+    private const string ShowSignalName = @"Local\RelayAppShow";
 
     private TaskbarIcon? _tray;
     private MainWindow? _window;
@@ -21,6 +23,16 @@ public partial class App : Application
 
     protected override void OnLaunched(LaunchActivatedEventArgs args)
     {
+        // Uninstall/repair runs "Relay.App.exe --restore-proxy" to undo an active
+        // session's system proxy before the app is removed. Headless; no window.
+        if (Environment.GetCommandLineArgs().Any(a =>
+                string.Equals(a, "--restore-proxy", StringComparison.OrdinalIgnoreCase)))
+        {
+            try { AppController.Instance.RecoverIfCrashed(); } catch { }
+            Exit();
+            return;
+        }
+
         // Attach the crash handler FIRST so any startup failure is written to a
         // log instead of dying silently (this app is unpackaged; a stowed COM
         // exception during startup would otherwise leave no trace).
@@ -36,6 +48,9 @@ public partial class App : Application
             _singleInstance = new Mutex(initiallyOwned: true, @"Local\RelayAppSingleton", out var isFirst);
             if (!isFirst)
             {
+                // Already running in the tray: tell that instance to show its
+                // window instead of silently doing nothing, then exit.
+                try { EventWaitHandle.OpenExisting(ShowSignalName).Set(); } catch { }
                 Exit();
                 return;
             }
@@ -45,6 +60,13 @@ public partial class App : Application
 
             _window = new MainWindow();
             _window.ShowNearTray();
+
+            // Let a second launch (see the !isFirst path) pop this window back up.
+            _showSignal = new EventWaitHandle(false, EventResetMode.AutoReset, ShowSignalName);
+            ThreadPool.RegisterWaitForSingleObject(
+                _showSignal,
+                (_, _) => _window?.DispatcherQueue.TryEnqueue(() => _window?.ShowNearTray()),
+                null, Timeout.Infinite, executeOnlyOnce: false);
             // Tray creation is best-effort: a failure here must not stop the
             // window (which is already shown) from being usable.
             try

--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -127,6 +127,23 @@ public sealed partial class MainWindow : Window
 
     private void Render()
     {
+        // Local input errors (bad scan/code, camera) are owned here too, so a
+        // Render triggered by anything else (e.g. a Windows theme switch) can't
+        // silently wipe the error panel.
+        if (_localError is not null)
+        {
+            IdlePanel.Visibility = Visibility.Collapsed;
+            ScanPanel.Visibility = Visibility.Collapsed;
+            CodePanel.Visibility = Visibility.Collapsed;
+            BusyPanel.Visibility = Visibility.Collapsed;
+            ConnectedPanel.Visibility = Visibility.Collapsed;
+            ErrorPanel.Visibility = Visibility.Visible;
+            ErrorText.Text = LocalErrorMessage(_localError);
+            ErrorDismissButton.Content = Strings.Get("Dismiss");
+            StatusDot.Fill = ThemeBrush("ErrorBrush");
+            return;
+        }
+
         var state = _controller.StateName;
 
         IdlePanel.Visibility = Show(state == "Idle" && _mode == InputMode.None);
@@ -172,6 +189,10 @@ public sealed partial class MainWindow : Window
                 "ERR_CAMERA_DENIED" => "ErrCameraDenied",
                 _ => "ErrProxyApply",
             });
+            // Rollback-incomplete leaves a half-applied proxy: offer a retry here
+            // (the button re-runs Disconnect) instead of only "Dismiss".
+            ErrorDismissButton.Content = Strings.Get(
+                _controller.ErrorCode == "ERR_ROLLBACK_INCOMPLETE" ? "Disconnect" : "Dismiss");
         }
 
         // Advanced address reflects the active session, if any.
@@ -187,6 +208,7 @@ public sealed partial class MainWindow : Window
 
     private async void OnScanClick(object sender, RoutedEventArgs e)
     {
+        _localError = null;
         _mode = InputMode.Scanning;
         Render();
         _scanner = new CameraQrScanner();
@@ -219,9 +241,11 @@ public sealed partial class MainWindow : Window
             using (bitmap)
             {
                 if (_mode != InputMode.Scanning) return;
+                var previous = PreviewImage.Source as SoftwareBitmapSource;
                 var source = new SoftwareBitmapSource();
                 await source.SetBitmapAsync(bitmap);
                 PreviewImage.Source = source;
+                previous?.Dispose(); // release the outgoing frame's native buffer now
             }
         });
     }
@@ -258,6 +282,7 @@ public sealed partial class MainWindow : Window
 
     private void OnEnterCodeClick(object sender, RoutedEventArgs e)
     {
+        _localError = null;
         _mode = InputMode.Code;
         CodeBox.Text = string.Empty;
         Render();
@@ -272,6 +297,7 @@ public sealed partial class MainWindow : Window
             ShowLocalError("ERR_CODE_INVALID");
             return;
         }
+        _localError = null;
         _mode = InputMode.None;
         await _controller.ConnectAsync(new QrPayload
         {
@@ -289,8 +315,15 @@ public sealed partial class MainWindow : Window
     private async void OnDisconnectClick(object sender, RoutedEventArgs e) =>
         await _controller.DisconnectAsync();
 
-    private void OnDismissClick(object sender, RoutedEventArgs e)
+    private async void OnDismissClick(object sender, RoutedEventArgs e)
     {
+        // On a rollback-incomplete error the proxy may still be applied, so the
+        // button retries Disconnect instead of just clearing the message.
+        if (_localError is null && _controller.ErrorCode == "ERR_ROLLBACK_INCOMPLETE")
+        {
+            await _controller.DisconnectAsync();
+            return;
+        }
         _localError = null;
         _controller.DismissError();
         Render();
@@ -304,17 +337,15 @@ public sealed partial class MainWindow : Window
     {
         _localError = code;
         _mode = InputMode.None;
-        IdlePanel.Visibility = Visibility.Collapsed;
-        ScanPanel.Visibility = Visibility.Collapsed;
-        CodePanel.Visibility = Visibility.Collapsed;
-        ErrorPanel.Visibility = Visibility.Visible;
-        ErrorText.Text = Strings.Get(code switch
-        {
-            "ERR_QR_NEWER_VERSION" => "ErrQrNewer",
-            "ERR_QR_INVALID" => "ErrQrInvalid",
-            "ERR_CODE_INVALID" => "ErrCodeInvalid",
-            "ERR_CAMERA_DENIED" => "ErrCameraDenied",
-            _ => "ErrQrInvalid",
-        });
+        Render();
     }
+
+    private static string LocalErrorMessage(string code) => Strings.Get(code switch
+    {
+        "ERR_QR_NEWER_VERSION" => "ErrQrNewer",
+        "ERR_QR_INVALID" => "ErrQrInvalid",
+        "ERR_CODE_INVALID" => "ErrCodeInvalid",
+        "ERR_CAMERA_DENIED" => "ErrCameraDenied",
+        _ => "ErrQrInvalid",
+    });
 }

--- a/windows/Relay.App/Services/AppController.cs
+++ b/windows/Relay.App/Services/AppController.cs
@@ -78,7 +78,14 @@ public sealed class AppController(IProxyStore proxyStore, IBackupStore backupSto
             Fail(applied.ErrorCode!);
             return;
         }
-        Dispatch("ready");
+        // A concurrent Disconnect may have moved us back to Idle after the proxy
+        // was applied; if so, undo it rather than leaving the proxy on with an
+        // Idle UI (silent, unrecoverable-from-the-window proxy leak).
+        if (!Dispatch("ready"))
+        {
+            try { await DisconnectLocked(); } catch { }
+            return;
+        }
 
         var probe = await Task.Run(() => ProbePhone(payload.Host, payload.Port));
         if (probe != Probe.Ok)
@@ -89,8 +96,12 @@ public sealed class AppController(IProxyStore proxyStore, IBackupStore backupSto
             Fail(code);
             return;
         }
+        if (!Dispatch("clientConnected"))
+        {
+            try { await DisconnectLocked(); } catch { }
+            return;
+        }
         LocalLog.Add("Connected");
-        Dispatch("clientConnected");
         StartSupervisor(payload);
     }
 
@@ -112,7 +123,9 @@ public sealed class AppController(IProxyStore proxyStore, IBackupStore backupSto
         if (result.Ok)
         {
             LocalLog.Add("Disconnected");
-            Dispatch("stop");
+            // "stop" is legal from Connected; a retry from the Error surface
+            // (ERR_ROLLBACK_INCOMPLETE) clears via "dismiss" instead.
+            if (!Dispatch("stop")) Dispatch("dismiss");
         }
         else
         {
@@ -137,15 +150,19 @@ public sealed class AppController(IProxyStore proxyStore, IBackupStore backupSto
     {
         StopSupervisor();
         var cts = new CancellationTokenSource();
-        _supervisor = cts;
+        lock (_gate) { _supervisor = cts; }
         _ = SuperviseAsync(payload, cts.Token);
     }
 
     private void StopSupervisor()
     {
-        _supervisor?.Cancel();
-        _supervisor?.Dispose();
-        _supervisor = null;
+        // Swap the field out under the lock and operate on the local so a
+        // concurrent Start/Stop can't Cancel-after-Dispose or double-dispose.
+        CancellationTokenSource? cts;
+        lock (_gate) { cts = _supervisor; _supervisor = null; }
+        if (cts is null) return;
+        try { cts.Cancel(); } catch { }
+        cts.Dispose();
     }
 
     private async Task SuperviseAsync(QrPayload payload, CancellationToken token)

--- a/windows/Relay.App/Services/CameraQrScanner.cs
+++ b/windows/Relay.App/Services/CameraQrScanner.cs
@@ -111,18 +111,19 @@ public sealed class CameraQrScanner : IDisposable
     public void Dispose()
     {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
-        try
-        {
-            if (_reader is not null)
-            {
-                _reader.FrameArrived -= OnFrame;
-                _reader.StopAsync().AsTask().Wait(TimeSpan.FromSeconds(2));
-                _reader.Dispose();
-            }
-        }
-        catch (Exception) { /* teardown must never throw */ }
-        _capture?.Dispose();
-        _capture = null;
+        var reader = _reader;
+        var capture = _capture;
         _reader = null;
+        _capture = null;
+        // Unsubscribe synchronously so no more frames reach us, then tear the
+        // camera down on a background thread — StopAsync can take ~a second and
+        // Dispose() is called from the UI thread (Cancel / window close).
+        if (reader is not null) reader.FrameArrived -= OnFrame;
+        Task.Run(() =>
+        {
+            try { reader?.StopAsync().AsTask().Wait(TimeSpan.FromSeconds(2)); } catch { }
+            try { reader?.Dispose(); } catch { }
+            try { capture?.Dispose(); } catch { }
+        });
     }
 }

--- a/windows/Relay.App/Strings.cs
+++ b/windows/Relay.App/Strings.cs
@@ -53,7 +53,7 @@ public static class Strings
         ["ErrFirewall"] = "The connection was blocked. Allow Relay through Windows Firewall (or your security software), then try again.",
         ["ErrProxyApply"] = "Windows refused the proxy change. Close other proxy/VPN managers and try again.",
         ["ErrRollback"] = "Relay couldn't fully restore your proxy settings. Disconnect again to retry.",
-        ["ErrCameraDenied"] = "Relay can't use the camera. Allow camera access for desktop apps in Windows Settings > Privacy, or enter the code manually.",
+        ["ErrCameraDenied"] = "Relay can't use the camera — it may be missing, in use by another app, or blocked. Allow camera access in Windows Settings > Privacy, or enter the code manually.",
     };
 
     private static readonly Dictionary<string, string> Fa = new()
@@ -89,6 +89,6 @@ public static class Strings
         ["ErrFirewall"] = "اتصال مسدود شد. به رله در فایروال ویندوز (یا نرم‌افزار امنیتی) اجازه دهید و دوباره تلاش کنید.",
         ["ErrProxyApply"] = "ویندوز تغییر پراکسی را نپذیرفت. مدیریت‌کننده‌های دیگر پراکسی/VPN را ببندید و دوباره تلاش کنید.",
         ["ErrRollback"] = "رله نتوانست تنظیمات پراکسی را کاملاً بازگرداند. برای تلاش دوباره، دوباره «قطع اتصال» را بزنید.",
-        ["ErrCameraDenied"] = "رله به دوربین دسترسی ندارد. در تنظیمات ویندوز > حریم خصوصی، دسترسی دوربین برنامه‌های دسکتاپ را فعال کنید، یا کد را دستی وارد کنید.",
+        ["ErrCameraDenied"] = "رله به دوربین دسترسی ندارد — ممکن است نبودن دوربین، اشغال توسط برنامه‌ای دیگر، یا مسدودبودن باشد. در تنظیمات ویندوز > حریم خصوصی دسترسی دوربین را فعال کنید، یا کد را دستی وارد کنید.",
     };
 }

--- a/windows/installer/relay.iss
+++ b/windows/installer/relay.iss
@@ -48,3 +48,13 @@ Name: "{autodesktop}\Relay"; Filename: "{app}\Relay.App.exe"; Tasks: desktopicon
 
 [Run]
 Filename: "{app}\Relay.App.exe"; Description: "{cm:LaunchProgram,Relay}"; Flags: nowait postinstall skipifsilent
+
+[UninstallRun]
+; If a session is active at uninstall time, stop the app and restore the system
+; proxy so the user isn't left with a dangling SOCKS proxy and no app to undo it.
+Filename: "{sys}\taskkill.exe"; Parameters: "/f /im Relay.App.exe"; Flags: runhidden; RunOnceId: "StopRelay"
+Filename: "{app}\Relay.App.exe"; Parameters: "--restore-proxy"; Flags: runhidden waituntilterminated skipifdoesntexist; RunOnceId: "RestoreProxy"
+
+[UninstallDelete]
+; Don't leave the local-only backup/log behind after uninstall.
+Type: filesandordirs; Name: "{localappdata}\Relay"


### PR DESCRIPTION
Complete professional review of the Windows app. Fixed: (1 critical) Connect/Disconnect race leaving proxy applied with Idle UI; (2) second-launch silent no-op; (3) uninstall strands proxy + leftover data; (4) 2s UI freeze on camera close; (5) rollback-incomplete retry; (6) local error wiped on theme change; (7) camera message; (8) preview source leak; (9) supervisor CTS race.

🤖 Generated with [Claude Code](https://claude.com/claude-code)