### PR TITLE
fix(windows): eliminate tray freeze + Liquid Glass redesign

### DIFF
--- a/windows/Relay.App/MainWindow.xaml
+++ b/windows/Relay.App/MainWindow.xaml
@@ -3,10 +3,69 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <!-- No custom resource dictionary on purpose: hand-built resource lookups
-         were parse-faulting at window load in this unpackaged build. Colors are
-         inline; the dynamic status-dot colors are set from code (ThemeBrush). -->
-    <Grid x:Name="Root" Padding="24" Background="#0A0C10">
+    <Grid x:Name="Root" Padding="22,18,22,20">
+        <Grid.Background>
+            <!-- Light scrim over the acrylic backdrop: keeps text legible on any
+                 wallpaper while letting the frosted glass show through. -->
+            <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
+                <GradientStop Color="#33121620" Offset="0" />
+                <GradientStop Color="#4D0A0C10" Offset="1" />
+            </LinearGradientBrush>
+        </Grid.Background>
+
+        <Grid.Resources>
+            <!-- One pill-button look for the whole app. A white overlay brightens on
+                 hover (works for both the accent and the glass buttons); no theme
+                 resources are referenced, so it can't fault at load. -->
+            <Style x:Key="PillButton" TargetType="Button">
+                <Setter Property="CornerRadius" Value="23" />
+                <Setter Property="Height" Value="46" />
+                <Setter Property="HorizontalAlignment" Value="Stretch" />
+                <Setter Property="FontSize" Value="15" />
+                <Setter Property="FontWeight" Value="SemiBold" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="UseSystemFocusVisuals" Value="False" />
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="Bd" CornerRadius="{TemplateBinding CornerRadius}"
+                                    Background="{TemplateBinding Background}"
+                                    BorderBrush="{TemplateBinding BorderBrush}"
+                                    BorderThickness="{TemplateBinding BorderThickness}">
+                                <Grid>
+                                    <Border x:Name="Hover" CornerRadius="{TemplateBinding CornerRadius}"
+                                            Background="Transparent" />
+                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"
+                                                      Foreground="{TemplateBinding Foreground}"
+                                                      Content="{TemplateBinding Content}" />
+                                </Grid>
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup x:Name="CommonStates">
+                                        <VisualState x:Name="Normal" />
+                                        <VisualState x:Name="PointerOver">
+                                            <VisualState.Setters>
+                                                <Setter Target="Hover.Background" Value="#22FFFFFF" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Pressed">
+                                            <VisualState.Setters>
+                                                <Setter Target="Hover.Background" Value="#2E000000" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Disabled">
+                                            <VisualState.Setters>
+                                                <Setter Target="Bd.Opacity" Value="0.4" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+                            </Border>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+        </Grid.Resources>
+
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
@@ -14,114 +73,127 @@
         </Grid.RowDefinitions>
 
         <!-- Header -->
-        <Grid Grid.Row="0" Margin="0,4,0,20">
-            <TextBlock x:Name="TitleText" Text="Relay" FontSize="20" FontWeight="SemiBold"
-                       Foreground="#F5FFFFFF" />
+        <Grid Grid.Row="0" Margin="2,0,2,14">
+            <TextBlock x:Name="TitleText" Text="Relay" FontSize="22" FontWeight="SemiBold"
+                       FontFamily="Segoe UI Variable Display" Foreground="#F2FFFFFF" />
             <Ellipse x:Name="StatusDot" Width="10" Height="10"
-                     HorizontalAlignment="Right" VerticalAlignment="Center" Fill="#61FFFFFF" />
+                     HorizontalAlignment="Right" VerticalAlignment="Center" Fill="#66FFFFFF" />
         </Grid>
 
         <!-- Idle -->
-        <StackPanel x:Name="IdlePanel" Grid.Row="1" VerticalAlignment="Center" Spacing="12">
-            <TextBlock x:Name="IdleStatusText" HorizontalAlignment="Center" Foreground="#9EFFFFFF" />
-            <Button x:Name="ScanButton" Margin="0,16,0,0" HorizontalAlignment="Stretch"
-                    Background="#45D6B8" Foreground="#0A0C10" CornerRadius="20" Padding="24,10"
-                    FontWeight="SemiBold" BorderThickness="0" Click="OnScanClick" />
-            <Button x:Name="EnterCodeButton" HorizontalAlignment="Stretch"
-                    Background="#14FFFFFF" Foreground="#F5FFFFFF" BorderBrush="#1FFFFFFF"
-                    BorderThickness="1" CornerRadius="20" Padding="24,10" Click="OnEnterCodeClick" />
-            <TextBlock x:Name="TaglineText" HorizontalAlignment="Center" Margin="0,12,0,0"
-                       FontSize="12" Foreground="#61FFFFFF" />
+        <StackPanel x:Name="IdlePanel" Grid.Row="1" VerticalAlignment="Center" Spacing="14">
+            <TextBlock x:Name="IdleStatusText" HorizontalAlignment="Center" FontSize="15"
+                       Foreground="#A8FFFFFF" Margin="0,0,0,4" />
+            <Button x:Name="ScanButton" Style="{StaticResource PillButton}"
+                    Background="#4ADFBF" Foreground="#05201B" BorderBrush="Transparent"
+                    Click="OnScanClick" />
+            <Button x:Name="EnterCodeButton" Style="{StaticResource PillButton}"
+                    Background="#16FFFFFF" Foreground="#F2FFFFFF" BorderBrush="#2AFFFFFF"
+                    Click="OnEnterCodeClick" />
+            <TextBlock x:Name="TaglineText" HorizontalAlignment="Center" Margin="0,6,0,0"
+                       FontSize="12" Foreground="#66FFFFFF" />
         </StackPanel>
 
         <!-- Scanning -->
-        <Grid x:Name="ScanPanel" Grid.Row="1" Visibility="Collapsed">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*" />
-                <RowDefinition Height="Auto" />
-                <RowDefinition Height="Auto" />
-            </Grid.RowDefinitions>
-            <Border Grid.Row="0" CornerRadius="16" Background="#14171D"
-                    BorderBrush="#1FFFFFFF" BorderThickness="1">
-                <Image x:Name="PreviewImage" Stretch="UniformToFill" />
+        <StackPanel x:Name="ScanPanel" Grid.Row="1" VerticalAlignment="Center" Spacing="14"
+                    Visibility="Collapsed">
+            <Border CornerRadius="18" Background="#14171D" BorderBrush="#26FFFFFF" BorderThickness="1"
+                    Height="300" HorizontalAlignment="Stretch">
+                <Border CornerRadius="18">
+                    <Border.Clip>
+                        <RectangleGeometry Rect="0,0,336,300" RadiusX="18" RadiusY="18" />
+                    </Border.Clip>
+                    <Image x:Name="PreviewImage" Stretch="UniformToFill" />
+                </Border>
             </Border>
-            <TextBlock x:Name="ScanHintText" Grid.Row="1" Margin="0,12,0,12"
-                       TextWrapping="Wrap" TextAlignment="Center" FontSize="12" Foreground="#61FFFFFF" />
-            <Button x:Name="ScanCancelButton" Grid.Row="2" HorizontalAlignment="Stretch"
-                    Background="#14FFFFFF" Foreground="#F5FFFFFF" BorderBrush="#1FFFFFFF"
-                    BorderThickness="1" CornerRadius="20" Padding="24,10" Click="OnCancelClick" />
-        </Grid>
+            <TextBlock x:Name="ScanHintText" TextWrapping="Wrap" TextAlignment="Center"
+                       FontSize="12.5" Foreground="#8AFFFFFF" />
+            <Button x:Name="ScanCancelButton" Style="{StaticResource PillButton}"
+                    Background="#16FFFFFF" Foreground="#F2FFFFFF" BorderBrush="#2AFFFFFF"
+                    Click="OnCancelClick" />
+        </StackPanel>
 
         <!-- Manual code entry -->
-        <StackPanel x:Name="CodePanel" Grid.Row="1" VerticalAlignment="Center" Spacing="12"
+        <StackPanel x:Name="CodePanel" Grid.Row="1" VerticalAlignment="Center" Spacing="14"
                     Visibility="Collapsed">
-            <TextBox x:Name="CodeBox" PlaceholderText="XXXX-XXXX"
-                     FontSize="24" TextAlignment="Center" CharacterSpacing="150" MaxLength="9" />
+            <TextBox x:Name="CodeBox" PlaceholderText="XXXX-XXXX" FontSize="26" MaxLength="9"
+                     TextAlignment="Center" CharacterSpacing="180" CornerRadius="16" Height="66"
+                     Background="#16FFFFFF" Foreground="#F2FFFFFF" BorderBrush="#2AFFFFFF"
+                     VerticalContentAlignment="Center" FontFamily="Consolas" />
             <TextBlock x:Name="CodeHintText" TextWrapping="Wrap" TextAlignment="Center"
-                       FontSize="12" Foreground="#61FFFFFF" />
-            <Button x:Name="CodeConnectButton" HorizontalAlignment="Stretch"
-                    Background="#45D6B8" Foreground="#0A0C10" CornerRadius="20" Padding="24,10"
-                    FontWeight="SemiBold" BorderThickness="0" Click="OnCodeConnectClick" />
-            <Button x:Name="CodeCancelButton" HorizontalAlignment="Stretch"
-                    Background="#14FFFFFF" Foreground="#F5FFFFFF" BorderBrush="#1FFFFFFF"
-                    BorderThickness="1" CornerRadius="20" Padding="24,10" Click="OnCancelClick" />
+                       FontSize="12.5" Foreground="#8AFFFFFF" />
+            <Button x:Name="CodeConnectButton" Style="{StaticResource PillButton}"
+                    Background="#4ADFBF" Foreground="#05201B" BorderBrush="Transparent"
+                    Click="OnCodeConnectClick" />
+            <Button x:Name="CodeCancelButton" Style="{StaticResource PillButton}"
+                    Background="#16FFFFFF" Foreground="#F2FFFFFF" BorderBrush="#2AFFFFFF"
+                    Click="OnCancelClick" />
         </StackPanel>
 
         <!-- Busy -->
-        <StackPanel x:Name="BusyPanel" Grid.Row="1" VerticalAlignment="Center" Spacing="16"
+        <StackPanel x:Name="BusyPanel" Grid.Row="1" VerticalAlignment="Center" Spacing="18"
                     Visibility="Collapsed">
-            <ProgressRing IsActive="True" Width="36" Height="36" Foreground="#45D6B8" />
-            <TextBlock x:Name="BusyText" HorizontalAlignment="Center" Foreground="#9EFFFFFF" />
+            <ProgressRing IsActive="True" Width="40" Height="40" Foreground="#4ADFBF" />
+            <TextBlock x:Name="BusyText" HorizontalAlignment="Center" FontSize="15" Foreground="#A8FFFFFF" />
         </StackPanel>
 
         <!-- Connected -->
-        <StackPanel x:Name="ConnectedPanel" Grid.Row="1" VerticalAlignment="Center" Spacing="8"
+        <StackPanel x:Name="ConnectedPanel" Grid.Row="1" VerticalAlignment="Center" Spacing="10"
                     Visibility="Collapsed">
-            <Ellipse x:Name="ConnectedDot" Width="12" Height="12" Fill="#45D6B8"
-                     HorizontalAlignment="Center" />
-            <TextBlock x:Name="ConnectedText" HorizontalAlignment="Center" FontSize="16"
-                       FontWeight="SemiBold" Foreground="#F5FFFFFF" TextAlignment="Center"
+            <Grid HorizontalAlignment="Center" Width="72" Height="72" Margin="0,0,0,6">
+                <Ellipse Width="72" Height="72" Fill="#1F4ADFBF" />
+                <Ellipse Width="44" Height="44" Fill="#334ADFBF" />
+                <Ellipse x:Name="ConnectedDot" Width="18" Height="18" Fill="#4ADFBF" />
+            </Grid>
+            <TextBlock x:Name="ConnectedText" HorizontalAlignment="Center" FontSize="17"
+                       FontWeight="SemiBold" Foreground="#F2FFFFFF" TextAlignment="Center"
                        TextWrapping="Wrap" />
-            <TextBlock x:Name="ConnectedDetailText" HorizontalAlignment="Center"
-                       FontSize="12" Foreground="#61FFFFFF" />
+            <TextBlock x:Name="ConnectedDetailText" HorizontalAlignment="Center" FontSize="12.5"
+                       FontFamily="Consolas" Foreground="#66FFFFFF" />
             <TextBlock x:Name="ReconnectingText" HorizontalAlignment="Center" Visibility="Collapsed"
-                       FontSize="12" Foreground="#E0A458" />
-            <Button x:Name="DisconnectButton" Margin="0,20,0,0" HorizontalAlignment="Stretch"
-                    Background="#14FFFFFF" Foreground="#F5FFFFFF" BorderBrush="#1FFFFFFF"
-                    BorderThickness="1" CornerRadius="20" Padding="24,10" Click="OnDisconnectClick" />
+                       FontSize="12.5" Foreground="#F0B45E" />
+            <Button x:Name="DisconnectButton" Style="{StaticResource PillButton}" Margin="0,14,0,0"
+                    Background="#16FFFFFF" Foreground="#F2FFFFFF" BorderBrush="#2AFFFFFF"
+                    Click="OnDisconnectClick" />
         </StackPanel>
 
         <!-- Error -->
-        <StackPanel x:Name="ErrorPanel" Grid.Row="1" VerticalAlignment="Center" Spacing="12"
+        <StackPanel x:Name="ErrorPanel" Grid.Row="1" VerticalAlignment="Center" Spacing="14"
                     Visibility="Collapsed">
-            <Ellipse Width="12" Height="12" Fill="#E5645F" HorizontalAlignment="Center" />
-            <TextBlock x:Name="ErrorText" TextWrapping="Wrap" TextAlignment="Center" Foreground="#9EFFFFFF" />
-            <Button x:Name="ErrorDismissButton" Margin="0,12,0,0" HorizontalAlignment="Stretch"
-                    Background="#14FFFFFF" Foreground="#F5FFFFFF" BorderBrush="#1FFFFFFF"
-                    BorderThickness="1" CornerRadius="20" Padding="24,10" Click="OnDismissClick" />
+            <Grid HorizontalAlignment="Center" Width="60" Height="60">
+                <Ellipse Width="60" Height="60" Fill="#1FFF6B66" />
+                <Ellipse Width="14" Height="14" Fill="#FF6B66" />
+            </Grid>
+            <TextBlock x:Name="ErrorText" TextWrapping="Wrap" TextAlignment="Center" FontSize="14"
+                       Foreground="#C8FFFFFF" LineHeight="20" />
+            <Button x:Name="ErrorDismissButton" Style="{StaticResource PillButton}" Margin="0,6,0,0"
+                    Background="#16FFFFFF" Foreground="#F2FFFFFF" BorderBrush="#2AFFFFFF"
+                    Click="OnDismissClick" />
         </StackPanel>
 
         <!-- Advanced -->
-        <Expander x:Name="AdvancedExpander" Grid.Row="2" Margin="0,16,0,0"
+        <Expander x:Name="AdvancedExpander" Grid.Row="2" Margin="0,14,0,0" Background="Transparent"
                   HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch">
             <Expander.Header>
-                <TextBlock x:Name="AdvancedHeader" FontSize="12" Foreground="#9EFFFFFF" />
+                <TextBlock x:Name="AdvancedHeader" FontSize="12.5" Foreground="#A8FFFFFF" />
             </Expander.Header>
-            <StackPanel Spacing="10">
+            <StackPanel Spacing="12" Padding="2,6,2,2">
                 <Grid>
-                    <TextBlock x:Name="AdvancedAddressLabel" FontSize="12" Foreground="#9EFFFFFF" />
+                    <TextBlock x:Name="AdvancedAddressLabel" FontSize="12.5" Foreground="#A8FFFFFF" />
                     <TextBlock x:Name="AdvancedAddressValue" HorizontalAlignment="Right"
-                               FontFamily="Consolas" Foreground="#F5FFFFFF" />
+                               FontFamily="Consolas" FontSize="12.5" Foreground="#F2FFFFFF" />
                 </Grid>
                 <Grid>
-                    <TextBlock x:Name="AdvancedLogsLabel" FontSize="12" Foreground="#9EFFFFFF" />
+                    <TextBlock x:Name="AdvancedLogsLabel" FontSize="12.5" Foreground="#A8FFFFFF" />
                     <HyperlinkButton x:Name="AdvancedLogsClear" HorizontalAlignment="Right"
                                      Padding="0" Click="OnClearLogsClick" />
                 </Grid>
-                <ScrollViewer Height="140" VerticalScrollBarVisibility="Auto">
-                    <TextBlock x:Name="LogText" FontFamily="Consolas" FontSize="11"
-                               TextWrapping="NoWrap" Foreground="#61FFFFFF" />
-                </ScrollViewer>
+                <Border CornerRadius="12" Background="#12000000" Padding="12,8">
+                    <ScrollViewer Height="120" VerticalScrollBarVisibility="Auto">
+                        <TextBlock x:Name="LogText" FontFamily="Consolas" FontSize="11"
+                                   TextWrapping="NoWrap" Foreground="#8AFFFFFF" />
+                    </ScrollViewer>
+                </Border>
             </StackPanel>
         </Expander>
     </Grid>

--- a/windows/Relay.App/MainWindow.xaml
+++ b/windows/Relay.App/MainWindow.xaml
@@ -99,12 +99,7 @@
                     Visibility="Collapsed">
             <Border CornerRadius="18" Background="#14171D" BorderBrush="#26FFFFFF" BorderThickness="1"
                     Height="300" HorizontalAlignment="Stretch">
-                <Border CornerRadius="18">
-                    <Border.Clip>
-                        <RectangleGeometry Rect="0,0,336,300" RadiusX="18" RadiusY="18" />
-                    </Border.Clip>
-                    <Image x:Name="PreviewImage" Stretch="UniformToFill" />
-                </Border>
+                <Image x:Name="PreviewImage" Stretch="UniformToFill" Margin="1" />
             </Border>
             <TextBlock x:Name="ScanHintText" TextWrapping="Wrap" TextAlignment="Center"
                        FontSize="12.5" Foreground="#8AFFFFFF" />

--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -1,32 +1,45 @@
+using System.Runtime.InteropServices;
 using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Media.Imaging;
 using Relay.App.Services;
 using Relay.Core;
+using Windows.Graphics;
 using Windows.Graphics.Imaging;
 
 namespace Relay.App;
 
 /// <summary>
-/// The compact glass popup near the tray. UI is a pure projection of
-/// AppController state plus a local "input mode" (scanning / code entry).
+/// The compact glass popover near the tray. It behaves like a macOS menu-bar
+/// popover: the tray icon shows it (brought to the real foreground), and it
+/// hides itself when it loses focus. The UI is a projection of AppController
+/// state plus a local input mode (scanning / code entry).
 /// </summary>
 public sealed partial class MainWindow : Window
 {
-    private const int PopupWidth = 400;
-    private const int PopupHeight = 640;
+    private const int PopupWidth = 380;
+    private const int PopupHeight = 600;
 
     private readonly AppController _controller = AppController.Instance;
     private CameraQrScanner? _scanner;
     private long _lastPreviewTicks;
     private enum InputMode { None, Scanning, Code }
     private InputMode _mode = InputMode.None;
+    private string? _localError;
+    private long _shownAtTick;
+
+    [DllImport("user32.dll")] private static extern bool SetForegroundWindow(IntPtr hWnd);
+    [DllImport("user32.dll")] private static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+    [DllImport("user32.dll")] private static extern uint GetDpiForWindow(IntPtr hWnd);
+    private const int SW_SHOW = 5;
+
+    private IntPtr Hwnd => WinRT.Interop.WindowNative.GetWindowHandle(this);
 
     public MainWindow()
     {
         InitializeComponent();
-        // Acrylic is cosmetic and can fault on some setups; set it in code so a
-        // failure degrades to the solid Grid background instead of crashing load.
+        // Acrylic gives the glass look; set it in code so an unsupported backdrop
+        // degrades to the solid scrim instead of failing the XAML load.
         try { SystemBackdrop = new Microsoft.UI.Xaml.Media.DesktopAcrylicBackdrop(); } catch { }
         Title = Strings.Get("AppName");
         ConfigureAppWindow();
@@ -41,28 +54,72 @@ public sealed partial class MainWindow : Window
 
     private void ConfigureAppWindow()
     {
-        AppWindow.Resize(new Windows.Graphics.SizeInt32(PopupWidth, PopupHeight));
         if (AppWindow.Presenter is OverlappedPresenter presenter)
         {
             presenter.IsResizable = false;
             presenter.IsMaximizable = false;
             presenter.IsMinimizable = false;
             presenter.SetBorderAndTitleBar(true, false);
+            presenter.IsAlwaysOnTop = true;
         }
         AppWindow.IsShownInSwitchers = false;
 
-        // Closing the popup hides it; the app lives in the tray.
+        // Closing the popover hides it to the tray; it's never destroyed.
         AppWindow.Closing += (_, args) =>
         {
             args.Cancel = true;
-            StopScanning();
-            AppWindow.Hide();
+            HideToTray();
+        };
+
+        // macOS-popover behaviour: hide when focus is lost — but never mid-scan,
+        // so a system camera prompt can't dismiss the scanner.
+        Activated += (_, e) =>
+        {
+            // Ignore the brief deactivation that can follow a show (if the
+            // foreground grab momentarily loses), else the popover flash-hides.
+            if (e.WindowActivationState == WindowActivationState.Deactivated
+                && _mode != InputMode.Scanning
+                && Environment.TickCount64 - _shownAtTick > 400)
+            {
+                AppWindow.Hide();
+            }
         };
 
         if (System.Globalization.CultureInfo.CurrentUICulture.TextInfo.IsRightToLeft)
         {
             Root.FlowDirection = FlowDirection.RightToLeft;
         }
+    }
+
+    /// <summary>Positions the popover above the tray and brings it to the real foreground.</summary>
+    public void ShowNearTray()
+    {
+        var hwnd = Hwnd;
+        var scale = GetDpiForWindow(hwnd) / 96.0;
+        if (scale <= 0) scale = 1.0;
+        var w = (int)(PopupWidth * scale);
+        var h = (int)(PopupHeight * scale);
+        var margin = (int)(12 * scale);
+
+        AppWindow.Resize(new SizeInt32(w, h));
+        var area = DisplayArea.GetFromWindowId(AppWindow.Id, DisplayAreaFallback.Primary).WorkArea;
+        AppWindow.Move(new PointInt32(
+            area.X + area.Width - w - margin,
+            area.Y + area.Height - h - margin));
+
+        _shownAtTick = Environment.TickCount64;
+        AppWindow.Show();
+        // Window.Activate() alone doesn't beat Windows' foreground lock from a
+        // tray click, which left the window hidden/behind and looking frozen.
+        ShowWindow(hwnd, SW_SHOW);
+        SetForegroundWindow(hwnd);
+        Activate();
+    }
+
+    private void HideToTray()
+    {
+        StopScanning();
+        AppWindow.Hide();
     }
 
     private void ApplyStrings()
@@ -86,17 +143,16 @@ public sealed partial class MainWindow : Window
         AdvancedLogsClear.Content = Strings.Get("AdvancedLogsClear");
     }
 
-    /// <summary>Resolves a theme-dictionary brush by key for the effective theme.</summary>
-    /// <summary>Dynamic status-dot color by key. Inline so it needs no XAML resources.</summary>
+    /// <summary>Dynamic dot color by key — inline so it needs no XAML resources.</summary>
     private static Microsoft.UI.Xaml.Media.Brush ThemeBrush(string key)
     {
         (byte a, byte r, byte g, byte b) = key switch
         {
-            "Accent" => ((byte)0xFF, (byte)0x45, (byte)0xD6, (byte)0xB8),
-            "ErrorBrush" => ((byte)0xFF, (byte)0xE5, (byte)0x64, (byte)0x5F),
-            "WarningBrush" => ((byte)0xFF, (byte)0xE0, (byte)0xA4, (byte)0x58),
-            "TextSecondary" => ((byte)0x9E, (byte)0xFF, (byte)0xFF, (byte)0xFF),
-            _ => ((byte)0x61, (byte)0xFF, (byte)0xFF, (byte)0xFF), // TextTertiary
+            "Accent" => ((byte)0xFF, (byte)0x4A, (byte)0xDF, (byte)0xBF),
+            "ErrorBrush" => ((byte)0xFF, (byte)0xFF, (byte)0x6B, (byte)0x66),
+            "WarningBrush" => ((byte)0xFF, (byte)0xF0, (byte)0xB4, (byte)0x5E),
+            "TextSecondary" => ((byte)0xA8, (byte)0xFF, (byte)0xFF, (byte)0xFF),
+            _ => ((byte)0x66, (byte)0xFF, (byte)0xFF, (byte)0xFF),
         };
         return new Microsoft.UI.Xaml.Media.SolidColorBrush(Windows.UI.Color.FromArgb(a, r, g, b));
     }
@@ -106,38 +162,21 @@ public sealed partial class MainWindow : Window
         var logs = LocalLog.Snapshot();
         LogText.Text = logs.Count == 0
             ? Strings.Get("AdvancedLogsEmpty")
-            : string.Join("\n", logs.Reverse().Select(e =>
-                $"{e.ElapsedSeconds,7:F1}s  {e.Message}"));
+            : string.Join("\n", logs.Reverse().Select(entry =>
+                $"{entry.ElapsedSeconds,7:F1}s  {entry.Message}"));
     }
 
     private void OnClearLogsClick(object sender, RoutedEventArgs e) => LocalLog.Clear();
-
-    /// <summary>Positions the popup just above the taskbar corner and shows it.</summary>
-    public void ShowNearTray()
-    {
-        var workArea = DisplayArea.Primary.WorkArea;
-        AppWindow.Move(new Windows.Graphics.PointInt32(
-            workArea.X + workArea.Width - PopupWidth - 12,
-            workArea.Y + workArea.Height - PopupHeight - 12));
-        AppWindow.Show();
-        Activate();
-    }
 
     // --- state projection ----------------------------------------------------
 
     private void Render()
     {
-        // Local input errors (bad scan/code, camera) are owned here too, so a
-        // Render triggered by anything else (e.g. a Windows theme switch) can't
-        // silently wipe the error panel.
+        // A local input error (bad scan/code, camera) is a first-class Render
+        // state, so a later Render (e.g. from a theme change) can't erase it.
         if (_localError is not null)
         {
-            IdlePanel.Visibility = Visibility.Collapsed;
-            ScanPanel.Visibility = Visibility.Collapsed;
-            CodePanel.Visibility = Visibility.Collapsed;
-            BusyPanel.Visibility = Visibility.Collapsed;
-            ConnectedPanel.Visibility = Visibility.Collapsed;
-            ErrorPanel.Visibility = Visibility.Visible;
+            ShowOnly(ErrorPanel);
             ErrorText.Text = LocalErrorMessage(_localError);
             ErrorDismissButton.Content = Strings.Get("Dismiss");
             StatusDot.Fill = ThemeBrush("ErrorBrush");
@@ -145,7 +184,6 @@ public sealed partial class MainWindow : Window
         }
 
         var state = _controller.StateName;
-
         IdlePanel.Visibility = Show(state == "Idle" && _mode == InputMode.None);
         ScanPanel.Visibility = Show(state == "Idle" && _mode == InputMode.Scanning);
         CodePanel.Visibility = Show(state == "Idle" && _mode == InputMode.Code);
@@ -166,8 +204,7 @@ public sealed partial class MainWindow : Window
 
         if (state == "Connected" && _controller.Payload is { } payload)
         {
-            ConnectedText.Text = string.Format(
-                Strings.Get("ConnectedVia"), payload.Name ?? payload.Host);
+            ConnectedText.Text = string.Format(Strings.Get("ConnectedVia"), payload.Name ?? payload.Host);
             ConnectedDetailText.Text = $"{payload.Host}:{payload.Port}";
             ReconnectingText.Text = Strings.Get("Reconnecting");
             ReconnectingText.Visibility = Show(reconnecting);
@@ -189,20 +226,35 @@ public sealed partial class MainWindow : Window
                 "ERR_CAMERA_DENIED" => "ErrCameraDenied",
                 _ => "ErrProxyApply",
             });
-            // Rollback-incomplete leaves a half-applied proxy: offer a retry here
-            // (the button re-runs Disconnect) instead of only "Dismiss".
+            // The rollback-incomplete error's next action is to retry the disconnect.
             ErrorDismissButton.Content = Strings.Get(
                 _controller.ErrorCode == "ERR_ROLLBACK_INCOMPLETE" ? "Disconnect" : "Dismiss");
         }
 
-        // Advanced address reflects the active session, if any.
-        AdvancedAddressValue.Text = _controller.Payload is { } p
-            ? $"{p.Host}:{p.Port}"
-            : "—";
+        AdvancedAddressValue.Text = _controller.Payload is { } p ? $"{p.Host}:{p.Port}" : "—";
     }
 
-    private static Visibility Show(bool visible) =>
-        visible ? Visibility.Visible : Visibility.Collapsed;
+    private void ShowOnly(FrameworkElement panel)
+    {
+        IdlePanel.Visibility = Visibility.Collapsed;
+        ScanPanel.Visibility = Visibility.Collapsed;
+        CodePanel.Visibility = Visibility.Collapsed;
+        BusyPanel.Visibility = Visibility.Collapsed;
+        ConnectedPanel.Visibility = Visibility.Collapsed;
+        ErrorPanel.Visibility = Visibility.Collapsed;
+        panel.Visibility = Visibility.Visible;
+    }
+
+    private static string LocalErrorMessage(string code) => Strings.Get(code switch
+    {
+        "ERR_QR_NEWER_VERSION" => "ErrQrNewer",
+        "ERR_QR_INVALID" => "ErrQrInvalid",
+        "ERR_CODE_INVALID" => "ErrCodeInvalid",
+        "ERR_CAMERA_DENIED" => "ErrCameraDenied",
+        _ => "ErrQrInvalid",
+    });
+
+    private static Visibility Show(bool visible) => visible ? Visibility.Visible : Visibility.Collapsed;
 
     // --- scanning -------------------------------------------------------------
 
@@ -245,7 +297,7 @@ public sealed partial class MainWindow : Window
                 var source = new SoftwareBitmapSource();
                 await source.SetBitmapAsync(bitmap);
                 PreviewImage.Source = source;
-                previous?.Dispose(); // release the outgoing frame's native buffer now
+                previous?.Dispose();
             }
         });
     }
@@ -260,11 +312,10 @@ public sealed partial class MainWindow : Window
             var decoded = QrPayloadCodec.Decode(text);
             if (!decoded.IsOk)
             {
-                ShowLocalError(decoded.Reason == "unknown-version"
-                    ? "ERR_QR_NEWER_VERSION"
-                    : "ERR_QR_INVALID");
+                ShowLocalError(decoded.Reason == "unknown-version" ? "ERR_QR_NEWER_VERSION" : "ERR_QR_INVALID");
                 return;
             }
+            _localError = null;
             await _controller.ConnectAsync(decoded.Payload!);
         });
     }
@@ -317,8 +368,7 @@ public sealed partial class MainWindow : Window
 
     private async void OnDismissClick(object sender, RoutedEventArgs e)
     {
-        // On a rollback-incomplete error the proxy may still be applied, so the
-        // button retries Disconnect instead of just clearing the message.
+        // For a failed rollback the action is "retry the disconnect", not dismiss.
         if (_localError is null && _controller.ErrorCode == "ERR_ROLLBACK_INCOMPLETE")
         {
             await _controller.DisconnectAsync();
@@ -329,23 +379,10 @@ public sealed partial class MainWindow : Window
         Render();
     }
 
-    // Input-validation errors (bad scan/typed code) never touched the system,
-    // so they render locally without entering the shared state machine.
-    private string? _localError;
-
     private void ShowLocalError(string code)
     {
         _localError = code;
         _mode = InputMode.None;
         Render();
     }
-
-    private static string LocalErrorMessage(string code) => Strings.Get(code switch
-    {
-        "ERR_QR_NEWER_VERSION" => "ErrQrNewer",
-        "ERR_QR_INVALID" => "ErrQrInvalid",
-        "ERR_CODE_INVALID" => "ErrCodeInvalid",
-        "ERR_CAMERA_DENIED" => "ErrCameraDenied",
-        _ => "ErrQrInvalid",
-    });
 }


### PR DESCRIPTION
Fixes the 'freezes in the tray / won't open' bug (Window.Activate can't beat the foreground lock -> real SetForegroundWindow + macOS-style hide-on-focus-loss popover) and redesigns the UI to a translucent Liquid Glass look over acrylic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)