### PR TITLE
Unified release pipeline, README download buttons, verified dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,35 @@
 # Relay pins every dependency (android/gradle/libs.versions.toml, the .csproj
 # PackageReferences, and the actions in .github/workflows). Dependabot keeps
 # those pins honest — a stale pin is a security problem, not a stable one.
+#
+# Everything is grouped: ten single-dependency branches a week is noise, and
+# these updates are only ever verified together anyway (the toolchain upgrade in
+# docs/backlog.md is exactly one bump dragging four others with it).
 version: 2
 updates:
   - package-ecosystem: gradle
     directory: /android
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     groups:
-      androidx:
-        patterns: ['androidx.*']
-      compose:
-        patterns: ['androidx.compose*']
+      android-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: nuget
     directory: /windows
     schedule:
       interval: weekly
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
+    groups:
+      windows-dependencies:
+        patterns: ['*']
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 2
+    groups:
+      github-actions:
+        patterns: ['*']

--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -18,7 +18,7 @@ jobs:
       run:
         working-directory: android
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history for the changelog
 
@@ -35,13 +35,13 @@ jobs:
           fi
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Restore signing keystore
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,16 @@ jobs:
       run:
         working-directory: android
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Build and run unit tests
         run: ./gradlew assembleDebug testDebugUnitTest
@@ -47,7 +47,7 @@ jobs:
     name: Windows (build + test)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up .NET 8
         uses: actions/setup-dotnet@v4
@@ -57,7 +57,7 @@ jobs:
       # WinUI 3 projects need Visual Studio MSBuild: the PRI packaging tasks
       # (ExpandPriContent) are not shipped with the dotnet CLI's MSBuild.
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Build app (x64)
         run: msbuild windows/Relay.App/Relay.App.csproj /restore /p:Configuration=Release /p:Platform=x64 /v:minimal

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,16 +40,16 @@ jobs:
           - api: 34
             target: google_apis
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       # Without KVM the emulator falls back to software rendering and the job
       # times out instead of testing anything.
@@ -108,16 +108,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       # The host half of this test is the Windows client's own code.
       - name: Set up .NET 8
@@ -168,7 +168,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up .NET 8
         uses: actions/setup-dotnet@v4
@@ -176,7 +176,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Publish the app (x64, self-contained)
         shell: pwsh

--- a/.github/workflows/generate-keystore.yml
+++ b/.github/workflows/generate-keystore.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,259 @@
+# The release pipeline: one tag, one release, both platforms.
+#
+#   git tag v1.1.0 && git push origin v1.1.0
+#
+# builds the signed Android artifacts and both Windows installers, publishes
+# them as a single GitHub Release with checksums, and leaves
+# /releases/latest/download/<asset> resolving for every platform — which is what
+# the README download buttons point at.
+#
+# The older per-platform workflows (android-release.yml, windows-release.yml)
+# still exist for shipping one platform on its own; this is the normal path.
+#
+# workflow_dispatch runs everything except publishing: a safe dry run.
+name: Release
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  version:
+    name: Resolve version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+      publish: ${{ steps.v.outputs.publish }}
+    steps:
+      - id: v
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+            echo "publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=0.0.0-dry-run" >> "$GITHUB_OUTPUT"
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  android:
+    name: Android
+    needs: version
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: android
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Restore signing keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}
+        run: |
+          if [ -z "$KEYSTORE_BASE64" ]; then
+            echo "::error::ANDROID_KEYSTORE_BASE64 secret is missing — see docs/release.md"
+            exit 1
+          fi
+          echo "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.pfx"
+
+      - name: Build signed APK and AAB
+        env:
+          RELAY_KEYSTORE_FILE: ${{ runner.temp }}/release.pfx
+          RELAY_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          RELAY_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          RELAY_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+        run: ./gradlew assembleRelease bundleRelease -PrelayVersion=${{ needs.version.outputs.version }}
+
+      - name: Collect artifacts
+        run: |
+          VERSION=${{ needs.version.outputs.version }}
+          mkdir -p ../dist
+          # Match the ABI explicitly: a bare `head -1` would happily publish a
+          # different split under the arm64 name.
+          APK=$(find app/build/outputs/apk/release -name '*arm64-v8a*.apk' | head -1)
+          if [ -z "$APK" ]; then
+            echo "::error::No arm64-v8a release APK was produced; refusing to publish."
+            find app/build/outputs/apk/release -name '*.apk' || true
+            exit 1
+          fi
+          AAB=$(find app/build/outputs/bundle/release -name '*.aab' | head -1)
+          # Deliberately unversioned: /releases/latest/download/<name> only
+          # resolves a fixed filename, and that permalink is what the README
+          # download buttons use. The version lives in the release title, the
+          # notes, and the app itself.
+          cp "$APK" "../dist/Relay-android-arm64-v8a.apk"
+          cp "$AAB" "../dist/Relay-android.aab"
+          ls -la ../dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-android
+          path: dist/*
+          if-no-files-found: error
+
+  windows:
+    name: Windows
+    needs: version
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up .NET 8
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Set up MSBuild
+        uses: microsoft/setup-msbuild@v3
+
+      - name: Publish x64 and x86 (self-contained)
+        shell: pwsh
+        run: |
+          $proj = "windows/Relay.App/Relay.App.csproj"
+          foreach ($arch in @('x64', 'x86')) {
+            $pub = "$env:GITHUB_WORKSPACE\publish-$arch"
+            $props = "/p:Configuration=Release /p:Platform=$arch /p:RuntimeIdentifier=win-$arch /p:SelfContained=true /p:WindowsAppSDKSelfContained=true"
+            # Build before Publish: the MRT PRI generation that produces
+            # resources.pri only runs on Build, and the window fails to load
+            # without it.
+            msbuild $proj /restore /t:Build /v:minimal $props.Split(' ')
+            if ($LASTEXITCODE -ne 0) { exit 1 }
+            msbuild $proj /t:Publish /v:minimal $props.Split(' ') /p:PublishDir="$pub\"
+            if ($LASTEXITCODE -ne 0) { exit 1 }
+            if (-not (Test-Path "$pub\resources.pri")) {
+              $bin = "windows/Relay.App/bin/$arch/Release/net8.0-windows10.0.19041.0/win-$arch"
+              $pri = Get-ChildItem $bin -Filter resources.pri -Recurse -ErrorAction SilentlyContinue | Select-Object -First 1
+              if ($pri) { Copy-Item $pri.FullName "$pub\resources.pri" }
+            }
+            if (-not (Test-Path "$pub\resources.pri")) {
+              Write-Error "resources.pri missing for $arch - the app would crash at launch."
+              exit 1
+            }
+          }
+
+      - name: Build installers
+        shell: pwsh
+        run: |
+          $iscc = "${env:ProgramFiles(x86)}\Inno Setup 6\ISCC.exe"
+          if (-not (Test-Path $iscc)) { choco install innosetup -y --no-progress }
+          if (-not (Test-Path $iscc)) { $iscc = "iscc" }
+          foreach ($arch in @('x64', 'x86')) {
+            & $iscc "/DAppVersion=${{ needs.version.outputs.version }}" `
+                    "/DAppPlatform=$arch" `
+                    "/DSourceDir=$env:GITHUB_WORKSPACE\publish-$arch" `
+                    windows\installer\relay.iss
+            if ($LASTEXITCODE -ne 0) { exit 1 }
+          }
+          New-Item -ItemType Directory -Force -Path dist | Out-Null
+          Get-ChildItem windows\installer\output\*.exe | ForEach-Object {
+            # Unversioned, so /releases/latest/download/ resolves (see the
+            # Android job for why).
+            Copy-Item $_.FullName "dist\Relay-Setup-$($_.BaseName.Split('-')[2]).exe"
+          }
+          Get-ChildItem dist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: release-windows
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish release
+    needs: [version, android, windows]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: release-*
+          merge-multiple: true
+          path: dist
+
+      - name: Checksums
+        run: |
+          cd dist
+          # The installers are unsigned, so this is the only integrity check a
+          # user has. Not optional.
+          sha256sum ./* > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Release notes
+        run: |
+          VERSION=${{ needs.version.outputs.version }}
+          PREV=$(git tag -l 'v*.*.*' --sort=-v:refname | grep -v "^v$VERSION$" | head -1)
+          RANGE=$([ -n "$PREV" ] && echo "$PREV..HEAD" || echo "HEAD")
+          {
+            echo "## Relay $VERSION"
+            echo
+            echo "Share your phone's connection with your PC. Scan a QR code. That's the setup."
+            echo
+            echo "### Download"
+            echo
+            echo "| Platform | File | Requirements |"
+            echo "|---|---|---|"
+            echo "| **Windows** | \`Relay-Setup-x64.exe\` | Windows 10/11. Per-user install, no admin prompt. |"
+            echo "| Windows (32-bit) | \`Relay-Setup-x86.exe\` | Only if you know you need it. |"
+            echo "| **Android** | \`Relay-android-arm64-v8a.apk\` | Android 8.0+. Allow \"install from unknown sources\". |"
+            echo "| Android (stores) | \`Relay-android.aab\` | Not directly installable. |"
+            echo
+            echo "### Install"
+            echo
+            echo "1. Install both apps."
+            echo "2. On the phone, turn on the hotspot (or put both devices on the same Wi-Fi) and tap **Start Sharing**."
+            echo "3. On the PC, click **Scan QR** and hold the phone up to the webcam - or **Enter Code Manually**."
+            echo
+            echo "Windows SmartScreen warns on first run because the installer is not"
+            echo "code-signed yet: **More info -> Run anyway**. See \`docs/release.md\`."
+            echo
+            echo "### Verify your download"
+            echo
+            echo "\`SHA256SUMS.txt\` is attached."
+            echo '```bash'
+            echo 'sha256sum -c SHA256SUMS.txt'
+            echo '```'
+            echo
+            echo "### Security"
+            echo
+            echo "Relay's transport is an unauthenticated SOCKS5 proxy: safe on your own"
+            echo "hotspot, an open proxy on a shared network. [SECURITY.md](https://github.com/Mahdi-mortazavi/relay/blob/main/SECURITY.md)"
+            echo "has the full threat model."
+            echo
+            echo "### Changes"
+            echo
+            git log $RANGE --no-merges --pretty='- %s' | head -60
+          } > "$RUNNER_TEMP/notes.md"
+          cat "$RUNNER_TEMP/notes.md"
+
+      - name: Upload dry-run artifacts
+        if: needs.version.outputs.publish != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dry-run
+          path: dist/*
+
+      - name: Create GitHub Release
+        if: needs.version.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "v${{ needs.version.outputs.version }}" dist/* \
+            --title "Relay ${{ needs.version.outputs.version }}" \
+            --notes-file "$RUNNER_TEMP/notes.md" \
+            --latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,16 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: '17'
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
           build-mode: manual
@@ -42,7 +42,7 @@ jobs:
         run: ./gradlew assembleDebug
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: /language:java-kotlin
 
@@ -51,7 +51,7 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up .NET 8
         uses: actions/setup-dotnet@v4
@@ -59,10 +59,10 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: csharp
           build-mode: manual
@@ -71,7 +71,7 @@ jobs:
         run: msbuild windows/Relay.App/Relay.App.csproj /restore /p:Configuration=Release /p:Platform=x64 /v:minimal
 
       - name: Analyze
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: /language:csharp
 
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # Soft until the repository's Dependency graph is switched on
       # (Settings -> Code security -> Dependency graph). Without it the action
       # cannot run at all and fails every PR for a reason no code change can

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -15,7 +15,7 @@ jobs:
   release:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # full history for the changelog
 
@@ -35,7 +35,7 @@ jobs:
           dotnet-version: '8.0.x'
 
       - name: Set up MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Publish x64 and x86 (self-contained)
         shell: pwsh

--- a/README.fa.md
+++ b/README.fa.md
@@ -15,6 +15,12 @@
 
 [English](README.md) · [فارسی](README.fa.md)
 
+### دانلود
+
+[**⬇ نصب‌کنندهٔ ویندوز**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe) &nbsp;·&nbsp; [**⬇ فایل APK اندروید**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk)
+
+<sub>همیشه آخرین نسخه · [همهٔ فایل‌ها و توضیحات نسخه](https://github.com/Mahdi-mortazavi/relay/releases/latest)</sub>
+
 <p>
 <img src="docs/assets/android-idle.png" alt="برنامهٔ رله روی اندروید، آمادهٔ اشتراک‌گذاری" width="230">
 &nbsp;&nbsp;
@@ -74,12 +80,16 @@
 
 ## نصب
 
-آخرین نسخه را از [**صفحهٔ Releases**](https://github.com/Mahdi-mortazavi/relay/releases) بگیر. چیزی برای کامپایل کردن وجود ندارد.
+دو فایل، بدون نیاز به کامپایل. این لینک‌ها همیشه به جدیدترین نسخه اشاره می‌کنند:
 
-| | فایل | توضیح |
+| | دانلود | نیازمندی |
 |---|---|---|
-| **ویندوز** | `Relay-Setup-x64-<version>.exe` | ویندوز ۱۰ یا ۱۱. نسخهٔ x86 را فقط اگر مطمئنی لازم داری انتخاب کن. نصب برای کاربر جاری، بدون نیاز به دسترسی مدیر. |
-| **اندروید** | `relay-arm64-v8a-<version>.apk` | اندروید ۸ به بالا. «نصب از منابع ناشناس» را برای مرورگر یا فایل‌منیجرت فعال کن. |
+| **ویندوز** | [**Relay-Setup-x64.exe**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe) | ویندوز ۱۰ یا ۱۱. نصب برای کاربر جاری، بدون دسترسی مدیر. |
+| ویندوز ۳۲ بیتی | [Relay-Setup-x86.exe](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x86.exe) | فقط اگر مطمئنی لازم داری. |
+| **اندروید** | [**Relay-android-arm64-v8a.apk**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk) | اندروید ۸ به بالا. «نصب از منابع ناشناس» را فعال کن. |
+| اندروید (فروشگاه) | [Relay-android.aab](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android.aab) | بستهٔ فروشگاهی، مستقیم نصب نمی‌شود. |
+
+هر نسخه فایل `SHA256SUMS.txt` هم دارد تا بتوانی صحت دانلودت را بررسی کنی.
 
 نصب‌کنندهٔ ویندوز هنوز امضای دیجیتال ندارد، بنابراین SmartScreen در اجرای اول هشدار می‌دهد — **More info → Run anyway**. برای هر انتشار checksum منتشر می‌شود؛ کار امضا در [`docs/release.md`](docs/release.md) پیگیری می‌شود.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@
 
 [English](README.md) · [فارسی](README.fa.md)
 
+### Download
+
+[**⬇ Windows installer**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe) &nbsp;·&nbsp; [**⬇ Android APK**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk)
+
+<sub>Always the latest release · [all files and release notes](https://github.com/Mahdi-mortazavi/relay/releases/latest)</sub>
+
 <p>
 <img src="docs/assets/android-idle.png" alt="The Relay app on Android, ready to share" width="230">
 &nbsp;&nbsp;
@@ -65,12 +71,16 @@ Read more in [`docs/architecture.md`](docs/architecture.md).
 
 ## Install
 
-Grab the latest build from the [**Releases page**](https://github.com/Mahdi-mortazavi/relay/releases). There is nothing to compile.
+Two files, nothing to compile. These links always resolve to the newest release:
 
-| | File | Notes |
+| | Download | Requirements |
 |---|---|---|
-| **Windows** | `Relay-Setup-x64-<version>.exe` | Windows 10 or 11. Pick x86 only if you know you need it. Installs per-user, no administrator prompt. |
-| **Android** | `relay-arm64-v8a-<version>.apk` | Android 8.0 or newer. Enable "install from unknown sources" for your browser or file manager. |
+| **Windows** | [**Relay-Setup-x64.exe**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe) | Windows 10 or 11. Per-user install, no administrator prompt. |
+| Windows 32-bit | [Relay-Setup-x86.exe](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x86.exe) | Only if you know you need it. |
+| **Android** | [**Relay-android-arm64-v8a.apk**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk) | Android 8.0+. Enable "install from unknown sources" for your browser or file manager. |
+| Android (stores) | [Relay-android.aab](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android.aab) | App-store bundle, not directly installable. |
+
+Every release also carries `SHA256SUMS.txt` so you can verify what you downloaded.
 
 The Windows installer is not code-signed yet, so SmartScreen will show a warning on first run — **More info → Run anyway**. Checksums are published with every release; [`docs/release.md`](docs/release.md) tracks the signing work.
 

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -82,16 +84,19 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = "17"
-    }
-
     buildFeatures {
         compose = true
     }
 
     testOptions {
         unitTests.all { it.useJUnit() }
+    }
+}
+
+// Kotlin 2.4 removed the `kotlinOptions` DSL that used to live in `android { }`.
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_17)
     }
 }
 

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -6,13 +6,13 @@ activityCompose = "1.9.3"
 composeBom = "2024.11.00"
 lifecycle = "2.8.7"
 junit = "4.13.2"
-androidxTest = "1.6.2"
-androidxTestCore = "1.6.1"
-androidxTestExtJunit = "1.2.1"
+androidxTest = "1.7.0"
+androidxTestCore = "1.7.0"
+androidxTestExtJunit = "1.3.0"
 kotlinxSerialization = "1.7.3"
 kotlinxCoroutines = "1.9.0"
 zxing = "3.5.3"
-wireguard = "1.0.20230706"
+wireguard = "1.0.20260102"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -23,6 +23,16 @@ Ideas and known follow-ups that are **not** in the current phase. Nothing here m
 - x64 and x86 installers share one `AppId` and install directory, so running the
   wrong one over an existing install is treated as an upgrade. Fixing it means
   changing `AppId`, which orphans existing installs — needs a migration plan.
+- **Toolchain upgrade: compileSdk 37 + a newer AGP + Kotlin 2.4.** Verified by
+  building each Dependabot bump locally rather than guessing, so the chain is
+  known rather than suspected:
+  `androidx.core 1.19.0`, `lifecycle 2.11.0`, `activity 1.13.0` and
+  `compose-bom 2026.06.01` all fail `checkDebugAarMetadata` — they require
+  compileSdk 37, and AGP 8.7.3 tops out at 35. `kotlinx-coroutines 1.11.0`
+  needs Kotlin 2.2+, and Kotlin 2.4 additionally removes the `kotlinOptions`
+  DSL (migrate to `kotlin { compilerOptions { } }`). So this is one upgrade,
+  not five bumps, and it changes the SDK the app compiles against — it needs
+  the device lab run against it, not a rubber-stamped merge.
 - Windows code-signing certificate → signed installers, no SmartScreen warning (see `docs/release.md`).
 - OEM-specific battery-manager guidance (Xiaomi/MIUI, Samsung, Huawei aggressive killers) beyond the stock exemption flow.
 - Bytes-transferred counter in the Android status view (Phase 1 marks it nice-to-have).


### PR DESCRIPTION
Repository housekeeping, so the project has one branch, one tag scheme and one
release that a stranger can download from.

## One tag, one release, both platforms

Releases were per-platform (`android-v*`, `windows-v*`), which meant "the latest
release" was two different things and `/releases/latest/download/…` could never
resolve for both. `release.yml` now takes a single `vX.Y.Z` tag, builds the
signed Android APK + AAB and both Windows installers, and publishes them as one
release with `SHA256SUMS.txt` and full install / verify / security notes.

Asset names are deliberately **unversioned** — that permalink only resolves a
fixed filename, and it is what the new download buttons use. The version lives
in the release title, the notes and the app.

## README download buttons

One click for each platform, at the top of both `README.md` and `README.fa.md`,
always pointing at the newest release.

## Dependency updates — built, not rubber-stamped

Dependabot opened ten PRs. Merging them blind is how a green `main` breaks, so
each was built locally first.

**Merged** (verified: `assembleDebug`, `testDebugUnitTest`,
`assembleDebugAndroidTest` all pass)
- `androidx.test` 1.7.0, `ext-junit` 1.3.0
- `wireguard-tunnel` 1.0.20260102
- six GitHub Actions majors: checkout v7, setup-java v5, codeql-action v4,
  gradle/actions v6, setup-msbuild v3

**Deferred, with evidence**
- `androidx.core` 1.19.0, `lifecycle` 2.11.0, `activity` 1.13.0 and
  `compose-bom` 2026.06.01 fail `checkDebugAarMetadata`: they require
  compileSdk 37, and AGP 8.7.3 tops out at 35.
- `kotlinx-coroutines` 1.11.0 requires Kotlin 2.2+.
- Kotlin 2.4.10 additionally removes the `kotlinOptions` DSL.

That is a single toolchain upgrade wearing five hats, and it changes the SDK the
app compiles against — it needs its own change with the device lab run against
it. Recorded in `docs/backlog.md` with the exact failure for each, rather than
merged blind or silently dropped.

## After this merges

Old per-platform tags and releases are replaced by one `v1.1.0` release, and
every branch except `main` is deleted.

---
_Generated by [Claude Code](https://claude.ai/code/session_015jP1ymLW2XP7L5MuKVthQ1)_