### PR TITLE
Release: publish from dispatch, plus a guarded repository-maintenance workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,13 +10,26 @@
 # The older per-platform workflows (android-release.yml, windows-release.yml)
 # still exist for shipping one platform on its own; this is the normal path.
 #
-# workflow_dispatch runs everything except publishing: a safe dry run.
+# workflow_dispatch builds the same artifacts. Leave `publish` off for a dry
+# run; turn it on to cut the release without pushing a tag first — `gh release
+# create` creates the tag itself, which is also the only route available from
+# environments where pushing tags is blocked.
 name: Release
 
 on:
   push:
     tags: ['v*.*.*']
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build, without the leading v (e.g. 1.1.0)'
+        required: true
+        type: string
+      publish:
+        description: 'Publish a GitHub Release (otherwise artifacts only)'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -36,8 +49,8 @@ jobs:
             echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
             echo "publish=true" >> "$GITHUB_OUTPUT"
           else
-            echo "version=0.0.0-dry-run" >> "$GITHUB_OUTPUT"
-            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "version=${{ inputs.version || '0.0.0-dry-run' }}" >> "$GITHUB_OUTPUT"
+            echo "publish=${{ inputs.publish || false }}" >> "$GITHUB_OUTPUT"
           fi
 
   android:
@@ -253,7 +266,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # --target so a dispatch-triggered release tags the commit it built
+          # from; gh creates the tag when it does not already exist.
           gh release create "v${{ needs.version.outputs.version }}" dist/* \
+            --target "$GITHUB_SHA" \
             --title "Relay ${{ needs.version.outputs.version }}" \
             --notes-file "$RUNNER_TEMP/notes.md" \
             --latest

--- a/.github/workflows/repo-maintenance.yml
+++ b/.github/workflows/repo-maintenance.yml
@@ -1,0 +1,117 @@
+# One-shot repository housekeeping, run by hand from the Actions tab.
+#
+# This deletes things permanently, so it is deliberately awkward to fire:
+# it never runs on a push, and it refuses to do anything unless you type
+# DELETE into the confirmation box.
+#
+# What it will and will not touch is fixed in the rules below rather than
+# inferred at runtime — "everything except the newest" is the kind of rule that
+# deletes the wrong thing the one time the ordering surprises you.
+#
+#   keeps    the `main` branch, every `v*` release and tag (the unified scheme)
+#   deletes  legacy `android-v*` / `windows-v*` releases and tags,
+#            and every branch other than `main`
+name: Repository maintenance
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: 'Type DELETE to confirm. Anything else aborts.'
+        required: true
+        type: string
+      legacy_releases:
+        description: 'Delete legacy android-v* / windows-v* releases and their tags'
+        required: false
+        default: true
+        type: boolean
+      stale_branches:
+        description: 'Delete every branch except main'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+
+jobs:
+  maintenance:
+    name: Housekeeping
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check the confirmation
+        run: |
+          if [ "${{ inputs.confirm }}" != "DELETE" ]; then
+            echo "::error::Confirmation not given (expected DELETE). Nothing was changed."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Delete legacy releases and tags
+        if: inputs.legacy_releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          echo "::group::Releases"
+          # Only the legacy per-platform scheme. A v* release is never touched,
+          # so this cannot remove the current one no matter when it is run.
+          gh release list --limit 200 --json tagName \
+            --jq '.[] | select(.tagName | test("^(android|windows)-v")) | .tagName' > legacy.txt || true
+          if [ ! -s legacy.txt ]; then
+            echo "No legacy releases found."
+          else
+            while read -r tag; do
+              [ -n "$tag" ] || continue
+              echo "deleting release $tag"
+              # --cleanup-tag removes the tag along with the release.
+              gh release delete "$tag" --yes --cleanup-tag
+            done < legacy.txt
+          fi
+          echo "::endgroup::"
+
+          echo "::group::Tags without a release"
+          # Legacy tags that never had a release attached.
+          for tag in $(git tag -l 'android-v*' 'windows-v*'); do
+            if git ls-remote --exit-code --tags origin "$tag" >/dev/null 2>&1; then
+              echo "deleting tag $tag"
+              git push origin --delete "$tag" || echo "  (already gone)"
+            fi
+          done
+          echo "::endgroup::"
+
+      - name: Delete branches other than main
+        if: inputs.stale_branches
+        run: |
+          set -euo pipefail
+          git fetch --prune origin
+          for ref in $(git for-each-ref --format='%(refname:short)' refs/remotes/origin \
+                        | grep -v 'origin/HEAD' | sed 's|^origin/||'); do
+            if [ "$ref" = "main" ]; then continue; fi
+            echo "deleting branch $ref"
+            git push origin --delete "$ref" || echo "  (could not delete $ref; it may be protected)"
+          done
+
+      - name: Summary
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          {
+            echo "### Repository state"
+            echo
+            echo "**Branches**"
+            echo '```'
+            git ls-remote --heads origin | awk '{print $2}' | sed 's|refs/heads/||'
+            echo '```'
+            echo "**Tags**"
+            echo '```'
+            git ls-remote --tags origin | awk '{print $2}' | sed 's|refs/tags/||' | grep -v '\^{}' || echo "(none)"
+            echo '```'
+            echo "**Releases**"
+            echo '```'
+            gh release list --limit 50 || echo "(none)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Two additions needed to finish the repository cleanup.

## Publish from `workflow_dispatch`

`release.yml` only published on a pushed tag. Dispatch now takes a **version**
and a **publish** flag, and `gh release create` creates the tag itself against
the commit it built from. Leaving publish off is still a full dry run.

Beyond convenience, this is the only workable route from environments that block
writes to git refs — the tag can then be created neither by `git push` nor
through the API.

## `repo-maintenance.yml`

Deleting releases, tags and branches needs a token with rights that only exist
inside Actions, so the housekeeping runs there.

It is deliberately awkward to fire: dispatch-only, and it aborts unless you type
`DELETE` into the confirmation box. The rules are fixed rather than inferred at
runtime —

- **keeps** `main`, and every `v*` release and tag,
- **deletes** legacy `android-v*` / `windows-v*` releases and tags, and every
  branch other than `main`.

"Everything except the newest" is the kind of rule that deletes the wrong thing
the one time the ordering surprises you, so it isn't used.

## How to finish the cleanup after this merges

1. **Actions → Release → Run workflow** with `version = 1.1.0` and
   `publish = true`. That publishes one release with the signed Android APK/AAB,
   both Windows installers and `SHA256SUMS.txt`, and makes
   `/releases/latest/download/…` resolve for the README buttons.
2. Confirm the release has all five assets.
3. **Actions → Repository maintenance → Run workflow**, type `DELETE`. That
   removes the 16 legacy releases and tags and every branch but `main`.

Step 2 before step 3 is deliberate: nothing old is removed until the replacement
exists and is verified.

---
_Generated by [Claude Code](https://claude.ai/code/session_015jP1ymLW2XP7L5MuKVthQ1)_