### PR TITLE
Stop the Windows code box approving codes the decoder then refuses

### DIFF
--- a/windows/Relay.App.Tests/TypedCodeTests.cs
+++ b/windows/Relay.App.Tests/TypedCodeTests.cs
@@ -41,6 +41,35 @@ public class TypedCodeTests
         Assert.Equal(TypedCode.Decode(code), TypedCode.Decode(relaxed));
     }
 
+    /// <summary>
+    /// The code box validates a keystroke and then hands the box to the decoder,
+    /// so whatever it normalises with has to agree with the decoder on every
+    /// input — including the ones neither of them accepts. It once stripped any
+    /// non-alphanumeric character, so "ABCD.EFGH" validated as ready and was
+    /// then rejected as invalid by the decoder a line later.
+    /// </summary>
+    [Fact]
+    public void Normalize_agrees_with_Decode_on_separators_outside_the_contract()
+    {
+        var code = TypedCodes.GetProperty("valid")[0].GetProperty("code").GetString()!;
+
+        // In the contract: stripped, so the code still decodes.
+        Assert.Equal(code, TypedCode.Normalize($" {code.ToLowerInvariant()} ".Insert(5, "-")));
+
+        // Outside it: kept, so the box sees a character the alphabet lacks and
+        // says so, instead of accepting a code the decoder will refuse.
+        foreach (var separator in new[] { '.', '_', '/', '+' })
+        {
+            var typed = code.Insert(4, separator.ToString());
+            var normalized = TypedCode.Normalize(typed);
+
+            Assert.Contains(separator, normalized);
+            Assert.Null(TypedCode.Decode(typed));
+            // The box's own verdict, reached the same way it reaches it.
+            Assert.Contains(normalized, c => !TypedCode.Alphabet.Contains(c));
+        }
+    }
+
     [Fact]
     public void Invalid_codes_are_rejected()
     {

--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -655,8 +655,16 @@ public sealed partial class MainWindow : Window
     /// </summary>
     private void OnCodeChanged(object sender, TextChangedEventArgs e)
     {
-        var raw = CodeBox.Text ?? string.Empty;
-        var clean = new string(raw.Where(char.IsLetterOrDigit).ToArray()).ToUpperInvariant();
+        // Normalise exactly as TypedCode.Decode does, because that is what
+        // judges the code a moment later. This used to strip every character
+        // that was not a letter or digit, which is a wider rule than the
+        // contract's "whitespace and '-'". A code typed or pasted with any
+        // other separator — "ABCD.EFGH" — therefore passed this check with the
+        // dot quietly removed, turned the hint green, said "ready" and
+        // auto-connected, and the decoder then saw the raw nine characters and
+        // rejected them as ERR_CODE_INVALID. The code was correct; the app
+        // refused it and blamed the user.
+        var clean = TypedCode.Normalize(CodeBox.Text);
 
         if (clean.Length == 0)
         {
@@ -703,7 +711,7 @@ public sealed partial class MainWindow : Window
 
     private async void OnCodeConnectClick(object sender, RoutedEventArgs e)
     {
-        var decoded = TypedCode.Decode(CodeBox.Text);
+        var decoded = TypedCode.Decode(TypedCode.Normalize(CodeBox.Text));
         if (decoded is null)
         {
             ShowLocalError("ERR_CODE_INVALID");

--- a/windows/Relay.Core/TypedCode.cs
+++ b/windows/Relay.Core/TypedCode.cs
@@ -31,11 +31,23 @@ public static class TypedCode
         return new string(code);
     }
 
+    /// <summary>
+    /// The contract's input rule (/shared/typed-code.md): upper-case, with
+    /// whitespace and <c>-</c> stripped and nothing else.
+    ///
+    /// Public because anything that validates a code before handing it to
+    /// <see cref="Decode"/> has to see exactly the same string the decoder will.
+    /// The code box normalised more loosely than this and the two disagreed —
+    /// see the call site for what that cost the user.
+    /// </summary>
+    public static string Normalize(string? input) =>
+        new((input ?? string.Empty).ToUpperInvariant()
+            .Where(c => c != '-' && !char.IsWhiteSpace(c)).ToArray());
+
     /// <summary>Decodes user input (case-insensitive, separators tolerated); null on any failure.</summary>
     public static (string Host, int Port)? Decode(string input)
     {
-        var clean = new string(input.ToUpperInvariant()
-            .Where(c => c != '-' && !char.IsWhiteSpace(c)).ToArray());
+        var clean = Normalize(input);
         if (clean.Length != Length) return null;
 
         var value = 0L;


### PR DESCRIPTION
## What this changes

On Windows, typing or pasting a pairing code with a separator other than `-` — `FNAS.JQE2`, `FNAS_JQE2` — no longer turns the hint green, says "ready", auto-connects and then answers with `ERR_CODE_INVALID`. The box now reports the character as one the alphabet does not contain, which is both true and actionable.

## Why

`OnCodeChanged` validated a keystroke by stripping every character that was not a letter or digit, then handed the **raw** box text to `TypedCode.Decode`, which strips only whitespace and `-` — the rule `/shared/typed-code.md` actually specifies.

The two normalisations disagreed on every other separator. The validator quietly removed the dot, found eight good characters and a matching checksum, reported "ready" and fired the auto-connect; the decoder then saw nine characters, returned `null`, and the app rejected a code that was correct.

Root cause is the duplicated normalisation, so the fix is to have one: `TypedCode.Normalize`, the contract's rule in a single place, used by both the box and the connect path.

## How it was verified

Reproduced against `Relay.Core` before and after, using the code a stock Android hotspot actually produces (`192.168.43.1:1080` → `FNAS-JQE2`):

```
user types  : FNAS.JQE2
  before    : box says ready=True  connect works=False  <-- 'ready', then ERR_CODE_INVALID
  after     : box says ready=False connect works=False  consistent

user types  : FNAS-JQE2        (in-contract separator, must keep working)
  before    : box says ready=True  connect works=True   ok
  after     : box says ready=True  connect works=True   consistent
```

`Normalize_agrees_with_Decode_on_separators_outside_the_contract` asserts the box's verdict and the decoder's verdict agree for `.`, `_`, `/` and `+`, and that whitespace and `-` are still stripped. It fails against the old code, which reached "ready" on input the decoder rejects.

- [x] Unit tests pass (`CI` workflow) — also run locally, 25/25 in `Relay.App.Tests`
- [x] Device and cross-platform tests pass (`E2E` workflow)
- [x] New behaviour has a test that fails without this change
- [ ] Verified by hand on a real phone and PC — **not done, see below**

## Checklist

- [x] Shared contracts (`/shared`) were changed **first** if the wire format, state machine or tokens moved, and both platforms follow — **no contract change**: `/shared/typed-code.md` already specifies this rule and `TypedCode.Decode` already implemented it correctly. Android only ever *encodes* the typed code, so the divergence was Windows-side only.
- [x] User-facing strings exist in **both** English and Persian — no new strings; this routes to the existing `CodeBadChars`.
- [x] No new network calls, telemetry, or data leaving the device
- [x] System changes remain transactional with verified rollback — proxy path untouched
- [ ] Docs updated — no behaviour documented anywhere changed; the code now matches the contract as written

## Anything reviewers should look at closely

**What is not covered:** this was found and fixed by reading the code, not by using the app. `MainWindow.xaml.cs` has no test harness, so the regression test covers `TypedCode.Normalize` — the shared rule both call sites now go through — rather than the handler itself. A test that drives the real code box would be stronger and does not exist.

The behaviour change is deliberate and narrow: `FNAS.JQE2` used to be *accepted* by the box and is now *rejected* by it. That is the correct reading of the contract, and the alternative — widening `Decode` to tolerate any separator — would have changed the cross-platform wire contract to fix a one-sided UI bug.

---
_Generated by [Claude Code](https://claude.ai/code/session_013RNNaWzrN6B4dNSSd8pkhG)_