### PR TITLE
Tapping Allow must not freeze the app — and three failures the release CI found

### DIFF
--- a/android/app/src/androidTest/kotlin/io/relay/app/e2e/CrossPlatformSessionTest.kt
+++ b/android/app/src/androidTest/kotlin/io/relay/app/e2e/CrossPlatformSessionTest.kt
@@ -8,6 +8,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.relay.app.MainActivity
 import io.relay.app.R
 import io.relay.app.core.ConnectionState
+import io.relay.app.core.QrPayload
 import io.relay.app.core.QrPayloadCodec
 import io.relay.app.service.ConnectionRepository
 import io.relay.app.service.SharingService
@@ -21,6 +22,8 @@ import java.io.File
 import java.io.IOException
 import java.net.InetSocketAddress
 import java.net.Socket
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 
 /**
  * Holds a real sharing session open while the **host** runs the Windows-side
@@ -75,27 +78,52 @@ class CrossPlatformSessionTest {
         // Tell the workflow the session is up and where to reach it.
         File(evidence, "ready").writeText("${payload.host}:${payload.port}")
 
-        val done = File(evidence, "host-done")
-        val deadline = System.currentTimeMillis() + HOST_TIMEOUT_MS
-        while (!done.exists() && System.currentTimeMillis() < deadline) {
-            // Stand in for the person holding the phone. The gate holds the
-            // host's first connection until someone allows it
-            // (/shared/pairing-beacon.md), and this harness has no UI to tap --
-            // it drives the service directly. Answering here is the same act
-            // the golden-journey test performs by tapping Allow, not a way
-            // around the gate: an unapproved client still never gets through.
-            ConnectionRepository.clientGate.pending.value?.let { waiting ->
-                DeviceEvidence.note("Allowing ${waiting.address} on the host's behalf")
-                ConnectionRepository.clientGate.resolve(waiting.address, allowed = true)
+        // Stand in for the person holding the phone, for as long as this test
+        // needs one. The gate holds every unapproved address until someone
+        // answers (/shared/pairing-beacon.md), and this harness has no UI to tap
+        // -- it drives the service directly. Answering here is the same act the
+        // golden-journey test performs by tapping Allow, not a way around the
+        // gate: an unapproved client still never gets through.
+        //
+        // It runs for the whole test rather than only while waiting for the
+        // host, because the last thing this test does is open its *own*
+        // connection, from the phone's address rather than the host's tunnel.
+        // That is a second address, so it gets a second prompt. Answering only
+        // until `host-done` appeared left that one unanswered: the gate did
+        // exactly what it should -- waited a minute and refused -- and the
+        // re-probe died on "Connection reset" while reading a greeting that
+        // was never going to come.
+        val answering = AtomicBoolean(true)
+        val standIn = thread(isDaemon = true, name = "relay-e2e-approver") {
+            while (answering.get()) {
+                ConnectionRepository.clientGate.pending.value?.let { waiting ->
+                    DeviceEvidence.note("Allowing ${waiting.address} on the person's behalf")
+                    ConnectionRepository.clientGate.resolve(waiting.address, allowed = true)
+                }
+                Thread.sleep(100)
             }
-            Thread.sleep(500)
         }
-        assertTrue(
-            "the host harness never finished within ${HOST_TIMEOUT_MS / 1000}s — " +
-                "see the host job's log for what it was doing",
-            done.exists(),
-        )
 
+        try {
+            val done = File(evidence, "host-done")
+            val deadline = System.currentTimeMillis() + HOST_TIMEOUT_MS
+            while (!done.exists() && System.currentTimeMillis() < deadline) {
+                Thread.sleep(500)
+            }
+            assertTrue(
+                "the host harness never finished within ${HOST_TIMEOUT_MS / 1000}s — " +
+                    "see the host job's log for what it was doing",
+                done.exists(),
+            )
+            checkTheSessionSurvivedTheHost(payload)
+        } finally {
+            answering.set(false)
+            standIn.join(2_000)
+        }
+    }
+
+    /** The post-conditions, once the host has had its turn. */
+    private fun checkTheSessionSurvivedTheHost(payload: QrPayload) {
         // The host's traffic must have registered as a connected device, and the
         // session must still be healthy after it.
         val state = ConnectionRepository.state.value
@@ -110,6 +138,12 @@ class CrossPlatformSessionTest {
         // the difference between a demo and a product.
         Socket().use { probe ->
             probe.connect(InetSocketAddress(payload.host, payload.port), 5_000)
+            // Without a read timeout this blocks on the approval gate for its
+            // full minute and then fails as a bare "Connection reset", which
+            // says nothing about why. Ten seconds is far longer than a greeting
+            // needs and far shorter than the gate's patience, so a stall here
+            // reports itself as a stall.
+            probe.soTimeout = 10_000
             probe.getOutputStream().write(byteArrayOf(0x05, 0x01, 0x00))
             probe.getOutputStream().flush()
             val reply = ByteArray(2)

--- a/android/app/src/main/kotlin/io/relay/app/core/PairingCode.kt
+++ b/android/app/src/main/kotlin/io/relay/app/core/PairingCode.kt
@@ -25,16 +25,22 @@ object PairingCode {
 
     /**
      * Draws a code, avoiding [taken] — the codes of phones already announcing
-     * themselves on this network. Gives up after [attempts] and returns a code
-     * anyway: a collision produces a "which of these two?" prompt on the PC,
-     * which is worse than a unique code but much better than refusing to share.
+     * themselves on this network.
+     *
+     * Chooses uniformly from the codes that are still free rather than guessing
+     * and retrying. Rejection sampling gets steadily worse exactly when it
+     * matters most: with a crowded network it can run out of tries and hand
+     * back a code it was told to avoid, and it can do that while free codes
+     * remain. Enumerating ninety strings costs nothing and cannot fail that way.
+     *
+     * When every value is taken it returns one anyway. A collision produces a
+     * "which of these two?" prompt on the PC — worse than a unique code, and
+     * far better than refusing to share.
      */
-    fun draw(taken: Set<String> = emptySet(), attempts: Int = 5): String {
-        repeat(attempts) {
-            val candidate = next()
-            if (candidate !in taken) return candidate
-        }
-        return next()
+    fun draw(taken: Set<String> = emptySet()): String {
+        val free = (MIN..MAX).map { it.toString() }.filterNot { it in taken }
+        if (free.isEmpty()) return next()
+        return free[random.nextInt(free.size)]
     }
 
     private fun next(): String = (MIN + random.nextInt(MAX - MIN + 1)).toString()

--- a/android/app/src/main/kotlin/io/relay/app/net/ClientGate.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/ClientGate.kt
@@ -1,5 +1,6 @@
 package io.relay.app.net
 
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -8,8 +9,6 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withTimeout
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.coroutines.resume
-import kotlin.coroutines.suspendCoroutine
 
 /**
  * Decides whether a computer may use this phone's proxy, by asking the person
@@ -34,7 +33,20 @@ class ClientGate(
     data class Pending(val address: String)
 
     private val decisions = ConcurrentHashMap<String, Decision>()
-    private val waiters = ConcurrentHashMap<String, (Decision) -> Unit>()
+
+    /**
+     * One promise per waiting client.
+     *
+     * Deliberately a CompletableDeferred rather than a raw continuation. A
+     * continuation resumed by hand runs the rest of the coroutine *inline, on
+     * whatever thread called resume* -- which here is the UI thread, the moment
+     * someone taps Allow. The coroutine that continues is the one that goes on
+     * to relay the connection, so tapping Allow would have run socket I/O on
+     * the main thread: a frozen app, and on Android a
+     * NetworkOnMainThreadException. Completing a deferred instead wakes the
+     * waiter on its own dispatcher, where it belongs.
+     */
+    private val waiters = ConcurrentHashMap<String, CompletableDeferred<Decision>>()
     private val queue = Mutex()
 
     private val _pending = MutableStateFlow<Pending?>(null)
@@ -57,13 +69,11 @@ class ClientGate(
         // person was never shown.
         return queue.withLock {
             decisions[address]?.let { return@withLock it == Decision.ALLOWED }
+            val answer = CompletableDeferred<Decision>()
+            waiters[address] = answer
+            _pending.value = Pending(address)
             val decision = try {
-                withTimeout(timeoutMs) {
-                    suspendCoroutine { continuation ->
-                        waiters[address] = { continuation.resume(it) }
-                        _pending.value = Pending(address)
-                    }
-                }
+                withTimeout(timeoutMs) { answer.await() }
             } catch (_: TimeoutCancellationException) {
                 Decision.DENIED
             } finally {
@@ -75,11 +85,15 @@ class ClientGate(
         }
     }
 
-    /** Called by the UI when the person answers. */
+    /**
+     * Called by the UI when the person answers. Returns immediately: completing
+     * the promise hands the waiting coroutine back to its own dispatcher rather
+     * than running it here.
+     */
     fun resolve(address: String, allowed: Boolean) {
         val decision = if (allowed) Decision.ALLOWED else Decision.DENIED
         decisions[address] = decision
-        waiters.remove(address)?.invoke(decision)
+        waiters.remove(address)?.complete(decision)
         if (_pending.value?.address == address) _pending.value = null
     }
 
@@ -89,7 +103,7 @@ class ClientGate(
     /** Forgets every decision. Called when sharing stops. */
     fun reset() {
         decisions.clear()
-        waiters.keys.toList().forEach { waiters.remove(it)?.invoke(Decision.DENIED) }
+        waiters.keys.toList().forEach { waiters.remove(it)?.complete(Decision.DENIED) }
         _pending.value = null
     }
 

--- a/android/app/src/main/kotlin/io/relay/app/service/DiagnosticReport.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/DiagnosticReport.kt
@@ -37,10 +37,17 @@ object DiagnosticReport {
         appendLine("Relay diagnostic report")
         appendLine("=======================")
         appendLine()
+        // Every Build field is read defensively. They are platform types, not
+        // guaranteed non-null, and this is the one function in the app that must
+        // never throw: it runs when something has already gone wrong, and a
+        // report that crashes instead of printing leaves the person with
+        // nothing to send. SUPPORTED_ABIS is null outside a device — a JVM unit
+        // test is the honest case, an unusual OEM image the paranoid one.
         appendLine("App:      $appVersion")
-        appendLine("Android:  ${Build.VERSION.RELEASE} (API ${Build.VERSION.SDK_INT})")
-        appendLine("Device:   ${if (redactNames) "${Build.MANUFACTURER} ${Build.MODEL}" else Build.MODEL}")
-        appendLine("ABIs:     ${Build.SUPPORTED_ABIS.joinToString(", ")}")
+        appendLine("Android:  ${Build.VERSION.RELEASE ?: UNKNOWN} (API ${Build.VERSION.SDK_INT})")
+        val model = Build.MODEL ?: UNKNOWN
+        appendLine("Device:   ${if (redactNames) "${Build.MANUFACTURER ?: UNKNOWN} $model" else model}")
+        appendLine("ABIs:     ${Build.SUPPORTED_ABIS?.joinToString(", ") ?: UNKNOWN}")
         appendLine("State:    ${describe(state)}")
         appendLine()
         appendLine("Log (most recent last, times in seconds since sharing started)")
@@ -101,6 +108,7 @@ object DiagnosticReport {
     private fun encode(text: String): String =
         java.net.URLEncoder.encode(text, "UTF-8").replace("+", "%20")
 
+    private const val UNKNOWN = "unknown"
     private const val BODY_LIMIT = 6000
     private const val ISSUES_URL = "https://github.com/Mahdi-mortazavi/relay/issues"
 }

--- a/android/app/src/test/kotlin/io/relay/app/ClientGateTest.kt
+++ b/android/app/src/test/kotlin/io/relay/app/ClientGateTest.kt
@@ -1,6 +1,7 @@
 package io.relay.app
 
 import io.relay.app.net.ClientGate
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
@@ -8,6 +9,7 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -108,6 +110,36 @@ class ClientGateTest {
         waitForPrompt(gate, "192.168.1.13")
         gate.reset()
         assertFalse("a pending request must not be left hanging", waiting.await())
+    }
+
+    @Test
+    fun `resolving does not run the waiter on the caller's thread`() = runTest {
+        // The bug this guards against: with a hand-resumed continuation, the
+        // coroutine that was waiting continues *inline on whichever thread
+        // called resolve*. That thread is the UI thread, and the coroutine it
+        // resumes is the one that goes on to relay the connection -- so a tap
+        // on Allow ran socket I/O on the main thread. In tests it hung the
+        // thread that approved; in the app it would freeze the screen.
+        val gate = ClientGate()
+        val resumedOn = java.util.concurrent.atomic.AtomicReference<String>()
+        val resolverThread = Thread.currentThread().name
+
+        val request = async(Dispatchers.Default) {
+            val allowed = gate.authorize("192.168.1.20")
+            resumedOn.set(Thread.currentThread().name)
+            allowed
+        }
+        withTimeout(2_000) {
+            while (gate.pending.value?.address != "192.168.1.20") delay(5)
+        }
+        gate.resolve("192.168.1.20", allowed = true)
+
+        assertTrue(request.await())
+        assertNotEquals(
+            "the waiter resumed on the thread that answered the prompt",
+            resolverThread,
+            resumedOn.get(),
+        )
     }
 
     private suspend fun waitForPrompt(gate: ClientGate, address: String) {

--- a/android/app/src/test/kotlin/io/relay/app/PairingCodeTest.kt
+++ b/android/app/src/test/kotlin/io/relay/app/PairingCodeTest.kt
@@ -32,7 +32,7 @@ class PairingCodeTest {
     fun `draw avoids codes already in use`() {
         // Everything except 42 is taken, so 42 is the only answer it can give.
         val taken = (PairingCode.MIN..PairingCode.MAX).map { it.toString() }.toSet() - "42"
-        repeat(50) { assertEquals("42", PairingCode.draw(taken, attempts = 200)) }
+        repeat(50) { assertEquals("42", PairingCode.draw(taken)) }
     }
 
     @Test

--- a/shared/pairing-beacon.md
+++ b/shared/pairing-beacon.md
@@ -69,7 +69,9 @@ anywhere it could be executed.
   enough to be useful blocks the thread that starts sharing, and a frozen app
   is a worse outcome than a rare collision. `PairingCode.draw` accepts a set of
   codes to avoid, for a caller that already has that knowledge cheaply, but the
-  phone does not gather it on this path.
+  phone does not gather it on this path. When given such a set it chooses
+  uniformly from the codes still free, so it cannot hand back a code it was
+  told to avoid while free ones remain.
 - Two phones can therefore land on the same code. That case has an answer
   already — see `ERR_CODE_AMBIGUOUS` below, where the PC shows both device
   names and asks which one.


### PR DESCRIPTION
## What this fixes

**The one that shipped in v1.4.0.** `ClientGate` resumed the waiting connection
with a hand-resumed continuation, which continues the coroutine *inline, on
whatever thread called `resolve`*. That thread is the UI thread the moment
someone taps **Allow**, and the coroutine it resumes is the one that goes on to
relay the connection — so tapping Allow handed socket I/O to the main thread: a
frozen screen, and on Android a `NetworkOnMainThreadException`. It now completes
a `CompletableDeferred`, which wakes the waiter on its own dispatcher.

How it showed up: the `Cross-platform (host client ↔ live phone)` job hung for
45 minutes *after its own assertions had passed*. On this branch that same leg
finished its 7 host-side tests against the live phone in two seconds.

Three more, all older than this branch and two of them on `main`:

- **`DiagnosticReport` crashed on every path.** `Build.SUPPORTED_ABIS` is null
  off a device and the report dereferenced it. This is the one function that
  must never throw — it runs when something has already gone wrong, and a crash
  there leaves the person with nothing to send. Every `Build` field is now read
  defensively.
- **`PairingCode.draw` guessed and retried.** With most codes taken it could
  exhaust its tries and return a code it was told to avoid, while free codes
  remained. It now picks uniformly from what is free. The test that asserted
  this was itself probabilistic and had roughly a 99% chance of failing on any
  given run — it is deterministic now.
- **The cross-platform harness stopped answering the approval gate** as soon as
  the host was done, then opened its own connection from a second address. The
  gate did exactly what it should — waited its minute and refused — and the
  probe died on `Connection reset`. The stand-in for the person now answers for
  the whole test, and the probe carries a read timeout so a stall reports itself
  as a stall.

## Tests

- New regression test: `resolving does not run the waiter on the caller's
  thread`, asserting the approving thread is not the resuming thread.
- Android unit suite: **80 tests, 0 failures** (run locally against this commit;
  it was 8 failures before).
- `Android device (API 30)`, `Android device (API 34)` and `Universal APK` all
  passed on the previous push, which is what proved the gate fix on real
  hardware emulation.