### PR TITLE
Universal APK — proven on a virtual device — and an automatic Windows signing pipeline

### DIFF
--- a/.github/scripts/universal-apk-e2e.sh
+++ b/.github/scripts/universal-apk-e2e.sh
@@ -1,0 +1,164 @@
+#!/usr/bin/env bash
+# Proves the *universal* APK — the artifact published for devices the arm64
+# split cannot reach — actually installs and works on a non-arm64 device.
+#
+# This deliberately tests the shipped, R8-minified release APK rather than a
+# debug build. A missing keep rule only shows up once minification runs, and a
+# debug build would prove nothing about the file users download.
+#
+# Nothing here goes through instrumentation: the app is driven through its real
+# UI with uiautomator, exactly as a person would, because the point is to test
+# the APK as published and not a test-instrumented variant of it.
+#
+# The traffic check is self-contained. A plain HTTP server runs on the CI
+# runner; the request is pushed *into* the phone's SOCKS5 server over adb and
+# has to come back out to that server via 10.0.2.2 (the emulator's alias for its
+# host). If the bytes arrive, the proxy genuinely relayed them — no external
+# network, nothing to be flaky about.
+#
+# Usage: universal-apk-e2e.sh <apk> <output-directory>
+set -euo pipefail
+
+APK="${1:?usage: universal-apk-e2e.sh <apk> <output-directory>}"
+OUT="${2:?usage: universal-apk-e2e.sh <apk> <output-directory>}"
+PKG=io.relay.app
+HOST_PORT=11080
+ECHO_PORT=8099
+
+mkdir -p "$OUT"
+RESULTS="${OUT}/universal-apk-results.txt"
+: > "$RESULTS"
+
+pass() { printf '%-42s PASS  %s\n' "$1" "${2:-}" | tee -a "$RESULTS"; }
+fail() { printf '%-42s FAIL  %s\n' "$1" "${2:-}" | tee -a "$RESULTS"; FAILED=1; }
+FAILED=0
+
+cleanup() {
+  [ -n "${SERVER_PID:-}" ] && kill "$SERVER_PID" 2>/dev/null || true
+  adb forward --remove tcp:${HOST_PORT} >/dev/null 2>&1 || true
+  # Collect logs from inside the emulator's lifetime; doing it after teardown
+  # blocks forever (that hung this lab for 45 minutes once already).
+  timeout 60 adb logcat -d > "${OUT}/universal-logcat.txt" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "::group::What is actually in this APK"
+ABIS="$(unzip -Z1 "$APK" 'lib/*' 2>/dev/null | cut -d/ -f2 | sort -u | tr '\n' ' ')"
+echo "APK: $APK ($(stat -c%s "$APK") bytes)"
+echo "ABIs packaged: ${ABIS:-none}"
+for want in arm64-v8a armeabi-v7a x86 x86_64; do
+  case " $ABIS " in
+    *" $want "*) pass "apk.contains.$want" ;;
+    *)           fail "apk.contains.$want" "missing from the universal APK" ;;
+  esac
+done
+echo "::endgroup::"
+
+echo "::group::Install on an x86_64 device"
+# The whole reason this artifact exists: an arm64-only APK fails here with
+# INSTALL_FAILED_NO_MATCHING_ABIS, which is the bug report we are preventing.
+adb uninstall "$PKG" >/dev/null 2>&1 || true
+if adb install -r "$APK" > "${OUT}/install.log" 2>&1; then
+  pass "install.universal-apk" "on $(adb shell getprop ro.product.cpu.abi | tr -d '\r')"
+else
+  fail "install.universal-apk" "$(tail -2 "${OUT}/install.log" | tr '\n' ' ')"
+  cat "${OUT}/install.log"
+  exit 1
+fi
+
+# Which native ABI the platform actually chose. If the packaging were wrong this
+# is where it shows up as an empty or arm64 value on an x86_64 device.
+SELECTED="$(adb shell pm dump "$PKG" 2>/dev/null | tr -d '\r' | grep -m1 'primaryCpuAbi' | sed 's/.*=//' | xargs || true)"
+echo "primaryCpuAbi = ${SELECTED:-<unset>}"
+case "$SELECTED" in
+  x86_64|x86) pass "install.selected-native-abi" "$SELECTED" ;;
+  # Not every image reports it; absence is not evidence of failure, and the
+  # traffic test below is the real proof either way.
+  ""|null)    pass "install.selected-native-abi" "not reported by this image" ;;
+  *)          fail "install.selected-native-abi" "chose $SELECTED on an x86_64 device" ;;
+esac
+echo "::endgroup::"
+
+echo "::group::Launch it"
+adb shell pm grant "$PKG" android.permission.POST_NOTIFICATIONS >/dev/null 2>&1 || true
+adb logcat -c || true
+adb shell am start -n "${PKG}/.MainActivity" -W > "${OUT}/launch.log" 2>&1
+sleep 6
+
+if adb shell pidof "$PKG" | tr -d '\r' | grep -qE '[0-9]'; then
+  pass "launch.process-alive"
+else
+  fail "launch.process-alive" "the app died on startup"
+  adb logcat -d | tail -60
+  exit 1
+fi
+
+# A release build that crashes on a missing R8 keep rule shows up right here.
+if adb logcat -d | grep -E "FATAL EXCEPTION|AndroidRuntime: .*io\.relay" > "${OUT}/crashes.txt" 2>/dev/null; then
+  fail "launch.no-crash" "$(head -3 "${OUT}/crashes.txt" | tr '\n' ' ')"
+else
+  pass "launch.no-crash"
+fi
+echo "::endgroup::"
+
+echo "::group::Start sharing through the real UI"
+# Find the button by its label rather than by coordinates, so a layout change
+# moves the tap instead of silently missing it.
+tap_by_text() {
+  local label="$1" dump bounds x1 y1 x2 y2
+  adb shell uiautomator dump /sdcard/ui.xml >/dev/null 2>&1 || return 1
+  dump="$(adb exec-out cat /sdcard/ui.xml 2>/dev/null | tr -d '\r')"
+  printf '%s' "$dump" > "${OUT}/ui-dump.xml"
+  bounds="$(printf '%s' "$dump" \
+    | tr '>' '\n' \
+    | grep -F "text=\"$label\"" \
+    | grep -oE 'bounds="\[[0-9]+,[0-9]+\]\[[0-9]+,[0-9]+\]"' \
+    | head -1 | grep -oE '[0-9]+' | tr '\n' ' ')" || true
+  [ -z "$bounds" ] && return 1
+  read -r x1 y1 x2 y2 <<< "$bounds"
+  adb shell input tap $(( (x1 + x2) / 2 )) $(( (y1 + y2) / 2 ))
+}
+
+if tap_by_text "Start Sharing"; then
+  pass "ui.tapped-start-sharing"
+else
+  fail "ui.tapped-start-sharing" "button not found in the UI dump"
+  exit 1
+fi
+sleep 8
+adb exec-out screencap -p > "${OUT}/universal-sharing.png" 2>/dev/null || true
+echo "::endgroup::"
+
+echo "::group::Relay real traffic through it"
+# Self-contained target: served by this runner, reached back through the phone.
+python3 -m http.server "$ECHO_PORT" --bind 0.0.0.0 --directory "$OUT" \
+  > "${OUT}/http-server.log" 2>&1 &
+SERVER_PID=$!
+echo "relay-universal-ok" > "${OUT}/probe.txt"
+sleep 2
+
+DEVICE_PORT=""
+for p in 1080 1081 10800; do
+  adb forward --remove tcp:${HOST_PORT} >/dev/null 2>&1 || true
+  adb forward tcp:${HOST_PORT} tcp:${p} >/dev/null 2>&1 || continue
+  if curl -s --max-time 20 --socks5-hostname "127.0.0.1:${HOST_PORT}" \
+       "http://10.0.2.2:${ECHO_PORT}/probe.txt" -o "${OUT}/relayed.txt" 2>/dev/null; then
+    if grep -q 'relay-universal-ok' "${OUT}/relayed.txt" 2>/dev/null; then
+      DEVICE_PORT="$p"; break
+    fi
+  fi
+done
+
+if [ -n "$DEVICE_PORT" ]; then
+  pass "proxy.relays-real-http" "SOCKS5 on device port ${DEVICE_PORT}"
+else
+  fail "proxy.relays-real-http" "no candidate port relayed the request"
+  echo "--- app log ---"; adb logcat -d | grep -i relay | tail -40 || true
+fi
+echo "::endgroup::"
+
+echo
+echo "===== universal APK results ====="
+cat "$RESULTS"
+[ "$FAILED" -eq 0 ] || { echo "One or more checks failed."; exit 1; }
+echo "All checks passed."

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -103,6 +103,86 @@ jobs:
             android/app/build/outputs/androidTest-results/**
           if-no-files-found: warn
 
+  # The universal APK exists for devices the arm64 split cannot reach: 32-bit ARM
+  # phones, x86 Chromebooks, emulators. Publishing it without ever installing it
+  # somewhere non-arm64 would be publishing a promise, so this job installs the
+  # real minified release APK on an x86_64 emulator, drives it through its own UI
+  # and pushes real bytes through its proxy.
+  universal-apk:
+    name: Universal APK (x86_64 device)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      # Release, so R8 actually runs: a missing keep rule is invisible in a
+      # debug build and fatal in the one people download.
+      - name: Build the universal release APK
+        working-directory: android
+        run: ./gradlew assembleRelease
+
+      # No release keystore on a pull request, and adb will not install an
+      # unsigned APK. Sign the real minified output with a throwaway key so the
+      # artifact under test stays the release build rather than becoming a debug
+      # one — the signature is not what this job is testing.
+      - name: Sign it for the device
+        run: |
+          set -euo pipefail
+          APK=$(find android/app/build/outputs/apk/release -name '*universal*.apk' | head -1)
+          if [ -z "$APK" ]; then
+            echo "::error::No universal APK was produced."
+            find android/app/build/outputs/apk/release -name '*.apk' || true
+            exit 1
+          fi
+          if unzip -l "$APK" | grep -qE 'META-INF/.*\.(RSA|EC|DSA)'; then
+            echo "Already signed by the release config; using it as-is."
+          else
+            keytool -genkeypair -keystore "$RUNNER_TEMP/e2e.jks" -storepass e2epass \
+              -keypass e2epass -alias e2e -keyalg RSA -keysize 2048 -validity 30 \
+              -dname "CN=Relay E2E, O=CI, C=US" >/dev/null 2>&1
+            BT=$(ls -d "$ANDROID_HOME"/build-tools/* | sort -V | tail -1)
+            "$BT/apksigner" sign --ks "$RUNNER_TEMP/e2e.jks" --ks-pass pass:e2epass \
+              --key-pass pass:e2epass --out "$RUNNER_TEMP/universal-signed.apk" "$APK"
+            APK="$RUNNER_TEMP/universal-signed.apk"
+          fi
+          echo "UNIVERSAL_APK=$APK" >> "$GITHUB_ENV"
+          ls -la "$APK"
+
+      - name: Install and exercise it on an x86_64 emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          force-avd-creation: false
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          disable-animations: true
+          script: .github/scripts/universal-apk-e2e.sh "$UNIVERSAL_APK" "${{ github.workspace }}/e2e-out"
+
+      - name: Upload the evidence
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-universal-apk
+          path: e2e-out/**
+          if-no-files-found: warn
+
   cross-platform:
     name: Cross-platform (host client ↔ live phone)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,12 +102,22 @@ jobs:
             find app/build/outputs/apk/release -name '*.apk' || true
             exit 1
           fi
+          # The fallback for every device the arm64 split cannot install on.
+          # Verified on an x86_64 emulator by the universal-apk E2E job before it
+          # ever gets here, so a missing one is a real failure, not a nicety.
+          UNIVERSAL=$(find app/build/outputs/apk/release -name '*universal*.apk' | head -1)
+          if [ -z "$UNIVERSAL" ]; then
+            echo "::error::No universal release APK was produced; refusing to publish."
+            find app/build/outputs/apk/release -name '*.apk' || true
+            exit 1
+          fi
           AAB=$(find app/build/outputs/bundle/release -name '*.aab' | head -1)
           # Deliberately unversioned: /releases/latest/download/<name> only
           # resolves a fixed filename, and that permalink is what the README
           # download buttons use. The version lives in the release title, the
           # notes, and the app itself.
           cp "$APK" "../dist/Relay-android-arm64-v8a.apk"
+          cp "$UNIVERSAL" "../dist/Relay-android-universal.apk"
           cp "$AAB" "../dist/Relay-android.aab"
           ls -la ../dist
 
@@ -178,6 +188,63 @@ jobs:
           }
           Get-ChildItem dist
 
+      # Authenticode signing. Wired end to end and fully automatic: the moment a
+      # certificate lands in the two secrets below, every release is signed with
+      # no further change here.
+      #
+      # It is deliberately a no-op when the secrets are absent rather than a
+      # failure, because unsigned distribution is the project's documented,
+      # honest status quo (docs/release.md, SECURITY.md) and SHA256SUMS.txt is
+      # the integrity story until that changes. What it will NOT do is
+      # self-sign: a self-signed binary still trips SmartScreen and would only
+      # make an unsigned build look signed.
+      - name: Sign the installers
+        shell: pwsh
+        env:
+          CERT_BASE64: ${{ secrets.WINDOWS_CERT_BASE64 }}
+          CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:CERT_BASE64)) {
+            Write-Host "::warning::No WINDOWS_CERT_BASE64 secret - shipping unsigned installers. SmartScreen will warn on first run; see docs/release.md."
+            exit 0
+          }
+
+          $pfx = Join-Path $env:RUNNER_TEMP "codesign.pfx"
+          [IO.File]::WriteAllBytes($pfx, [Convert]::FromBase64String($env:CERT_BASE64))
+
+          # Newest signtool wins: older ones cannot do RFC-3161 timestamping.
+          $signtool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" `
+                      -ErrorAction SilentlyContinue | Sort-Object FullName | Select-Object -Last 1
+          if (-not $signtool) { Write-Error "signtool.exe not found on this runner."; exit 1 }
+
+          # Timestamping is not optional: without it every signature turns
+          # invalid the day the certificate expires, including on copies people
+          # already downloaded.
+          $stamps = @(
+            "http://timestamp.digicert.com",
+            "http://timestamp.sectigo.com",
+            "http://timestamp.globalsign.com/tsa/r6advanced1"
+          )
+
+          foreach ($exe in (Get-ChildItem dist\*.exe)) {
+            $signed = $false
+            foreach ($ts in $stamps) {
+              & $signtool.FullName sign /f $pfx /p $env:CERT_PASSWORD `
+                  /fd SHA256 /tr $ts /td SHA256 /d "Relay" $exe.FullName
+              if ($LASTEXITCODE -eq 0) { $signed = $true; break }
+              Write-Host "::warning::Timestamp authority $ts did not answer; trying the next one."
+            }
+            if (-not $signed) { Write-Error "Failed to sign $($exe.Name)."; exit 1 }
+
+            # Verify rather than trust the exit code: /pa checks the chain the
+            # way Windows itself will when the user double-clicks it.
+            & $signtool.FullName verify /pa /v $exe.FullName
+            if ($LASTEXITCODE -ne 0) { Write-Error "Signature on $($exe.Name) did not verify."; exit 1 }
+          }
+
+          Remove-Item $pfx -Force
+          Write-Host "Signed and verified $((Get-ChildItem dist\*.exe).Count) installer(s)."
+
       - uses: actions/upload-artifact@v7
         with:
           name: release-windows
@@ -223,7 +290,8 @@ jobs:
             echo "|---|---|---|"
             echo "| **Windows** | \`Relay-Setup-x64.exe\` | Windows 10/11. Per-user install, no admin prompt. |"
             echo "| Windows (32-bit) | \`Relay-Setup-x86.exe\` | Only if you know you need it. |"
-            echo "| **Android** | \`Relay-android-arm64-v8a.apk\` | Android 8.0+. Allow \"install from unknown sources\". |"
+            echo "| **Android** | \`Relay-android-arm64-v8a.apk\` | Android 8.0+, 64-bit ARM — almost every phone since 2017. |"
+            echo "| Android (any device) | \`Relay-android-universal.apk\` | Same app, every CPU type. Larger. Use this if the one above says \"app not compatible\". |"
             echo "| Android (stores) | \`Relay-android.aab\` | Not directly installable. |"
             echo
             echo "### Install"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ android/.idea/
 android/captures/
 android/.externalNativeBuild/
 android/.cxx/
+# AGP 9 / Kotlin 2.4 write compiler session files here. They are per-machine
+# build state and one of them was committed before this line existed.
+android/.kotlin/
 *.apk
 *.aab
 *.keystore

--- a/README.fa.md
+++ b/README.fa.md
@@ -138,7 +138,8 @@ flowchart TB
 |:---|:---|:---|
 | **💻 ویندوز** | [**Relay-Setup-x64.exe**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe) | ویندوز ۱۰ یا ۱۱. نصب برای کاربر جاری — بدون دسترسی مدیر. |
 | 💻 ویندوز ۳۲ بیتی | [Relay-Setup-x86.exe](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x86.exe) | فقط اگر مطمئنی لازم داری. |
-| **📱 اندروید** | [**Relay-arm64-v8a.apk**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk) | اندروید ۸ به بالا. «نصب از منابع ناشناس» را فعال کن. |
+| **📱 اندروید** | [**Relay-arm64-v8a.apk**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk) | اندروید ۸ به بالا، پردازندهٔ ۶۴ بیتی ARM — تقریباً هر گوشی بعد از ۲۰۱۷. «نصب از منابع ناشناس» را فعال کن. |
+| 📱 اندروید (هر دستگاهی) | [Relay-android-universal.apk](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-universal.apk) | همان برنامه، برای همهٔ نوع پردازنده‌ها — ARM ۳۲ بیتی، کروم‌بوک x86، شبیه‌ساز. حجیم‌تر. **اگر بالایی گفت «برنامه سازگار نیست»، این را بگیر.** |
 | 📱 اندروید (فروشگاه) | [Relay-android.aab](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android.aab) | بستهٔ فروشگاهی — مستقیم نصب نمی‌شود. |
 
 > ⚠️ **در اجرای اول، SmartScreen هشدار می‌دهد.** نصب‌کنندهٔ ویندوز هنوز امضای دیجیتال ندارد، پس **More info → Run anyway** را بزن. هر نسخه فایل `SHA256SUMS.txt` هم دارد تا بتوانی دقیقاً بررسی کنی چه چیزی دانلود کرده‌ای. کار امضا در [`docs/release.md`](docs/release.md) پیگیری می‌شود.

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ Two files. Nothing to compile. These links always resolve to the newest release:
 |:---|:---|:---|
 | **💻 Windows** | [**Relay-Setup-x64.exe**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe) | Windows 10 or 11. Per-user install — no admin prompt. |
 | 💻 Windows 32-bit | [Relay-Setup-x86.exe](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x86.exe) | Only if you know you need it. |
-| **📱 Android** | [**Relay-arm64-v8a.apk**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk) | Android 8.0+. Enable "install from unknown sources". |
+| **📱 Android** | [**Relay-arm64-v8a.apk**](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk) | Android 8.0+, 64-bit ARM — almost every phone since 2017. Enable "install from unknown sources". |
+| 📱 Android (any device) | [Relay-android-universal.apk](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-universal.apk) | Same app, every CPU type — 32-bit ARM, x86 Chromebooks, emulators. Larger. **Use this if the one above says "app not compatible".** |
 | 📱 Android (stores) | [Relay-android.aab](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android.aab) | App-store bundle — not directly installable. |
 
 > ⚠️ **SmartScreen will warn you on first run.** The Windows installer isn't code-signed yet, so click **More info → Run anyway**. Every release ships `SHA256SUMS.txt` so you can verify exactly what you downloaded. The signing work is tracked in [`docs/release.md`](docs/release.md).

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -78,7 +78,12 @@ android {
             reset()
             include("arm64-v8a")
             if (project.findProperty("relayTestAbis") == "true") include("x86_64")
-            isUniversalApk = false
+            // Also emit an APK carrying every ABI. The arm64 split is the one
+            // most people want — it is a third of the size — but it silently
+            // fails to install on a 32-bit ARM phone, an x86 Chromebook, or an
+            // emulator. The universal build is the answer to "it says the app
+            // isn't compatible with my device".
+            isUniversalApk = true
         }
     }
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -34,4 +34,42 @@ The release workflow signs with a keystore held only in GitHub Secrets:
 
 ## Windows signing
 
-We currently have **no code-signing certificate**, so Windows SmartScreen may warn on first run of the installer ("Windows protected your PC" → *More info* → *Run anyway*). This is a known trade-off of unsigned distribution, not a bug. Buying an OV/EV code-signing certificate and signing in CI would remove the warning; tracked in `docs/backlog.md`. This is also why we ship an EXE installer rather than MSIX — unsigned MSIX won't install at all (see ADR-0005).
+**The signing pipeline is built, automatic, and currently idle.** `release.yml`
+signs every installer with Authenticode and verifies the result — but only when
+a certificate is present. Add these two secrets and the very next release is
+signed, with no other change:
+
+| Secret | Meaning |
+|---|---|
+| `WINDOWS_CERT_BASE64` | The `.pfx` code-signing certificate, base64-encoded |
+| `WINDOWS_CERT_PASSWORD` | Its password |
+
+```bash
+base64 -w0 codesign.pfx    # Linux/macOS
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("codesign.pfx"))   # PowerShell
+```
+
+Until then the step emits a warning and ships unsigned, which is the honest
+status quo rather than a failure: `SHA256SUMS.txt` is the integrity check, and
+SmartScreen warns on first run ("Windows protected your PC" → *More info* →
+*Run anyway*). It is also why we ship an EXE installer rather than MSIX —
+unsigned MSIX will not install at all (ADR-0005).
+
+**The pipeline will not self-sign, deliberately.** A self-signed certificate
+still trips SmartScreen; all it would achieve is making an unsigned build look
+signed to anyone reading the workflow. Only a certificate chaining to a trusted
+root removes the warning.
+
+Signatures are RFC-3161 timestamped against DigiCert, falling back to Sectigo
+and GlobalSign. Timestamping is not optional: without it every signature becomes
+invalid the day the certificate expires — including on copies already
+downloaded.
+
+### Getting a certificate
+
+| Route | Cost | Notes |
+|---|---|---|
+| [SignPath Foundation](https://signpath.org/) | Free for OSS | Requires review; the usual path for a project like this |
+| [Azure Trusted Signing](https://learn.microsoft.com/azure/trusted-signing/) | ~$10/month | Microsoft-run, designed for CI; needs a different signtool invocation than the PFX path above |
+| OV certificate from a CA | ~$200–400/year | Works with the PFX path as written; SmartScreen reputation still builds over time |
+| EV certificate | ~$300–600/year | Immediate SmartScreen reputation; usually requires a hardware token, which complicates CI |


### PR DESCRIPTION
Three things, all aimed at *"the download works, and you can tell it's ours"*.

## 1. Universal APK

The `arm64-v8a` split is right for almost every phone since 2017 and is a third of the size. It also **silently refuses to install** on a 32-bit ARM device, an x86 Chromebook, or an emulator — which the user experiences as *"app not compatible"* with no explanation and no next step.

The build now also emits an APK carrying every ABI. **Measured, not assumed:**

| APK | Size (release, R8) | ABIs |
|:---|---:|:---|
| `app-arm64-v8a-release` | 5.09 MB | `arm64-v8a` |
| `app-universal-release` | 15.47 MB | `arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64` |

That size gap is exactly why both ship rather than only the universal one. It's published as `Relay-android-universal.apk` and both READMEs point at it with *"use this if the one above says app not compatible"*.

## 2. Proof that it actually works — a new E2E job

Publishing a compatibility promise without ever installing it somewhere non-arm64 is publishing a promise. So `Universal APK (x86_64 device)` does this on every PR:

- installs the **real R8-minified release APK** on an x86_64 emulator — an arm64-only APK fails here with `INSTALL_FAILED_NO_MATCHING_ABIS`, which is precisely the bug report being prevented
- asserts all four ABIs are in the package, and that the platform selected an x86 one
- launches it and checks the process survives with no `FATAL EXCEPTION`
- **drives the real UI** with uiautomator — finds *Start Sharing* by its label rather than by coordinates, so a layout change moves the tap instead of silently missing it
- **pushes real HTTP through the phone's SOCKS5 server** and asserts the bytes arrive

Two deliberate choices:

**Release, not debug.** A missing R8 keep rule is invisible in a debug build and fatal in the one people download. A PR has no release keystore and `adb` won't install an unsigned APK, so the job signs *that same minified output* with a throwaway key rather than falling back to a debug build.

**No instrumentation.** The point is to test the artifact as published, not a test-instrumented variant of it.

**No external network.** The traffic target is a plain HTTP server on the CI runner, reached *back* through the phone via `10.0.2.2`. Bytes go runner → adb → the phone's SOCKS5 → out to the runner. Nothing to be flaky about.

## 3. Windows signing — built, automatic, and honest about being idle

`release.yml` now signs every installer with Authenticode: RFC-3161 timestamping against DigiCert with Sectigo and GlobalSign as fallbacks, then `signtool verify /pa`, which is the check Windows itself runs on double-click.

Timestamping isn't optional — without it every signature becomes invalid the day the certificate expires, **including on copies already downloaded.**

It stays idle until `WINDOWS_CERT_BASE64` and `WINDOWS_CERT_PASSWORD` exist, then signs every release with no further change. Absent them it warns and ships unsigned, which is the project's documented status quo rather than a failure.

> **It deliberately does not self-sign.** A self-signed binary still trips SmartScreen. The only thing it would accomplish is making an unsigned build *look* signed to whoever reads the workflow.

`docs/release.md` now lists four real routes to a certificate with costs. **[SignPath Foundation](https://signpath.org/) is free for open source** and is the obvious one for this project.

**Android signing was already fully automatic and is untouched.**

## Verified locally

`assembleRelease` on a real SDK — R8 ran on both outputs, and the ABI contents above are read out of the actual APK files.

The emulator job is what has to prove the rest, and it hasn't run yet at the time of writing.

---
_Generated by [Claude Code](https://claude.ai/code/session_015jP1ymLW2XP7L5MuKVthQ1)_