### PR TITLE
Start the install matrix from the release job, and survive a network blip

### DIFF
--- a/.github/scripts/fetch-release-apks.py
+++ b/.github/scripts/fetch-release-apks.py
@@ -16,16 +16,38 @@ GH_TOKEN in the env.
 import json
 import os
 import sys
+import time
+import urllib.error
 import urllib.request
 
 API = "https://api.github.com"
 
+# A runner occasionally fails a request for reasons that have nothing to do
+# with the release -- one job died on "CERTIFICATE_VERIFY_FAILED: self-signed
+# certificate", which is something between the runner and GitHub, not a broken
+# APK. Retrying keeps a network blip from being reported as a release that
+# cannot be installed.
+ATTEMPTS = 4
+
 
 def get(url, accept="application/vnd.github+json"):
-    req = urllib.request.Request(
-        url, headers={"Authorization": "Bearer " + os.environ["GH_TOKEN"],
-                      "Accept": accept, "User-Agent": "relay-install-matrix"})
-    return urllib.request.urlopen(req)
+    last = None
+    for attempt in range(ATTEMPTS):
+        req = urllib.request.Request(
+            url, headers={"Authorization": "Bearer " + os.environ["GH_TOKEN"],
+                          "Accept": accept, "User-Agent": "relay-install-matrix"})
+        try:
+            return urllib.request.urlopen(req, timeout=120)
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            # A 404 or 401 will not improve by asking again.
+            if isinstance(exc, urllib.error.HTTPError) and exc.code < 500:
+                raise
+            last = exc
+            if attempt < ATTEMPTS - 1:
+                delay = 2 ** (attempt + 1)
+                print(f"  request failed ({exc}); retrying in {delay}s")
+                time.sleep(delay)
+    raise SystemExit(f"giving up after {ATTEMPTS} attempts: {last}")
 
 
 def download(release, out):

--- a/.github/workflows/install-matrix.yml
+++ b/.github/workflows/install-matrix.yml
@@ -7,12 +7,14 @@
 # its own way of producing "App not installed", and none of them were covered.
 #
 # This workflow takes the published file and installs it, unmodified, across
-# the ABIs and Android versions real phones run.
+# the Android versions real phones run. release.yml starts it as its last step,
+# once the release exists.
 name: Install matrix
 
 on:
-  release:
-    types: [published]
+  # Started by release.yml once the release exists, not by the `release` event:
+  # a release published with GITHUB_TOKEN raises no event, by design, so
+  # subscribing to it meant this never ran for an actual release.
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -255,6 +255,11 @@ jobs:
     name: Publish release
     needs: [version, android, windows]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      # To start install-matrix.yml once the release exists. Without it the
+      # dispatch is refused and the release ships unverified.
+      actions: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -349,3 +354,19 @@ jobs:
             --title "Relay ${{ needs.version.outputs.version }}" \
             --notes-file "$RUNNER_TEMP/notes.md" \
             --latest
+
+      # A release published with GITHUB_TOKEN raises no `release` event -- that
+      # is deliberate on GitHub's side, to stop workflows triggering each other
+      # in a loop. So install-matrix.yml, which subscribes to that event, never
+      # ran for a release this workflow created: it claimed to check every
+      # release and checked none of them. Start it here instead, where the
+      # release definitely exists.
+      - name: Check the published APKs install on real Android versions
+        if: needs.version.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh workflow run install-matrix.yml \
+            --ref "$GITHUB_REF_NAME" \
+            -f tag="v${{ needs.version.outputs.version }}"
+          echo "Install matrix started for v${{ needs.version.outputs.version }}."

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -120,8 +120,14 @@ build, and the app is started afterwards. That sequence makes the platform
 reconcile signing keys, version codes and the native ABI it committed to on the
 previous install — none of which a clean install exercises.
 
-It runs on every published release, and monthly, since new Android versions
-change what sideloading accepts without any change of ours to trigger a run.
+`release.yml` starts it as its last step, once the release exists, and it also
+runs monthly, since new Android versions change what sideloading accepts
+without any change of ours to trigger a run.
+
+It is started explicitly rather than subscribing to the `release` event,
+because a release published with `GITHUB_TOKEN` raises no event — GitHub
+suppresses it to stop workflows triggering one another. Subscribing looked
+correct and ran for nothing.
 
 Two limits worth stating plainly:
 


### PR DESCRIPTION
Publishing v1.3.1 exposed two things, both in the checking rather than the
product.

## The install matrix had never run for a release

It subscribes to `release: published`. A release created with `GITHUB_TOKEN`
raises no such event — GitHub suppresses it so workflows cannot trigger one
another in a loop. The subscription read correctly in the file, two documents
described it as running on every release, and it had run for none of them. The
monthly schedule was quietly doing all the real work.

`release.yml` now dispatches it as its final step, once the release exists,
with the `actions: write` scope that needs. The `release` trigger is removed
rather than left in place looking like a second safety net, and both documents
now say what actually happens and why.

## A network blip was being reported as a bad release

The Android 15 job died before booting anything:

```
ssl.SSLCertVerificationError: CERTIFICATE_VERIFY_FAILED: self-signed certificate
```

That is between one runner and GitHub, not a property of the release — the
same file installed cleanly on Android 11, 12 and 14 in the same run. A red job
there reads as "this release may not install", which is a false accusation
against a good build.

The download now makes four attempts with 2/4/8s backoff and a request
timeout. Responses below 500 are raised immediately, since a 404 or 401 will
not improve by asking again. Tested against the live release, against a stub
that fails twice then succeeds, and against a stub returning 404 — which must
not retry at all.

## v1.3.1 itself

Published and verified: both published APKs carry `install-location:'auto'`
per `aapt2`, checksums match `SHA256SUMS.txt`, and the install matrix passes on
Android 11, 12, 14 and 16 — the failed Android 15 job is the network blip
above and has been re-run.

---
_Generated by [Claude Code](https://claude.ai/code/session_015jP1ymLW2XP7L5MuKVthQ1)_