### PR TITLE
fix: three connection defects reported in issue #18

### DIFF
--- a/android/app/src/main/kotlin/io/relay/app/net/LocalAddress.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/LocalAddress.kt
@@ -12,7 +12,9 @@ import java.net.NetworkInterface
  * There is no public API for "which interface will the client reach me on", so
  * we score candidates: hotspot AP interfaces are preferred (the client is
  * almost certainly on them), then station Wi-Fi, then wired; a gateway-looking
- * `.1` host nudges AP interfaces higher. Any site-local IPv4 is advertisable.
+ * `.1` host nudges AP interfaces higher. Cellular and VPN links are excluded
+ * outright (see [isReachableFromClient]); every remaining site-local IPv4 is
+ * advertisable, and finding none is a real "no Wi-Fi or hotspot" error.
  */
 object LocalAddress {
 
@@ -35,8 +37,21 @@ object LocalAddress {
                     .filter { it.isSiteLocalAddress }
                     .map { Candidate(nic.name.lowercase(), it.hostAddress ?: "") }
             }
-            .filter { it.ip.isNotEmpty() }
+            .filter { it.ip.isNotEmpty() && isReachableFromClient(it.interfaceName) }
     }
+
+    /**
+     * Rejects links the client can never route to. Both the carrier's mobile-data
+     * link and a VPN tunnel hand out site-local IPv4 (a carrier commonly uses
+     * 10.0.0.0/8, a tun sits on 10.x or 172.16.x), so [Inet4Address.isSiteLocalAddress]
+     * alone will happily advertise an address no PC can reach — and since sharing a
+     * phone VPN is this app's whole point, a tun interface is always present.
+     *
+     * Blocklist, not allowlist: an OEM hotspot under an unexpected name keeps
+     * working on the baseline score instead of regressing to "no Wi-Fi or hotspot".
+     */
+    internal fun isReachableFromClient(interfaceName: String): Boolean =
+        UNREACHABLE_HINTS.none { interfaceName.contains(it) }
 
     /** Pure selection over already-enumerated candidates. Highest score wins; null if none. */
     internal fun choose(candidates: List<Candidate>): String? =
@@ -56,4 +71,17 @@ object LocalAddress {
     }
 
     private val AP_HINTS = listOf("ap", "swlan", "softap", "wlan1", "wigig")
+
+    /**
+     * Substrings (not prefixes — 464XLAT names its link `v4-rmnet_data0`) of
+     * interfaces whose addresses are unreachable from the client. See issue #18:
+     * with hotspot and Wi-Fi both off, `rmnet_data0`'s carrier address was the only
+     * candidate left and got advertised, producing a QR that could never connect.
+     */
+    private val UNREACHABLE_HINTS = listOf(
+        "rmnet", "ccmni", "pdp", "seth", "wwan", "qmi", "ppp", // cellular
+        "tun", "ipsec", "dummy",                               // VPN / placeholder
+        // No "tap" here: it is a substring of the legitimate `softap0` hotspot,
+        // and Android VPNs land on tun anyway.
+    )
 }

--- a/android/app/src/main/kotlin/io/relay/app/ui/HomeScreen.kt
+++ b/android/app/src/main/kotlin/io/relay/app/ui/HomeScreen.kt
@@ -363,8 +363,8 @@ private fun PairingPanel(
             color = glass.textTertiary,
         )
 
+        Spacer(Modifier.height(20.dp))
         if (typedCode != null) {
-            Spacer(Modifier.height(20.dp))
             Text(
                 text = stringResource(R.string.or_type_code),
                 style = MaterialTheme.typography.labelSmall,
@@ -375,6 +375,14 @@ private fun PairingPanel(
                 text = typedCode.chunked(4).joinToString("-"),
                 style = MaterialTheme.typography.headlineMedium,
                 color = glass.textPrimary,
+            )
+        } else {
+            // Full Mode (key material doesn't fit) or a host outside 192.168.0.0/16.
+            // Say so — an unexplained gap here reads as a bug (issue #18).
+            Text(
+                text = stringResource(R.string.code_unavailable),
+                style = MaterialTheme.typography.labelSmall,
+                color = glass.textTertiary,
             )
         }
 

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -15,6 +15,7 @@
     </plurals>
     <string name="scan_hint">با «رله» روی رایانه‌تان اسکن کنید</string>
     <string name="or_type_code">یا این کد را در رایانه وارد کنید</string>
+    <string name="code_unavailable">کد دستی در این شبکه نیست — کیو‌آر را اسکن کنید</string>
     <string name="traffic_format">↑ %1$s   ↓ %2$s</string>
     <string name="status_reconnecting">در حال اتصال مجدد…</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -15,6 +15,7 @@
     </plurals>
     <string name="scan_hint">Scan with Relay on your PC</string>
     <string name="or_type_code">or enter this code on your PC</string>
+    <string name="code_unavailable">No manual code on this network — scan the QR</string>
     <string name="traffic_format">↑ %1$s   ↓ %2$s</string>
     <string name="status_reconnecting">Reconnecting…</string>
 

--- a/android/app/src/test/kotlin/io/relay/app/LocalAddressTest.kt
+++ b/android/app/src/test/kotlin/io/relay/app/LocalAddressTest.kt
@@ -3,7 +3,9 @@ package io.relay.app
 import io.relay.app.net.LocalAddress
 import io.relay.app.net.LocalAddress.Candidate
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class LocalAddressTest {
@@ -38,6 +40,25 @@ class LocalAddressTest {
     @Test
     fun `returns null when there are no candidates`() {
         assertNull(LocalAddress.choose(emptyList()))
+    }
+
+    @Test
+    fun `rejects cellular and tunnel interfaces the client cannot route to`() {
+        // issue #18: rmnet_data0's carrier address (10.174.226.46) was advertised
+        // with hotspot and Wi-Fi off, producing a QR no PC could ever connect to.
+        for (name in listOf(
+            "rmnet_data0", "v4-rmnet_data0", "ccmni0", "pdp_ip0", "ppp0", "tun0", "dummy0",
+        )) {
+            assertFalse("expected $name to be rejected", LocalAddress.isReachableFromClient(name))
+        }
+    }
+
+    @Test
+    fun `keeps hotspot wifi and wired interfaces`() {
+        // "softap0" contains "tap" — the blocklist must not match it.
+        for (name in listOf("ap0", "swlan0", "softap0", "wlan0", "wlan1", "eth0", "rndis0")) {
+            assertTrue("expected $name to be kept", LocalAddress.isReachableFromClient(name))
+        }
     }
 
     @Test

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -8,3 +8,9 @@ Ideas and known follow-ups that are **not** in the current phase. Nothing here m
 - Solution (`.sln`) file for the Windows projects for IDE convenience (CI builds per-csproj and doesn't need it).
 - Publish the arm64-v8a APK alongside a universal APK if non-ARM devices ever matter.
 - In-app update check against GitHub Releases (must stay opt-in / privacy-respecting).
+- Widen the typed code beyond `192.168.0.0/16` (issue #18). A shared LAN on `10.x` or
+  `172.16–31.x` gets QR-only pairing today. 8 characters cannot hold it — 10.x alone needs
+  24 host + 16 port bits, leaving nothing for the checksum — so this means a longer code for
+  the wider ranges (e.g. 10 chars = 50 bits: 3-bit range selector + host + port + CRC), with
+  the existing 8-char form kept as-is for `192.168.x.x`. Touches `shared/typed-code.md`,
+  both platforms, and `shared/test-vectors.json` together.

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -14,7 +14,7 @@ Codes are **never renamed or reused**. This is the complete Phase 2 taxonomy; ne
 
 | Code | Severity | Condition | Next action shown to user |
 |---|---|---|---|
-| `HOTSPOT_OFF` | Error | No usable Wi-Fi or hotspot IPv4 interface when starting (works on a shared Wi-Fi/LAN too, not only the phone's hotspot) | Connect the phone to Wi-Fi or turn on its hotspot, then try again |
+| `HOTSPOT_OFF` | Error | No usable Wi-Fi or hotspot IPv4 interface when starting (works on a shared Wi-Fi/LAN too, not only the phone's hotspot). Mobile-data and VPN interfaces don't count — the client cannot route to them | Connect the phone to Wi-Fi or turn on its hotspot, then try again |
 | `HOTSPOT_LOST` | Transient → Error | Hotspot interface dropped and did not return within the reconnect bound | Check the hotspot is still on, then start sharing again |
 | `PORT_IN_USE` | Error | Every candidate SOCKS port is bound by another app | Close the other app using those ports, then try again |
 | `SERVICE_FAILED` | Error | Foreground service stopped unexpectedly | Start sharing again |

--- a/windows/Relay.App/App.xaml.cs
+++ b/windows/Relay.App/App.xaml.cs
@@ -136,6 +136,13 @@ public partial class App : Application
         {
             await AppController.Instance.DisconnectAsync();
             _tray?.Dispose();
+            // Exit() works by closing the app's windows, so the popover has to
+            // stop cancelling its own close first (issue #18).
+            if (_window is not null)
+            {
+                _window.ExitRequested = true;
+                _window.Close();
+            }
             Exit();
         };
 

--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -57,6 +57,12 @@ public sealed partial class MainWindow : Window
 
     private IntPtr Hwnd => WinRT.Interop.WindowNative.GetWindowHandle(this);
 
+    /// <summary>
+    /// Set by the tray's Exit item so the Closing handler lets the close through
+    /// instead of hiding to the tray. UI-thread only.
+    /// </summary>
+    public bool ExitRequested { get; set; }
+
     public MainWindow()
     {
         InitializeComponent();
@@ -86,9 +92,13 @@ public sealed partial class MainWindow : Window
         }
         AppWindow.IsShownInSwitchers = false;
 
-        // Closing the popover hides it to the tray; it's never destroyed.
+        // Closing the popover hides it to the tray; it's never destroyed — unless
+        // the user picked Exit, in which case cancelling here would swallow the
+        // close that Application.Exit() depends on and strand the process with no
+        // tray icon and the single-instance mutex still held (issue #18).
         AppWindow.Closing += (_, args) =>
         {
+            if (ExitRequested) return;
             args.Cancel = true;
             HideToTray();
         };

--- a/windows/Relay.App/Services/CameraQrScanner.cs
+++ b/windows/Relay.App/Services/CameraQrScanner.cs
@@ -54,10 +54,40 @@ public sealed class CameraQrScanner : IDisposable
         });
 
         var source = _capture.FrameSources[pick.Info.Id];
+        await SelectScanFormatAsync(source);
         _reader = await _capture.CreateFrameReaderAsync(
             source, Windows.Media.MediaProperties.MediaEncodingSubtypes.Bgra8);
         _reader.FrameArrived += OnFrame;
         await _reader.StartAsync();
+    }
+
+    /// <summary>
+    /// Raises capture resolution before the reader is created. Without this the
+    /// source keeps its default format — commonly 640x480 — and a ~49-module QR
+    /// held at arm's length covers maybe a third of the frame, leaving ~4px per
+    /// module. That is under what ZXing needs once webcam softness and screen
+    /// glare are in play, so scanning a phone simply fails (issue #18).
+    /// Best-effort: a camera that rejects the format keeps its default.
+    /// </summary>
+    // ponytail: capped at 1280x720 to bound the per-frame BGRA copy + decode cost
+    // (1080p is a 8MB buffer 6x/sec). Raise the cap if a QR still won't scan.
+    private static async Task SelectScanFormatAsync(MediaFrameSource source)
+    {
+        static long Pixels(MediaFrameFormat f) => (long)f.VideoFormat.Width * f.VideoFormat.Height;
+
+        var best = source.SupportedFormats
+            .Where(f => f.VideoFormat.Width <= 1280 && f.VideoFormat.Height <= 720)
+            .OrderByDescending(Pixels)
+            .ThenByDescending(f => f.FrameRate.Denominator == 0
+                ? 0d
+                : f.FrameRate.Numerator / (double)f.FrameRate.Denominator)
+            .FirstOrDefault();
+
+        // Only ever move up: a camera already defaulting above the cap (some do)
+        // must not be dragged down to 720p by this.
+        var current = source.CurrentFormat;
+        if (best is null || (current is not null && Pixels(best) <= Pixels(current))) return;
+        try { await source.SetFormatAsync(best); } catch (Exception) { }
     }
 
     private void OnFrame(MediaFrameReader sender, MediaFrameArrivedEventArgs args)


### PR DESCRIPTION
Fixes the three problems in #18. Decoding the QR from the reporter's screenshot changed the diagnosis substantially — problems 1 and 2 were not what they looked like.

The QR carried:

```json
{ "v": 1, "mode": "socks5", "host": "10.174.226.46",
  "port": 1080, "name": "24117RN76G", "issuedAt": 1785853007 }
```

Fast Mode, and a **carrier** address — so this pairing could never have worked even with a perfect scan.

---

### 1. Android advertised an address the client cannot reach — `LocalAddress.kt`

`enumerate()` accepted any `isSiteLocalAddress` IPv4. A carrier's mobile-data link sits in `10.0.0.0/8` and a VPN `tun` sits on `10.x`/`172.16.x`, so both passed. `score()` gives every candidate a baseline of 1 ("any site-local address is advertisable"), so with hotspot and Wi-Fi both off, `rmnet_data0` was the only candidate left and won by default.

Worth noting the VPN case specifically: sharing a phone VPN is this app's entire purpose, so a `tun` interface is essentially always present and was always an eligible candidate.

Cellular, VPN and placeholder links are now filtered out, which makes `findAdvertisableIpv4()` return `null` and raises the `HOTSPOT_OFF` error that already existed — its message ("No Wi-Fi or hotspot / Connect the phone to Wi-Fi, or turn on its hotspot") is already exactly right for this case, so no string change.

This is a **blocklist, not an allowlist**, deliberately: an OEM hotspot under an unexpected interface name currently works via the baseline score, and an allowlist would regress it to a spurious "no Wi-Fi or hotspot".

One trap worth flagging for review: `"softap0".contains("tap")` is true, so `tap` is excluded from the list. `keeps hotspot wifi and wired interfaces` pins that.

### 2. Missing 8-character code — symptom of 1, plus a silent UI gap

`TypedCode.encode` covers only `192.168.0.0/16` and correctly returned `null` for a `10.x` host — it was refusing to encode an address that was itself wrong. Fixing 1 resolves the reported case.

The panel rendered *nothing* when there was no code, which reads as a bug. It now states why. Widening the codec to the other RFC1918 ranges is a genuine gap but cannot be done in 8 characters (10.x alone needs 24 host + 16 port bits, leaving nothing for the checksum), so it needs a longer code and a coordinated change across `shared/typed-code.md`, both platforms and `shared/test-vectors.json` — filed in `docs/backlog.md` rather than smuggled in here.

### 3. Windows scanner — `CameraQrScanner.cs`

`CreateFrameReaderAsync` was called without ever selecting a format, so the source kept its default — commonly 640×480. The reporter's QR is ~49 modules; filling a third of a VGA frame that is ~4px per module, below what ZXing holds once webcam softness and phone-screen glare are involved. `TryHarder` was already on and cannot compensate.

Now picks the largest format up to 1280×720. Two guards: it only ever *raises* resolution (a camera already defaulting above the cap must not be dragged down to 720p), and a camera that rejects `SetFormatAsync` keeps its default rather than failing the scan. Capped at 720p to bound the per-frame BGRA copy and decode cost — marked with a `ponytail:` comment naming the upgrade path.

### 4. Tray "Exit" left the process running — `MainWindow.xaml.cs`, `App.xaml.cs`

`AppWindow.Closing` cancelled **every** close to keep the popover alive:

```csharp
AppWindow.Closing += (_, args) => { args.Cancel = true; HideToTray(); };
```

`Application.Exit()` works by closing the app's windows, so that cancel swallowed the exit. The tray icon was disposed but `Relay.App.exe` stayed alive still holding the single-instance mutex — so a later launch just signalled the ghost process to show its window instead of starting fresh. A deliberate exit now passes through.

The proxy was already restored before this point, so no user was left with broken networking — the symptom was a stuck process and an app that appeared not to restart.

---

### Verification

Unit coverage added for the interface filter (rejects `rmnet_data0`, `v4-rmnet_data0`, `ccmni0`, `pdp_ip0`, `ppp0`, `tun0`, `dummy0`; keeps `ap0`, `swlan0`, `softap0`, `wlan0`, `wlan1`, `eth0`, `rndis0`). Everything else here is runtime WinUI/camera behaviour that unit tests can't reach.

**Not yet verified beyond CI** — there's no local toolchain, and three specific things need hardware before release:

- tray Exit actually terminating the process (and a relaunch starting clean)
- the camera picking a higher format on a real webcam, and a phone QR scanning at arm's length
- an Android device with hotspot and Wi-Fi off now showing "No Wi-Fi or hotspot" instead of an unusable QR

Closes #18