### PR TITLE
Android toolchain: AGP 9, Kotlin 2.4, compileSdk 37 — plus the unrelated Actions bumps

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload dry-run artifacts
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: android-release-dry-run
           path: android/dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: ./gradlew assembleDebug testDebugUnitTest
 
       - name: Upload debug APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: relay-android-debug-apk
           # ABI split names the file app-arm64-v8a-debug.apk; glob covers both.
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
 
@@ -66,7 +66,7 @@ jobs:
         run: dotnet test windows/Relay.App.Tests/Relay.App.Tests.csproj -c Release
 
       - name: Upload debug build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: relay-windows-debug-build
           path: windows/Relay.App/bin/x64/Release/net8.0-windows10.0.19041.0/

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,7 +61,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Cache the AVD
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         id: avd-cache
         with:
           path: |
@@ -94,7 +94,7 @@ jobs:
 
       - name: Upload the evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-android-api${{ matrix.api }}
           path: |
@@ -121,7 +121,7 @@ jobs:
 
       # The host half of this test is the Windows client's own code.
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
 
@@ -157,7 +157,7 @@ jobs:
 
       - name: Upload the evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-cross-platform
           path: e2e-out/**
@@ -171,7 +171,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
 
@@ -213,7 +213,7 @@ jobs:
 
       - name: Upload the evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-windows
           path: e2e-out/**

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
           cp "$AAB" "../dist/Relay-android.aab"
           ls -la ../dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: release-android
           path: dist/*
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
 
@@ -178,7 +178,7 @@ jobs:
           }
           Get-ChildItem dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: release-windows
           path: dist/*
@@ -256,7 +256,7 @@ jobs:
 
       - name: Upload dry-run artifacts
         if: needs.version.outputs.publish != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dry-run
           path: dist/*

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
 

--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Set up .NET 8
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v6
         with:
           dotnet-version: '8.0.x'
 
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload dry-run artifacts
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-release-dry-run
           path: |

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -14,7 +14,11 @@ val relayVersionCode: Int = relayVersion.substringBefore("-").split(".").let { p
     val major = parts.getOrNull(0)?.toIntOrNull() ?: 0
     val minor = parts.getOrNull(1)?.toIntOrNull() ?: 0
     val patch = parts.getOrNull(2)?.toIntOrNull() ?: 0
-    major * 10_000 + minor * 100 + patch
+    // Floor at 1. release.yml's dry-run path builds "0.0.0-dry-run", which
+    // computes to 0 — and AGP 9 rejects versionCode 0 outright, so the
+    // workflow's own rehearsal path could not build. A dry run never
+    // publishes, so any valid number will do; a real tag never lands here.
+    (major * 10_000 + minor * 100 + patch).coerceAtLeast(1)
 }
 
 android {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -2,7 +2,6 @@ import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
 }
@@ -20,12 +19,12 @@ val relayVersionCode: Int = relayVersion.substringBefore("-").split(".").let { p
 
 android {
     namespace = "io.relay.app"
-    compileSdk = 35
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "io.relay.app"
         minSdk = 26
-        targetSdk = 35
+        targetSdk = 37
         versionCode = relayVersionCode
         versionName = relayVersion
         // Instrumented tests are the device half of the test pyramid: they run
@@ -93,7 +92,10 @@ android {
     }
 }
 
-// Kotlin 2.4 removed the `kotlinOptions` DSL that used to live in `android { }`.
+// Kotlin 2.4 removed the `kotlinOptions` DSL that used to live in `android { }`,
+// and AGP 9 folded Kotlin support into the Android plugin itself — the standalone
+// `org.jetbrains.kotlin.android` plugin is gone from the block above because
+// applying it alongside AGP 9 is now a hard error.
 kotlin {
     compilerOptions {
         jvmTarget.set(JvmTarget.JVM_17)

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.kotlin.serialization) apply false
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -1,16 +1,16 @@
 [versions]
-agp = "8.7.3"
-kotlin = "2.0.21"
-coreKtx = "1.15.0"
-activityCompose = "1.9.3"
-composeBom = "2024.11.00"
-lifecycle = "2.8.7"
+agp = "9.3.1"
+kotlin = "2.4.10"
+coreKtx = "1.19.0"
+activityCompose = "1.13.0"
+composeBom = "2026.06.01"
+lifecycle = "2.11.0"
 junit = "4.13.2"
 androidxTest = "1.7.0"
 androidxTestCore = "1.7.0"
 androidxTestExtJunit = "1.3.0"
-kotlinxSerialization = "1.7.3"
-kotlinxCoroutines = "1.9.0"
+kotlinxSerialization = "1.11.0"
+kotlinxCoroutines = "1.11.0"
 zxing = "3.5.3"
 wireguard = "1.0.20260102"
 
@@ -39,6 +39,5 @@ compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-mani
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.7.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/docs/backlog.md
+++ b/docs/backlog.md
@@ -23,16 +23,15 @@ Ideas and known follow-ups that are **not** in the current phase. Nothing here m
 - x64 and x86 installers share one `AppId` and install directory, so running the
   wrong one over an existing install is treated as an upgrade. Fixing it means
   changing `AppId`, which orphans existing installs — needs a migration plan.
-- **Toolchain upgrade: compileSdk 37 + a newer AGP + Kotlin 2.4.** Verified by
-  building each Dependabot bump locally rather than guessing, so the chain is
-  known rather than suspected:
-  `androidx.core 1.19.0`, `lifecycle 2.11.0`, `activity 1.13.0` and
-  `compose-bom 2026.06.01` all fail `checkDebugAarMetadata` — they require
-  compileSdk 37, and AGP 8.7.3 tops out at 35. `kotlinx-coroutines 1.11.0`
-  needs Kotlin 2.2+, and Kotlin 2.4 additionally removes the `kotlinOptions`
-  DSL (migrate to `kotlin { compilerOptions { } }`). So this is one upgrade,
-  not five bumps, and it changes the SDK the app compiles against — it needs
-  the device lab run against it, not a rubber-stamped merge.
+- ~~**Toolchain upgrade: compileSdk 37 + a newer AGP + Kotlin 2.4.**~~ **Done.**
+  It landed as AGP 9.3.1 / Gradle 9.7.0 / Kotlin 2.4.10 / compileSdk 37. Two
+  things this entry had guessed at turned out to be sharper than expected:
+  the blocker is not compileSdk at all — `androidx.core 1.19.0` and
+  `lifecycle 2.11.0` demand *AGP 9.1.0 or higher* by name, so the last 8.x
+  (8.13.2) cannot satisfy them; and AGP 9 folded Kotlin support into itself,
+  making `org.jetbrains.kotlin.android` a hard error rather than a warning.
+  CI stayed on JDK 17, which was confirmed rather than assumed by reading the
+  AGP 9.3.1 jar's class-file version (61 = Java 17).
 - Windows code-signing certificate → signed installers, no SmartScreen warning (see `docs/release.md`).
 - OEM-specific battery-manager guidance (Xiaomi/MIUI, Samsung, Huawei aggressive killers) beyond the stock exemption flow.
 - Bytes-transferred counter in the Android status view (Phase 1 marks it nice-to-have).


### PR DESCRIPTION
Closes the four open Dependabot PRs, which are not four changes.

- **#28** (Kotlin 2.4.10) and **#30** (coroutines 1.11.0) are one toolchain upgrade — first commit.
- **#32** (GitHub Actions) shares nothing with them — second commit.
- **#29** is **already on `main`**: it proposes `wireguard = 1.0.20260102`, which the version catalog has carried since before this branch. It can be closed as obsolete.

A third commit fixes a release-pipeline bug that this work uncovered.

## What the versions actually demand

Established by building, not by reading changelogs. The backlog entry for this work had guessed compileSdk was the blocker. It isn't:

| Finding | Consequence |
|:---|:---|
| `androidx.core 1.19.0` and `lifecycle 2.11.0` fail `checkDebugAarMetadata` with **"requires Android Gradle plugin 9.1.0 or higher"** | AGP 8.13.2 — the last 8.x — cannot satisfy them. This is an AGP *major* upgrade, which pulls Gradle 9 with it. |
| **AGP 9 folded Kotlin support into the Android plugin.** Applying `org.jetbrains.kotlin.android` beside it is a hard error, not a deprecation | The plugin is removed from both build files and the version catalog |
| `kotlinx-coroutines 1.11.0` needs Kotlin 2.2+ | Kotlin 2.4.10 satisfies it. The `kotlinOptions` → `kotlin { compilerOptions { } }` migration was already done in an earlier pass |

**CI's Java version was checked rather than assumed.** The AGP 9.3.1 jar is class-file major 61, so JDK 17 is still sufficient and the workflows are untouched.

## Versions

`agp 8.7.3 → 9.3.1` · `gradle 8.10.2 → 9.7.0` · `kotlin 2.0.21 → 2.4.10` · `compileSdk/targetSdk 35 → 37` · `core-ktx 1.15.0 → 1.19.0` · `activity-compose 1.9.3 → 1.13.0` · `lifecycle 2.8.7 → 2.11.0` · `compose-bom 2024.11.00 → 2026.06.01` · `coroutines 1.9.0 → 1.11.0` · `serialization-json 1.7.3 → 1.11.0`

## A release-pipeline bug this turned up

I ran `release.yml`'s `workflow_dispatch` path to test something else, and it failed:

```
android.defaultConfig.versionCode is set to 0, but it should be a positive integer.
```

The dry run builds `0.0.0-dry-run`; the pre-release suffix is stripped before computing the integer, giving **0** — which **AGP 9 rejects outright**. So the workflow's own documented rehearsal path could not build. AGP 8 tolerated it quietly, which is why nothing had caught it, and no pull request exercises that path.

Fixed by flooring at 1. Real releases are untouched — verified across all three cases:

| `-PrelayVersion` | versionCode | versionName |
|:---|:---|:---|
| `0.0.0-dry-run` | **1** (was 0) | `0.0.0-dry-run` |
| `1.2.3` | 10203 | `1.2.3` |
| `1.1.0` | 10100 | `1.1.0` |

## Verified locally

Against a real SDK — platform `android-37.0`, build-tools `37.0.0`:

- `testDebugUnitTest` — **45 tests across 7 suites, 0 failures**
- `assembleDebug` — builds, and the arm64-v8a ABI split still produces exactly one APK

Changing the SDK the app compiles against is precisely the kind of change unit tests cannot speak for, so **the device lab on API 30 and 34 is the check that matters here**, not the unit suite.

## The artifact-pairing risk — closed with evidence

`upload-artifact` goes to v7 while `download-artifact` stays on v4 (Dependabot left the latter alone). Those two have to agree on the artifact format, and the only place `download-artifact` runs is `release.yml`'s publish job, **which no pull request exercises**.

So I ran the full dry run on this branch. The publish job succeeded, and `download-artifact@v4` read every file `upload-artifact@v7` produced:

```
4a9b2c1f…  ./Relay-Setup-x64.exe
7fcef2ab…  ./Relay-Setup-x86.exe
5e3b3127…  ./Relay-android-arm64-v8a.apk
9bb95d16…  ./Relay-android.aab
```

The pairing works. That is measured, not assumed.