### PR TITLE
Full Mode's Windows client, end to end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,12 @@ jobs:
 
       - name: Vet
         run: |
-          go vet ./...
+          # Two passes. The Windows client cannot even be parsed on Linux -- it
+          # imports golang.org/x/sys/windows -- so vetting as Windows is what
+          # actually covers every package; the native pass is what checks the
+          # endpoint the way it is built for Android.
+          GOOS=windows go vet ./...
+          go vet .
           # gofmt is not cosmetic here: this package is read by whoever is
           # debugging a tunnel that will not come up, and two files had already
           # drifted before anyone checked.
@@ -52,7 +57,10 @@ jobs:
         # -race because the forwarders, the packet pump and teardown all touch
         # the same endpoint from different goroutines, and a data race there
         # would show up in the field as an occasional dead tunnel.
-        run: go test -race -count=1 ./...
+        #
+        # The endpoint package only: the client's tests need a Windows machine
+        # and Administrator, and run in the E2E workflow instead.
+        run: go test -race -count=1 .
 
       # The same script a developer runs, so the library the app ships is built
       # the way the one on a desk is. The NDK comes from the runner image; an

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -128,7 +128,9 @@ jobs:
 
       - name: Build the client
         working-directory: wg
-        run: go build -o "${{ runner.temp }}/relaywg-client.exe" ./cmd/relaywg-client
+        # Its own directory: wintun.dll has to sit beside the executable, which
+        # is also how it will sit beside Relay.exe once installed.
+        run: go build -o "${{ runner.temp }}/client/relaywg-client.exe" ./cmd/relaywg-client
 
       # wintun.dll is not linked in: the library loads it at runtime from the
       # executable's own directory, which is also how it will sit next to
@@ -149,18 +151,23 @@ jobs:
             Write-Error "wintun.zip hash is $actual, expected $expected"
           }
           Expand-Archive -Path $zip -DestinationPath "$env:RUNNER_TEMP\wintun" -Force
-          Copy-Item "$env:RUNNER_TEMP\wintun\wintun\bin\amd64\wintun.dll" "$env:RUNNER_TEMP\wintun.dll"
-          Get-Item "$env:RUNNER_TEMP\wintun.dll" | Format-List Name, Length
+          Copy-Item "$env:RUNNER_TEMP\wintun\wintun\bin\amd64\wintun.dll" "$env:RUNNER_TEMP\client\wintun.dll"
+          Get-Item "$env:RUNNER_TEMP\client\wintun.dll" | Format-List Name, Length
 
       - name: Bring up a real adapter and route through it
         working-directory: wg
         shell: pwsh
         env:
-          RELAYWG_CLIENT: ${{ runner.temp }}\relaywg-client.exe
+          RELAYWG_CLIENT: ${{ runner.temp }}\client\relaywg-client.exe
         run: |
           $ErrorActionPreference = 'Stop'
-          Copy-Item "$env:RUNNER_TEMP\wintun.dll" (Split-Path $env:RELAYWG_CLIENT) -Force
-          whoami /groups | Select-String 'S-1-5-32-544' | Out-Null
+          # Named so a failure to create the adapter can be read as "not
+          # elevated" rather than guessed at.
+          $admin = ([Security.Principal.WindowsPrincipal] `
+            [Security.Principal.WindowsIdentity]::GetCurrent()
+          ).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+          Write-Host "Running as Administrator: $admin"
+          Get-ChildItem (Split-Path $env:RELAYWG_CLIENT) | Format-Table Name, Length
           go test -count=1 -v -timeout 15m ./cmd/relaywg-client
 
       - name: The machine's networking must be as we found it

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -107,6 +107,72 @@ jobs:
           path: e2e-out/**
           if-no-files-found: warn
 
+  # Full Mode's Windows half, on a real Windows machine.
+  #
+  # This is the only job in the lab that creates a network adapter. Everything
+  # about the client that can fail only on Windows lives here: WinTun needs
+  # Administrator, the address and metric and routes are Windows APIs, and the
+  # teardown has to leave the machine's networking as it found it.
+  windows-full-mode:
+    name: Full Mode client (WinTun adapter)
+    runs-on: windows-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: wg/go.sum
+
+      - name: Build the client
+        working-directory: wg
+        run: go build -o "${{ runner.temp }}/relaywg-client.exe" ./cmd/relaywg-client
+
+      # wintun.dll is not linked in: the library loads it at runtime from the
+      # executable's own directory, which is also how it will sit next to
+      # Relay.exe once installed.
+      - name: Fetch WinTun
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          $zip = "$env:RUNNER_TEMP\wintun.zip"
+          Invoke-WebRequest -Uri 'https://www.wintun.net/builds/wintun-0.14.1.zip' -OutFile $zip
+          # Pinned by hash: this DLL ends up inside the installer, and a
+          # silently changed build of it is a supply-chain problem, not an
+          # inconvenience.
+          $expected = '07c256185d6ee3652e09fa55c0b673e2624b565e02c4b9091c79ca7d2f24ef51'
+          $actual = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $expected) {
+            Write-Error "wintun.zip hash is $actual, expected $expected"
+          }
+          Expand-Archive -Path $zip -DestinationPath "$env:RUNNER_TEMP\wintun" -Force
+          Copy-Item "$env:RUNNER_TEMP\wintun\wintun\bin\amd64\wintun.dll" "$env:RUNNER_TEMP\wintun.dll"
+          Get-Item "$env:RUNNER_TEMP\wintun.dll" | Format-List Name, Length
+
+      - name: Bring up a real adapter and route through it
+        working-directory: wg
+        shell: pwsh
+        env:
+          RELAYWG_CLIENT: ${{ runner.temp }}\relaywg-client.exe
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Copy-Item "$env:RUNNER_TEMP\wintun.dll" (Split-Path $env:RELAYWG_CLIENT) -Force
+          whoami /groups | Select-String 'S-1-5-32-544' | Out-Null
+          go test -count=1 -v -timeout 15m ./cmd/relaywg-client
+
+      - name: The machine's networking must be as we found it
+        if: always()
+        shell: pwsh
+        run: |
+          $left = Get-NetAdapter -Name 'RelayTest' -ErrorAction SilentlyContinue
+          if ($left) {
+            Write-Error "The test left an adapter behind: $($left.Name)"
+          }
+          Write-Host "No Relay adapters remain."
+
   android-device:
     name: Android device (API ${{ matrix.api }})
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,6 +182,52 @@ jobs:
             }
           }
 
+      # Full Mode's tunnel process, and the driver library it loads. Both go
+      # into the publish directory, which is what the installer packages, so
+      # they land beside Relay.exe -- wintun.dll is loaded from the executable's
+      # own directory, so the three travel together or Full Mode is not there.
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+          cache-dependency-path: wg/go.sum
+
+      - name: Build the Full Mode client and bundle WinTun
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          $zip = "$env:RUNNER_TEMP\wintun.zip"
+          Invoke-WebRequest -Uri 'https://www.wintun.net/builds/wintun-0.14.1.zip' -OutFile $zip
+          # Pinned: this DLL ships inside the installer, so a silently changed
+          # build of it is a supply-chain problem rather than an inconvenience.
+          $expected = '07c256185d6ee3652e09fa55c0b673e2624b565e02c4b9091c79ca7d2f24ef51'
+          $actual = (Get-FileHash $zip -Algorithm SHA256).Hash.ToLower()
+          if ($actual -ne $expected) { Write-Error "wintun.zip hash is $actual, expected $expected" }
+          Expand-Archive -Path $zip -DestinationPath "$env:RUNNER_TEMP\wintun" -Force
+
+          # amd64 for the x64 installer, x86 for the 32-bit one: a mismatched
+          # DLL fails at load with a message about the file being invalid,
+          # which reads as a corrupt download rather than a wrong build.
+          $targets = @{ 'x64' = @{ goarch = 'amd64'; dll = 'amd64' }
+                        'x86' = @{ goarch = '386';   dll = 'x86'   } }
+          foreach ($arch in $targets.Keys) {
+            $out = "$env:GITHUB_WORKSPACE\publish-$arch"
+            $env:GOOS = 'windows'
+            $env:GOARCH = $targets[$arch].goarch
+            Push-Location wg
+            go build -o "$out\relaywg-client.exe" ./cmd/relaywg-client
+            if ($LASTEXITCODE -ne 0) { Pop-Location; Write-Error "building the client for $arch failed" }
+            Pop-Location
+            Copy-Item "$env:RUNNER_TEMP\wintun\wintun\bin\$($targets[$arch].dll)\wintun.dll" "$out\wintun.dll" -Force
+            # A release whose Full Mode is quietly absent is the failure this
+            # whole feature already had once, on Android.
+            foreach ($file in 'relaywg-client.exe', 'wintun.dll') {
+              if (-not (Test-Path "$out\$file")) { Write-Error "$file is missing from publish-$arch" }
+            }
+            Get-Item "$out\relaywg-client.exe", "$out\wintun.dll" | Format-Table Name, Length
+          }
+
       - name: Build installers
         shell: pwsh
         run: |

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -37,6 +37,10 @@ Input-validation codes (bad scan / bad typed code) never touch the system and re
 | `ERR_FIREWALL_BLOCKED` | Error | Local connect refused/blocked in a way consistent with a firewall rule | Allow Relay through Windows Firewall (or your security software), then try again |
 | `ERR_PROXY_APPLY_FAILED` | Error | Applied proxy didn't verify on read-back (rolled back) | Close other proxy/VPN managers and try again |
 | `ERR_ROLLBACK_INCOMPLETE` | Error | Disconnect couldn't restore the snapshot (backup kept) | Press Disconnect again to retry the restore |
+| `ERR_WG_ELEVATION_DECLINED` | Error | Full Mode's elevation prompt was dismissed | Choose Yes on the prompt, or switch the phone to Fast Mode |
+| `ERR_WG_START_FAILED` | Error | The tunnel process did not come up (no adapter, or the configuration was refused) | Close any other VPN, then try again — or switch the phone to Fast Mode |
+| `ERR_WG_ALREADY_RUNNING` | Error | A tunnel is already up; a second would fight it for the adapter | Disconnect first |
+| `ERR_WG_STOP_FAILED` | Error | The tunnel process would not exit | Restart Relay; the adapter and its routes go when it exits |
 | `ERR_CAMERA_DENIED` | Error | Camera unavailable or access denied | Allow camera access for desktop apps in Windows Settings → Privacy, or enter the code manually |
 
 ## Design rules

--- a/wg/cmd/relaywg-client/main.go
+++ b/wg/cmd/relaywg-client/main.go
@@ -8,16 +8,24 @@
 // keeps that property for everything except the mode that genuinely cannot have
 // it, and keeps the elevation prompt tied to a single visible action.
 //
-// The configuration arrives on **stdin**, never as a file. It carries the
+// The configuration is handed over a stream, never as a file. It carries the
 // client's private key, and a key written to a temp file survives a crash, a
-// backup, and anyone reading the disk afterwards.
+// backup, and anyone reading the disk afterwards. A command line is no better:
+// any process on the machine can read one.
 //
-// Protocol with the parent process:
+// Protocol with the parent process, over a named pipe (-config-pipe) or over
+// stdin and stdout when run by hand:
 //
-//	stdin   the wireguard-go IPC configuration, then EOF
-//	stdout  "READY\n" once traffic can flow, then nothing
+//	in      the wireguard-go IPC configuration, ended by "END-CONFIG"
+//	out     "READY" once traffic can flow, then nothing
 //	stderr  human-readable progress and errors
-//	exit    tear the tunnel down when stdin closes, or on Ctrl+Break
+//	exit    tear the tunnel down when the stream closes, or on Ctrl+Break
+//
+// The stream stays open for the life of the tunnel, which is what makes its
+// closing mean "the app is gone" -- including the app crashing, the case that
+// matters, because a tunnel nobody is watching still holds the machine's
+// routes. That is also why the configuration ends with a sentinel rather than
+// with EOF: reading to EOF would consume the very signal being waited on.
 //
 // The adapter disappears when this process exits, by any route including being
 // killed: WinTun removes it with the last handle. That is what makes the
@@ -62,17 +70,30 @@ func main() {
 	address := flag.String("address", "10.13.37.2/32", "this end of the tunnel")
 	dns := flag.String("dns", "", "DNS server to set on the adapter; empty leaves it alone")
 	routes := flag.String("routes", "0.0.0.0/0", "comma-separated prefixes to send through the tunnel")
+	pipe := flag.String("config-pipe", "",
+		"named pipe carrying the configuration and readiness; stdin/stdout when empty")
 	flag.Parse()
 
-	if err := run(*name, *address, *dns, *routes); err != nil {
+	if err := run(*name, *address, *dns, *routes, *pipe); err != nil {
 		fmt.Fprintf(os.Stderr, "relaywg-client: %v\n", err)
 		os.Exit(1)
 	}
 }
 
-func run(name, address, dns, routes string) error {
-	stdin := bufio.NewReader(os.Stdin)
-	config, parentGone, err := readConfig(stdin)
+func run(name, address, dns, routes, pipe string) error {
+	// The app talks over a named pipe rather than stdin, because a process
+	// launched through the elevation prompt cannot have its streams redirected
+	// at all -- and the only other way to hand it a private key would be a temp
+	// file, which is exactly what should not exist. Stdin remains for running
+	// this by hand, and for the tests.
+	channel, err := openChannel(pipe)
+	if err != nil {
+		return err
+	}
+	defer channel.Close()
+
+	reader := bufio.NewReader(channel)
+	config, parentGone, err := readConfig(reader)
 	if err != nil {
 		return err
 	}
@@ -117,10 +138,11 @@ func run(name, address, dns, routes string) error {
 	}
 
 	fmt.Fprintf(os.Stderr, "tunnel up on %s via %q\n", prefix, name)
-	fmt.Println("READY")
-	os.Stdout.Sync()
+	if _, err := io.WriteString(channel, "READY\n"); err != nil {
+		return fmt.Errorf("reporting readiness: %w", err)
+	}
 
-	waitForShutdown(stdin, parentGone)
+	waitForShutdown(reader, parentGone)
 	fmt.Fprintln(os.Stderr, "tearing down")
 	// The deferred Close calls remove the adapter, and Windows drops its
 	// addresses and routes with it.
@@ -202,6 +224,32 @@ func parsePrefixes(list string) ([]netip.Prefix, error) {
 	return parsed, nil
 }
 
+// openChannel returns the stream the configuration arrives on and readiness is
+// reported over: a named pipe when one is given, otherwise stdin and stdout.
+//
+// The pipe is opened read-write and stays open for the life of the tunnel. Its
+// closing is how this process learns the app has gone -- including the app
+// crashing, which is the case that matters, because a tunnel nobody is watching
+// still holds the machine's routes.
+func openChannel(pipe string) (io.ReadWriteCloser, error) {
+	if pipe == "" {
+		return stdioChannel{}, nil
+	}
+	path := `\\.\pipe\` + pipe
+	handle, err := os.OpenFile(path, os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("opening %s: %w", path, err)
+	}
+	return handle, nil
+}
+
+// stdioChannel reads from stdin and writes to stdout as one stream.
+type stdioChannel struct{}
+
+func (stdioChannel) Read(p []byte) (int, error)  { return os.Stdin.Read(p) }
+func (stdioChannel) Write(p []byte) (int, error) { return os.Stdout.Write(p) }
+func (stdioChannel) Close() error                { return nil }
+
 // readConfig reads the IPC configuration up to [configTerminator], and reports
 // whether stdin reached EOF while doing so.
 //
@@ -245,7 +293,7 @@ func readConfig(stdin *bufio.Reader) (config string, parentGone bool, err error)
 // Both matter. The parent closing stdin is the ordinary Disconnect; the signal
 // is what a person pressing Ctrl+C in a console window sends. Waiting on only
 // one of them leaves a tunnel running with nobody watching it.
-func waitForShutdown(stdin *bufio.Reader, parentAlreadyGone bool) {
+func waitForShutdown(channel *bufio.Reader, parentAlreadyGone bool) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 
@@ -256,7 +304,7 @@ func waitForShutdown(stdin *bufio.Reader, parentAlreadyGone bool) {
 
 	closed := make(chan struct{})
 	go func() {
-		io.Copy(io.Discard, stdin)
+		io.Copy(io.Discard, channel)
 		close(closed)
 	}()
 

--- a/wg/cmd/relaywg-client/main.go
+++ b/wg/cmd/relaywg-client/main.go
@@ -1,0 +1,267 @@
+// Command relaywg-client is the Windows half of Full Mode: it stands up a
+// WinTun adapter and runs a userspace WireGuard tunnel to the phone.
+//
+// It exists as a separate executable rather than as code inside the app for one
+// reason: creating a network adapter and changing routes requires
+// Administrator, and Relay is deliberately a per-user install that never asks
+// for it (ADR-0005). Putting the privileged part in its own short-lived process
+// keeps that property for everything except the mode that genuinely cannot have
+// it, and keeps the elevation prompt tied to a single visible action.
+//
+// The configuration arrives on **stdin**, never as a file. It carries the
+// client's private key, and a key written to a temp file survives a crash, a
+// backup, and anyone reading the disk afterwards.
+//
+// Protocol with the parent process:
+//
+//	stdin   the wireguard-go IPC configuration, then EOF
+//	stdout  "READY\n" once traffic can flow, then nothing
+//	stderr  human-readable progress and errors
+//	exit    tear the tunnel down when stdin closes, or on Ctrl+Break
+//
+// The adapter disappears when this process exits, by any route including being
+// killed: WinTun removes it with the last handle. That is what makes the
+// teardown safe rather than merely careful -- the routes go with it, so there
+// is no state left behind for a crash to strand.
+package main
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/netip"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+	"golang.zx2c4.com/wireguard/conn"
+	"golang.zx2c4.com/wireguard/device"
+	"golang.zx2c4.com/wireguard/tun"
+	"golang.zx2c4.com/wireguard/windows/tunnel/winipcfg"
+)
+
+const (
+	// Matches the endpoint's MTU (/wg/relaywg.go). A mismatch shows up as large
+	// replies vanishing while small ones work, which reads like a broken site.
+	mtu = 1420
+
+	// Lower than any physical adapter's, so the tunnel wins for the prefixes it
+	// is given without having to delete anyone else's routes.
+	routeMetric = 5
+
+	// Ends the configuration on stdin without closing it. See [readConfig].
+	configTerminator = "END-CONFIG"
+)
+
+func main() {
+	name := flag.String("name", "Relay", "adapter name")
+	address := flag.String("address", "10.13.37.2/32", "this end of the tunnel")
+	dns := flag.String("dns", "", "DNS server to set on the adapter; empty leaves it alone")
+	routes := flag.String("routes", "0.0.0.0/0", "comma-separated prefixes to send through the tunnel")
+	flag.Parse()
+
+	if err := run(*name, *address, *dns, *routes); err != nil {
+		fmt.Fprintf(os.Stderr, "relaywg-client: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(name, address, dns, routes string) error {
+	stdin := bufio.NewReader(os.Stdin)
+	config, parentGone, err := readConfig(stdin)
+	if err != nil {
+		return err
+	}
+
+	prefix, err := netip.ParsePrefix(address)
+	if err != nil {
+		return fmt.Errorf("address %q: %w", address, err)
+	}
+	tunnelRoutes, err := parsePrefixes(routes)
+	if err != nil {
+		return err
+	}
+
+	// Creating the adapter is the step that needs Administrator. Its failure is
+	// the one a person is most likely to hit, so it is reported on its own
+	// rather than folded into a generic "could not start".
+	adapter, err := tun.CreateTUN(name, mtu)
+	if err != nil {
+		return fmt.Errorf("could not create the %q adapter (Administrator required): %w", name, err)
+	}
+	defer adapter.Close()
+
+	native, ok := adapter.(*tun.NativeTun)
+	if !ok {
+		return errors.New("the adapter is not a WinTun device")
+	}
+	luid := winipcfg.LUID(native.LUID())
+
+	dev := device.NewDevice(adapter, conn.NewDefaultBind(),
+		device.NewLogger(device.LogLevelError, "relaywg-client: "))
+	defer dev.Close()
+
+	if err := dev.IpcSet(config); err != nil {
+		return fmt.Errorf("the configuration was rejected: %w", err)
+	}
+	if err := dev.Up(); err != nil {
+		return fmt.Errorf("the tunnel did not come up: %w", err)
+	}
+
+	if err := configureAdapter(luid, prefix, dns, tunnelRoutes); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr, "tunnel up on %s via %q\n", prefix, name)
+	fmt.Println("READY")
+	os.Stdout.Sync()
+
+	waitForShutdown(stdin, parentGone)
+	fmt.Fprintln(os.Stderr, "tearing down")
+	// The deferred Close calls remove the adapter, and Windows drops its
+	// addresses and routes with it.
+	return nil
+}
+
+// configureAdapter gives the tunnel its address, DNS and routes.
+//
+// Order matters: the address has to exist before a route can point at the
+// interface, and the interface metric has to be set before the routes or
+// Windows may prefer the physical adapter for the same prefix.
+func configureAdapter(luid winipcfg.LUID, prefix netip.Prefix, dns string, routes []netip.Prefix) error {
+	if err := luid.SetIPAddressesForFamily(windows.AF_INET, []netip.Prefix{prefix}); err != nil {
+		return fmt.Errorf("setting %s on the adapter: %w", prefix, err)
+	}
+
+	iface, err := luid.IPInterface(windows.AF_INET)
+	if err != nil {
+		return fmt.Errorf("reading the adapter's IP settings: %w", err)
+	}
+	iface.NLMTU = mtu
+	iface.UseAutomaticMetric = false
+	iface.Metric = routeMetric
+	// Without this Windows sends router solicitations out of a point-to-point
+	// tunnel that has no router, which shows up as a delay before traffic flows.
+	iface.RouterDiscoveryBehavior = winipcfg.RouterDiscoveryDisabled
+	iface.DadTransmits = 0
+	if err := iface.Set(); err != nil {
+		return fmt.Errorf("applying the adapter's IP settings: %w", err)
+	}
+
+	if dns != "" {
+		server, err := netip.ParseAddr(dns)
+		if err != nil {
+			return fmt.Errorf("dns %q: %w", dns, err)
+		}
+		if err := luid.SetDNS(windows.AF_INET, []netip.Addr{server}, nil); err != nil {
+			return fmt.Errorf("setting DNS: %w", err)
+		}
+	}
+
+	// Deliberately additive. Nothing here deletes or rewrites an existing route:
+	// the tunnel's default route wins on metric while it exists and disappears
+	// with the adapter, so a crash cannot strand a machine with a route to
+	// somewhere that is gone. The phone itself stays reachable because it sits
+	// on the local subnet, whose on-link route is more specific than 0.0.0.0/0
+	// and stays on the physical adapter -- which is also what stops the tunnel's
+	// own UDP from being routed into itself.
+	data := make([]*winipcfg.RouteData, 0, len(routes))
+	for _, route := range routes {
+		data = append(data, &winipcfg.RouteData{
+			Destination: route,
+			NextHop:     netip.IPv4Unspecified(),
+			Metric:      0,
+		})
+	}
+	if err := luid.SetRoutesForFamily(windows.AF_INET, data); err != nil {
+		return fmt.Errorf("setting routes: %w", err)
+	}
+	return nil
+}
+
+func parsePrefixes(list string) ([]netip.Prefix, error) {
+	parsed := []netip.Prefix{}
+	for _, item := range strings.Split(list, ",") {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		prefix, err := netip.ParsePrefix(item)
+		if err != nil {
+			return nil, fmt.Errorf("route %q: %w", item, err)
+		}
+		parsed = append(parsed, prefix)
+	}
+	if len(parsed) == 0 {
+		return nil, errors.New("no routes to install — the tunnel would carry nothing")
+	}
+	return parsed, nil
+}
+
+// readConfig reads the IPC configuration up to [configTerminator], and reports
+// whether stdin reached EOF while doing so.
+//
+// The terminator exists because stdin is two things at once: the way the
+// configuration arrives, and the way this process learns its parent is gone.
+// Reading to EOF for the first would consume the second, and the tunnel would
+// tear itself down the instant it came up.
+//
+// Reaching EOF instead of the terminator is not an error — that is what
+// `type relay.conf | relaywg-client` looks like, and it is a reasonable way to
+// run this by hand. It only means the parent is already gone, so Ctrl+Break
+// becomes the only way out.
+func readConfig(stdin *bufio.Reader) (config string, parentGone bool, err error) {
+	var builder strings.Builder
+	for {
+		line, readErr := stdin.ReadString('\n')
+		trimmed := strings.TrimRight(line, "\r\n")
+		if trimmed == configTerminator {
+			break
+		}
+		if trimmed != "" {
+			builder.WriteString(trimmed)
+			builder.WriteByte('\n')
+		}
+		if readErr != nil {
+			if !errors.Is(readErr, io.EOF) {
+				return "", true, fmt.Errorf("reading the configuration: %w", readErr)
+			}
+			parentGone = true
+			break
+		}
+	}
+	if builder.Len() == 0 {
+		return "", parentGone, errors.New("no configuration on stdin")
+	}
+	return builder.String(), parentGone, nil
+}
+
+// waitForShutdown returns when the parent goes away or the console interrupts.
+//
+// Both matter. The parent closing stdin is the ordinary Disconnect; the signal
+// is what a person pressing Ctrl+C in a console window sends. Waiting on only
+// one of them leaves a tunnel running with nobody watching it.
+func waitForShutdown(stdin *bufio.Reader, parentAlreadyGone bool) {
+	signals := make(chan os.Signal, 1)
+	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
+
+	if parentAlreadyGone {
+		<-signals
+		return
+	}
+
+	closed := make(chan struct{})
+	go func() {
+		io.Copy(io.Discard, stdin)
+		close(closed)
+	}()
+
+	select {
+	case <-signals:
+	case <-closed:
+	}
+}

--- a/wg/cmd/relaywg-client/tunnel_windows_test.go
+++ b/wg/cmd/relaywg-client/tunnel_windows_test.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bufio"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/crypto/curve25519"
+
+	relaywg "github.com/Mahdi-mortazavi/relay/wg"
+)
+
+// The Windows half of Full Mode, against the real Windows networking stack.
+//
+// What this can prove, and what it deliberately does not try to:
+//
+// The endpoint's own suite already puts real TCP and UDP through a real tunnel,
+// in a process and on a device. What none of that touches is the part of the
+// Windows client that can only fail on Windows: creating a WinTun adapter,
+// which needs Administrator; giving it an address, a metric and routes; and
+// tearing all of it down again without stranding the machine.
+//
+// A full "browse the web through the tunnel" test is not possible on one
+// machine, and pretending otherwise would produce a test that passes for the
+// wrong reason. Both ends share a single routing table, so any destination
+// routed into the tunnel is also routed into the tunnel when the endpoint tries
+// to forward it onward -- traffic would loop rather than reach anything. So
+// this proves the two things that are genuinely Windows-specific and genuinely
+// untested elsewhere:
+//
+//  1. the adapter comes up, and WireGuard completes a handshake across it;
+//  2. Windows really routes the prefixes it is given into that adapter --
+//     measured at the endpoint, which decrypts what arrives.
+//
+// Needs Administrator. On a GitHub runner that is the default; on a desk it is
+// not, and the test says so rather than failing obscurely.
+func TestTheAdapterComesUpAndCarriesRoutedTraffic(t *testing.T) {
+	binary := os.Getenv("RELAYWG_CLIENT")
+	if binary == "" {
+		t.Skip("RELAYWG_CLIENT is not set; CI builds the client and points this at it")
+	}
+
+	serverPrivate, serverPublic := keyPair(t)
+	clientPrivate, clientPublic := keyPair(t)
+	port := freeUDPPort(t)
+
+	// The phone, in this process.
+	endpoint, err := relaywg.Start(fmt.Sprintf(
+		"private_key=%s\nlisten_port=%d\npublic_key=%s\nallowed_ip=10.13.37.2/32\n",
+		serverPrivate, port, clientPublic))
+	if err != nil {
+		t.Fatalf("the endpoint did not start: %v", err)
+	}
+	defer endpoint.Stop()
+
+	// The laptop. Routes a documentation prefix rather than 0.0.0.0/0: taking
+	// over the default route on the machine running the test would cut the
+	// runner off from GitHub, and the claim under test is "Windows routes what
+	// it is told into this adapter", which a /24 shows exactly as well.
+	client := exec.Command(binary,
+		"-name", "RelayTest",
+		"-address", "10.13.37.2/32",
+		"-routes", "198.51.100.0/24",
+	)
+	stdin, err := client.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin: %v", err)
+	}
+	stdout, err := client.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout: %v", err)
+	}
+	client.Stderr = os.Stderr
+	if err := client.Start(); err != nil {
+		t.Fatalf("starting the client: %v", err)
+	}
+	defer func() {
+		stdin.Close()
+		client.Wait()
+	}()
+
+	fmt.Fprintf(stdin, "private_key=%s\npublic_key=%s\nendpoint=127.0.0.1:%d\n"+
+		"allowed_ip=0.0.0.0/0\npersistent_keepalive_interval=1\n%s\n",
+		clientPrivate, serverPublic, port, configTerminator)
+
+	waitForReady(t, stdout, client)
+
+	// The handshake. Nothing else in the suite proves that the configuration
+	// this client assembles is one the endpoint accepts across a real adapter.
+	deadline := time.Now().Add(30 * time.Second)
+	for endpoint.LastHandshakeUnix() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("no WireGuard handshake within 30s of the adapter coming up")
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// And the routing. A connection to the routed prefix cannot complete -- the
+	// endpoint would have to forward it back to itself -- but that is not what
+	// is being measured. What is measured is that the packets left through the
+	// adapter and the endpoint decrypted them, which can only happen if Windows
+	// really picked this interface for that prefix.
+	before := endpoint.BytesReceived()
+	go func() {
+		conn, err := net.DialTimeout("tcp", "198.51.100.5:80", 5*time.Second)
+		if err == nil {
+			conn.Close()
+		}
+	}()
+
+	deadline = time.Now().Add(20 * time.Second)
+	for endpoint.BytesReceived() <= before {
+		if time.Now().After(deadline) {
+			t.Fatalf("nothing arrived at the endpoint: Windows did not route "+
+				"198.51.100.0/24 into the adapter (rx stuck at %d)", before)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// Teardown: closing stdin is what the app does on Disconnect, and the
+	// adapter must go with the process. A tunnel adapter left behind holds its
+	// routes, and the machine keeps sending traffic somewhere that is gone.
+	stdin.Close()
+	done := make(chan error, 1)
+	go func() { done <- client.Wait() }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("the client exited badly: %v", err)
+		}
+	case <-time.After(20 * time.Second):
+		client.Process.Kill()
+		t.Fatal("the client did not exit when its parent closed stdin")
+	}
+
+	if adapterExists(t, "RelayTest") {
+		t.Error("the adapter is still there after the client exited")
+	}
+}
+
+func waitForReady(t *testing.T, stdout io.Reader, client *exec.Cmd) {
+	t.Helper()
+	ready := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			if strings.TrimSpace(scanner.Text()) == "READY" {
+				ready <- "READY"
+				return
+			}
+		}
+		ready <- ""
+	}()
+
+	select {
+	case line := <-ready:
+		if line == "" {
+			t.Fatal("the client exited before it was ready — most likely not running as Administrator")
+		}
+	case <-time.After(60 * time.Second):
+		client.Process.Kill()
+		t.Fatal("the client never reported READY")
+	}
+}
+
+// adapterExists asks Windows, not the client, whether the adapter is gone.
+func adapterExists(t *testing.T, name string) bool {
+	t.Helper()
+	// Give Windows a moment: the adapter is removed as the process exits, and
+	// the interface list can lag that by a beat.
+	for i := 0; i < 20; i++ {
+		out, err := exec.Command("powershell", "-NoProfile", "-Command",
+			fmt.Sprintf("if (Get-NetAdapter -Name '%s' -ErrorAction SilentlyContinue) { 'yes' } else { 'no' }", name),
+		).Output()
+		if err == nil && strings.TrimSpace(string(out)) == "no" {
+			return false
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return true
+}
+
+func keyPair(t *testing.T) (private, public string) {
+	t.Helper()
+	var priv [32]byte
+	if _, err := io.ReadFull(rand.Reader, priv[:]); err != nil {
+		t.Fatalf("key generation: %v", err)
+	}
+	priv[0] &= 248
+	priv[31] &= 127
+	priv[31] |= 64
+	pub, err := curve25519.X25519(priv[:], curve25519.Basepoint)
+	if err != nil {
+		t.Fatalf("public key: %v", err)
+	}
+	return hex.EncodeToString(priv[:]), hex.EncodeToString(pub)
+}
+
+func freeUDPPort(t *testing.T) int {
+	t.Helper()
+	c, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("no free port: %v", err)
+	}
+	defer c.Close()
+	return c.LocalAddr().(*net.UDPAddr).Port
+}

--- a/wg/go.mod
+++ b/wg/go.mod
@@ -18,4 +18,5 @@ require (
 	golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
 	golang.org/x/tools v0.48.0 // indirect
 	golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 // indirect
+	golang.zx2c4.com/wireguard/windows v1.0.1 // indirect
 )

--- a/wg/go.sum
+++ b/wg/go.sum
@@ -22,5 +22,7 @@ golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2 h1:B82qJJgjvYKsXS9jeu
 golang.zx2c4.com/wintun v0.0.0-20230126152724-0fa3db229ce2/go.mod h1:deeaetjYA+DHMHg+sMSMI58GrEteJUUzzw7en6TJQcI=
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173 h1:/jFs0duh4rdb8uIfPMv78iAJGcPKDeqAFnaLBropIC4=
 golang.zx2c4.com/wireguard v0.0.0-20231211153847-12269c276173/go.mod h1:tkCQ4FQXmpAgYVh++1cq16/dH4QJtmvpRv19DWGAHSA=
+golang.zx2c4.com/wireguard/windows v1.0.1 h1:eOxiDVbywPC+ZQqvdCK7x+ZwWXKbYv50TtH8ysFIbw8=
+golang.zx2c4.com/wireguard/windows v1.0.1/go.mod h1:+fbT3FFdX4zzYDLwJh5+HPEcNN/3HyNdzhNSVsQM+zs=
 gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259 h1:TbRPT0HtzFP3Cno1zZo7yPzEEnfu8EjLfl6IU9VfqkQ=
 gvisor.dev/gvisor v0.0.0-20230927004350-cbd86285d259/go.mod h1:AVgIgHMwK63XvmAzWG9vLQ41YnVHN0du0tEC46fI7yY=

--- a/windows/Relay.App.Tests/WgTunnelSessionTests.cs
+++ b/windows/Relay.App.Tests/WgTunnelSessionTests.cs
@@ -1,0 +1,189 @@
+using Relay.Core;
+using Xunit;
+
+namespace Relay.App.Tests;
+
+/// <summary>
+/// The tunnel's lifecycle, against a stub process.
+///
+/// What a machine with no adapter and no elevation can still prove is most of
+/// what goes wrong in practice: that the configuration reaches the child in the
+/// form it expects, that a declined elevation prompt is reported as itself
+/// rather than as a broken tunnel, that a child which never becomes ready is
+/// not left running, and that Disconnect actually stops something. The adapter
+/// coming up is proven on a real Windows runner by the client's own test.
+/// </summary>
+public class WgTunnelSessionTests
+{
+    private const string ClientPrivate = "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=";
+    private const string ServerPublic = "ICEiIyQlJicoKSorLC0uLzAxMjM0NTY3ODk6Ozw9Pj8=";
+
+    private static WgParams Params() => new()
+    {
+        ServerPublicKey = ServerPublic,
+        ClientPrivateKey = ClientPrivate,
+        AllowedIps = "0.0.0.0/0",
+        EndpointPort = 51820,
+        Dns = "1.1.1.1",
+    };
+
+    private sealed class StubProcess : WgTunnelSession.IProcessHandle
+    {
+        public readonly List<string> Written = [];
+        public Queue<string?> Output = new();
+        public bool InputClosed;
+        public bool Killed;
+        public bool Disposed;
+        public bool ExitsOnClose = true;
+        private bool _exited;
+
+        public bool HasExited => _exited;
+        public void WriteLine(string line) => Written.Add(line);
+        public string? ReadLine() => Output.Count > 0 ? Output.Dequeue() : null;
+        public void CloseInput()
+        {
+            InputClosed = true;
+            if (ExitsOnClose) _exited = true;
+        }
+        public bool WaitForExit(TimeSpan timeout) => _exited;
+        public void Kill() { Killed = true; _exited = true; }
+        public void Dispose() => Disposed = true;
+    }
+
+    private sealed class StubHost(StubProcess process) : WgTunnelSession.IProcessHost
+    {
+        public string? Arguments;
+        public int Starts;
+        public Exception? ThrowOnStart;
+
+        public WgTunnelSession.IProcessHandle Start(string arguments)
+        {
+            Starts++;
+            Arguments = arguments;
+            if (ThrowOnStart is not null) throw ThrowOnStart;
+            return process;
+        }
+    }
+
+    private static StubProcess ReadyProcess()
+    {
+        var process = new StubProcess();
+        process.Output.Enqueue("READY");
+        return process;
+    }
+
+    [Fact]
+    public void ConnectHandsTheChildTheIpcConfigurationAndTheTerminator()
+    {
+        var process = ReadyProcess();
+        var session = new WgTunnelSession(new StubHost(process));
+
+        Assert.True(session.Connect(Params(), "192.168.43.1").Ok);
+
+        // The dialect the client's WireGuard actually reads — hex keys, flat
+        // key=value — not the readable INI. The phone shipped four releases
+        // with that exact confusion.
+        Assert.Contains(process.Written, line => line.StartsWith("private_key=", StringComparison.Ordinal));
+        Assert.Contains(process.Written, line => line == "endpoint=192.168.43.1:51820");
+        Assert.DoesNotContain(process.Written, line => line.Contains("[Interface]", StringComparison.Ordinal));
+
+        // Without the terminator the child waits forever for a configuration it
+        // has already been given.
+        Assert.Equal(WgTunnelSession.ConfigTerminator, process.Written[^1]);
+    }
+
+    [Fact]
+    public void TheChildIsToldWhereToRouteAndWhatToCallItself()
+    {
+        var host = new StubHost(ReadyProcess());
+        new WgTunnelSession(host).Connect(Params(), "192.168.43.1");
+
+        Assert.Contains("-address 10.13.37.2/32", host.Arguments);
+        Assert.Contains("-routes 0.0.0.0/0", host.Arguments);
+        Assert.Contains("-dns 1.1.1.1", host.Arguments);
+    }
+
+    [Fact]
+    public void ADeclinedElevationPromptSaysSo()
+    {
+        // "Could not start the tunnel" would send someone looking at their
+        // network for something they did on purpose two seconds earlier.
+        var host = new StubHost(new StubProcess()) { ThrowOnStart = new WgTunnelSession.ElevationDeclined() };
+        var result = new WgTunnelSession(host).Connect(Params(), "192.168.43.1");
+
+        Assert.False(result.Ok);
+        Assert.Equal("ERR_WG_ELEVATION_DECLINED", result.ErrorCode);
+    }
+
+    [Fact]
+    public void AChildThatNeverBecomesReadyIsNotLeftRunning()
+    {
+        // The dangerous shape: a tunnel process alive with an adapter up, while
+        // the app believes nothing happened and shows an error.
+        var process = new StubProcess(); // no READY, stdout ends
+        var host = new StubHost(process);
+        var session = new WgTunnelSession(host);
+
+        var result = session.Connect(Params(), "192.168.43.1");
+
+        Assert.False(result.Ok);
+        Assert.Equal("ERR_WG_START_FAILED", result.ErrorCode);
+        Assert.True(process.InputClosed || process.Killed);
+        Assert.False(session.IsRunning);
+    }
+
+    [Fact]
+    public void AnUnusablePayloadIsRefusedBeforeAnythingIsStarted()
+    {
+        var host = new StubHost(ReadyProcess());
+        var broken = Params() with { AllowedIps = "" };
+
+        var result = new WgTunnelSession(host).Connect(broken, "192.168.43.1");
+
+        Assert.Equal("ERR_QR_INVALID", result.ErrorCode);
+        Assert.Equal(0, host.Starts); // nothing was elevated for a QR that cannot work
+    }
+
+    [Fact]
+    public void DisconnectClosesTheChildAndIsSafeToRepeat()
+    {
+        var process = ReadyProcess();
+        var session = new WgTunnelSession(new StubHost(process));
+        session.Connect(Params(), "192.168.43.1");
+
+        Assert.True(session.IsRunning);
+        Assert.True(session.Disconnect().Ok);
+        Assert.True(process.InputClosed);
+        Assert.False(session.IsRunning);
+
+        // Teardown runs on paths that are already unwinding from a failure.
+        Assert.True(session.Disconnect().Ok);
+    }
+
+    [Fact]
+    public void AChildThatWillNotLeaveIsKilled()
+    {
+        // The adapter goes with the process, so a wedged child is a machine
+        // still routing through a tunnel nobody is driving.
+        var process = ReadyProcess();
+        process.ExitsOnClose = false;
+        var session = new WgTunnelSession(new StubHost(process));
+        session.Connect(Params(), "192.168.43.1");
+
+        Assert.True(session.Disconnect().Ok);
+        Assert.True(process.Killed);
+    }
+
+    [Fact]
+    public void ASecondConnectDoesNotStartASecondTunnel()
+    {
+        var host = new StubHost(ReadyProcess());
+        var session = new WgTunnelSession(host);
+        session.Connect(Params(), "192.168.43.1");
+
+        var second = session.Connect(Params(), "192.168.43.1");
+
+        Assert.False(second.Ok);
+        Assert.Equal(1, host.Starts);
+    }
+}

--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -558,6 +558,13 @@ public sealed partial class MainWindow : Window
             "ERR_PROXY_APPLY_FAILED" => ("ErrTitleProxy", "ErrProxyApply", "TryAgain"),
             "ERR_ROLLBACK_INCOMPLETE" => ("ErrTitleRollback", "ErrRollback", "Disconnect"),
             "ERR_CAMERA_DENIED" => ("ErrTitleCamera", "ErrCameraDenied", "EnterCodeInstead"),
+            // Full Mode (ADR-0008). A declined elevation prompt is its own
+            // answer: "the tunnel failed" would send someone hunting their
+            // network for something they chose two seconds earlier.
+            "ERR_WG_ELEVATION_DECLINED" => ("ErrTitleElevation", "ErrWgElevationDeclined", "TryAgain"),
+            "ERR_WG_START_FAILED" => ("ErrTitleTunnel", "ErrWgStartFailed", "TryAgain"),
+            "ERR_WG_ALREADY_RUNNING" => ("ErrTitleTunnel", "ErrWgStartFailed", "TryAgain"),
+            "ERR_WG_STOP_FAILED" => ("ErrTitleTunnel", "ErrWgStopFailed", "TryAgain"),
             _ => ("ErrTitleProxy", "ErrProxyApply", "TryAgain"),
         };
 

--- a/windows/Relay.App/Services/AppController.cs
+++ b/windows/Relay.App/Services/AppController.cs
@@ -18,6 +18,14 @@ public sealed class AppController(IProxyStore proxyStore, IBackupStore backupSto
         new(new WinInetProxyStore(), new FileBackupStore());
 
     private readonly ProxySession _session = new(proxyStore, backupStore);
+
+    /// <summary>
+    /// Full Mode's tunnel. The client sits beside Relay.exe, with wintun.dll
+    /// next to it — the DLL is loaded from the executable's own directory, so
+    /// the two travel together or neither works.
+    /// </summary>
+    private readonly WgTunnelSession _tunnel = new(new ElevatedTunnelHost(
+        Path.Combine(AppContext.BaseDirectory, "relaywg-client.exe")));
     private readonly object _gate = new();
     private readonly object _sessionLock = new(); // serializes all _session IO
     private CancellationTokenSource? _supervisor;
@@ -44,6 +52,11 @@ public sealed class AppController(IProxyStore proxyStore, IBackupStore backupSto
     /// <summary>Full pairing flow from a decoded payload. Runs the blocking parts off the UI thread.</summary>
     public async Task ConnectAsync(QrPayload payload)
     {
+        if (payload.Mode == QrPayload.ModeWireguard)
+        {
+            await ConnectFullModeAsync(payload);
+            return;
+        }
         if (payload.Mode != QrPayload.ModeSocks5)
         {
             Fail("ERR_QR_NEWER_VERSION");
@@ -130,6 +143,35 @@ public sealed class AppController(IProxyStore proxyStore, IBackupStore backupSto
     public async Task DisconnectAsync()
     {
         StopSupervisor();
+
+        // Full Mode first: if a tunnel is up, that is what "connected" meant,
+        // and no proxy was ever applied to roll back.
+        if (_tunnel.IsRunning)
+        {
+            WgTunnelSession.Result stopped;
+            try
+            {
+                stopped = await TunnelDisconnectLocked();
+            }
+            catch (Exception ex)
+            {
+                LocalLog.Add($"Tunnel stop threw: {ex.Message}");
+                Fail("ERR_WG_STOP_FAILED");
+                return;
+            }
+            if (stopped.Ok)
+            {
+                LocalLog.Add("Disconnected (Full Mode)");
+                if (!Dispatch("stop")) Dispatch("dismiss");
+            }
+            else
+            {
+                LocalLog.Add($"Tunnel would not stop: {stopped.ErrorCode}");
+                Fail(stopped.ErrorCode!);
+            }
+            return;
+        }
+
         ProxySession.Result result;
         try
         {
@@ -156,6 +198,59 @@ public sealed class AppController(IProxyStore proxyStore, IBackupStore backupSto
         }
     }
 
+    /// <summary>
+    /// Full Mode (ADR-0008): a WireGuard tunnel to the phone instead of a
+    /// system proxy.
+    ///
+    /// Shorter than the Fast Mode path above, and the difference is real rather
+    /// than cosmetic. Relay changes nothing on this machine here — the adapter
+    /// and its routes belong to the tunnel process and vanish with it — so
+    /// there is no snapshot to take, no rollback to verify, and no recovery
+    /// hook to arm against a crash. There is also no probe: the tunnel reports
+    /// ready only after a WireGuard handshake, which is a stronger statement
+    /// than "something answered on that port".
+    /// </summary>
+    private async Task ConnectFullModeAsync(QrPayload payload)
+    {
+        if (payload.Wg is null)
+        {
+            // The decoder rejects this already; belt and braces, because the
+            // alternative is a NullReferenceException inside the tunnel.
+            Fail("ERR_QR_INVALID");
+            return;
+        }
+        if (!Dispatch("start", payload)) return;
+        LocalLog.Add($"Full Mode: dialling {payload.Host}:{payload.Port}");
+
+        WgTunnelSession.Result started;
+        try
+        {
+            started = await TunnelConnectLocked(payload.Wg, payload.Host);
+        }
+        catch (Exception ex)
+        {
+            LocalLog.Add($"Tunnel start threw: {ex.Message}");
+            Fail("ERR_WG_START_FAILED");
+            return;
+        }
+        if (!started.Ok)
+        {
+            LocalLog.Add($"Tunnel did not start: {started.ErrorCode}");
+            Fail(started.ErrorCode!);
+            return;
+        }
+
+        // A concurrent Disconnect may have moved us back to Idle while the
+        // adapter was coming up. Leaving it running would route the machine
+        // through a tunnel the UI says nothing about.
+        if (!Dispatch("ready"))
+        {
+            try { await TunnelDisconnectLocked(); } catch { }
+            return;
+        }
+        LocalLog.Add("Connected (Full Mode)");
+    }
+
     public void DismissError() => Dispatch("dismiss");
 
     // All ProxySession IO goes through these so a user Disconnect and the
@@ -165,6 +260,14 @@ public sealed class AppController(IProxyStore proxyStore, IBackupStore backupSto
 
     private Task<ProxySession.Result> DisconnectLocked() =>
         Task.Run(() => { lock (_sessionLock) return _session.Disconnect(); });
+
+    // Full Mode's tunnel shares the same lock: a user Disconnect and anything
+    // else touching the session must not overlap, exactly as for the proxy.
+    private Task<WgTunnelSession.Result> TunnelConnectLocked(WgParams wg, string host) =>
+        Task.Run(() => { lock (_sessionLock) return _tunnel.Connect(wg, host); });
+
+    private Task<WgTunnelSession.Result> TunnelDisconnectLocked() =>
+        Task.Run(() => { lock (_sessionLock) return _tunnel.Disconnect(); });
 
     // --- reconnect supervisor (ADR-0007) -------------------------------------
 

--- a/windows/Relay.App/Strings.cs
+++ b/windows/Relay.App/Strings.cs
@@ -72,6 +72,11 @@ public static class Strings
         ["ErrFirewall"] = "The connection was blocked. Allow Relay through Windows Firewall (or your security software), then try again.",
         ["ErrProxyApply"] = "Windows refused the proxy change. Close other proxy/VPN managers and try again.",
         ["ErrRollback"] = "Relay couldn't fully restore your proxy settings. Disconnect again to retry.",
+        ["ErrTitleElevation"] = "Full Mode needs permission",
+        ["ErrTitleTunnel"] = "The tunnel didn't start",
+        ["ErrWgElevationDeclined"] = "Full Mode has to create a network adapter, which Windows only allows with your permission. Choose Yes on the prompt, or switch the phone to Fast Mode.",
+        ["ErrWgStartFailed"] = "Relay couldn't bring the tunnel up. Close any other VPN that is running, then try again — or switch the phone to Fast Mode.",
+        ["ErrWgStopFailed"] = "The tunnel process wouldn't stop. Restart Relay; the adapter and its routes are removed when it exits.",
         ["ErrCameraDenied"] = "Relay can't use the camera — it may be missing, in use by another app, or blocked. Allow camera access in Windows Settings > Privacy, or enter the code manually.",
     };
 
@@ -127,6 +132,11 @@ public static class Strings
         ["ErrFirewall"] = "اتصال مسدود شد. به رله در فایروال ویندوز (یا نرم‌افزار امنیتی) اجازه دهید و دوباره تلاش کنید.",
         ["ErrProxyApply"] = "ویندوز تغییر پراکسی را نپذیرفت. مدیریت‌کننده‌های دیگر پراکسی/VPN را ببندید و دوباره تلاش کنید.",
         ["ErrRollback"] = "رله نتوانست تنظیمات پراکسی را کاملاً بازگرداند. برای تلاش دوباره، دوباره «قطع اتصال» را بزنید.",
+        ["ErrTitleElevation"] = "حالت کامل به اجازه نیاز دارد",
+        ["ErrTitleTunnel"] = "تونل بالا نیامد",
+        ["ErrWgElevationDeclined"] = "حالت کامل باید یک آداپتور شبکه بسازد و ویندوز این کار را فقط با اجازهٔ شما انجام می‌دهد. در پنجرهٔ ویندوز «بله» را بزنید، یا گوشی را روی حالت سریع بگذارید.",
+        ["ErrWgStartFailed"] = "رله نتوانست تونل را بالا بیاورد. اگر VPN دیگری روشن است ببندید و دوباره تلاش کنید — یا گوشی را روی حالت سریع بگذارید.",
+        ["ErrWgStopFailed"] = "پروسهٔ تونل بسته نشد. رله را دوباره اجرا کنید؛ آداپتور و مسیرهایش با بسته شدن آن پاک می‌شوند.",
         ["ErrCameraDenied"] = "رله به دوربین دسترسی ندارد — ممکن است نبودن دوربین، اشغال توسط برنامه‌ای دیگر، یا مسدودبودن باشد. در تنظیمات ویندوز > حریم خصوصی دسترسی دوربین را فعال کنید، یا کد را دستی وارد کنید.",
     };
 }

--- a/windows/Relay.Core/WgTunnelSession.cs
+++ b/windows/Relay.Core/WgTunnelSession.cs
@@ -17,7 +17,7 @@ namespace Relay.Core;
 /// only a real Windows machine can prove — that the adapter comes up and
 /// carries traffic — is proven by the client's own test, on a runner.
 /// </summary>
-public sealed class WgTunnelSession(WgTunnelSession.IProcessHost host)
+public sealed class WgTunnelSession(WgTunnelSession.IProcessHost processHost)
 {
     /// <summary>Error codes are the stable identifiers from docs/errors.md.</summary>
     public sealed record Result(bool Ok, string? ErrorCode = null)
@@ -108,7 +108,7 @@ public sealed class WgTunnelSession(WgTunnelSession.IProcessHost host)
         IProcessHandle tunnel;
         try
         {
-            tunnel = host.Start(Arguments(wg));
+            tunnel = processHost.Start(Arguments(wg));
         }
         catch (ElevationDeclined)
         {

--- a/windows/Relay.Core/WgTunnelSession.cs
+++ b/windows/Relay.Core/WgTunnelSession.cs
@@ -1,0 +1,357 @@
+using System.Diagnostics;
+
+namespace Relay.Core;
+
+/// <summary>
+/// Runs Full Mode's tunnel: starts <c>relaywg-client.exe</c>, hands it the
+/// configuration, and stops it again.
+///
+/// The tunnel lives in a child process because creating a WinTun adapter and
+/// changing routes needs Administrator, and Relay is a per-user install that
+/// never asks for it anywhere else (ADR-0005, ADR-0008). This class is the
+/// whole of the app's dealings with that privilege: everything above it works
+/// in terms of "connected" and "disconnected".
+///
+/// Kept out of <c>Relay.App</c> and free of any UI type so it can be tested
+/// against a stub process on a machine with no adapter and no elevation. What
+/// only a real Windows machine can prove — that the adapter comes up and
+/// carries traffic — is proven by the client's own test, on a runner.
+/// </summary>
+public sealed class WgTunnelSession(WgTunnelSession.IProcessHost host)
+{
+    /// <summary>Error codes are the stable identifiers from docs/errors.md.</summary>
+    public sealed record Result(bool Ok, string? ErrorCode = null)
+    {
+        public static readonly Result Success = new(true);
+        public static Result Fail(string code) => new(false, code);
+    }
+
+    /// <summary>
+    /// The child process, behind an interface so the lifecycle can be tested
+    /// without one. A test that has to launch a real elevated process to check
+    /// "what happens when the person clicks No on the UAC prompt" is a test
+    /// nobody can run.
+    /// </summary>
+    public interface IProcessHost
+    {
+        /// <summary>
+        /// Starts the tunnel process. Throws <see cref="ElevationDeclined"/> if
+        /// the person dismissed the UAC prompt.
+        /// </summary>
+        IProcessHandle Start(string arguments);
+    }
+
+    public interface IProcessHandle : IDisposable
+    {
+        /// <summary>Writes a line to the child's stdin.</summary>
+        void WriteLine(string line);
+
+        /// <summary>Reads one line of the child's stdout, or null at end of stream.</summary>
+        string? ReadLine();
+
+        /// <summary>Closes stdin, which is how the child is asked to stop.</summary>
+        void CloseInput();
+
+        /// <summary>Waits for exit; false if it did not within the timeout.</summary>
+        bool WaitForExit(TimeSpan timeout);
+
+        /// <summary>Last resort when it will not leave on its own.</summary>
+        void Kill();
+
+        bool HasExited { get; }
+    }
+
+    /// <summary>Thrown when the person answered No to the elevation prompt.</summary>
+    public sealed class ElevationDeclined(Exception? inner = null)
+        : Exception("The elevation prompt was declined", inner);
+
+    /// <summary>What the client prints once traffic can flow.</summary>
+    public const string ReadyLine = "READY";
+
+    /// <summary>Ends the configuration without closing stdin. Must match the client.</summary>
+    public const string ConfigTerminator = "END-CONFIG";
+
+    /// <summary>How long to wait for the adapter. Creating one is slow the first time.</summary>
+    public static readonly TimeSpan ReadyTimeout = TimeSpan.FromSeconds(45);
+
+    private IProcessHandle? _tunnel;
+
+    public bool IsRunning => _tunnel is { HasExited: false };
+
+    /// <summary>
+    /// Brings the tunnel up from the QR's <c>wg</c> block.
+    ///
+    /// Nothing on this machine is changed before the child starts, and
+    /// everything it changes goes away with it, so a failure at any point here
+    /// needs no rollback of its own — which is why this reads so much simpler
+    /// than <see cref="Proxy.ProxySession"/>, where Relay edits the registry
+    /// itself and has to be able to put it back.
+    /// </summary>
+    public Result Connect(WgParams wg, string host)
+    {
+        if (IsRunning) return Result.Fail("ERR_WG_ALREADY_RUNNING");
+
+        string config;
+        try
+        {
+            config = WgClientConfig.ToIpc(wg, host);
+        }
+        catch (ArgumentException)
+        {
+            // The payload cannot produce a tunnel. Saying "the QR is unusable"
+            // is honest; letting the child fail on it would report the same
+            // thing as a tunnel that could not start, which sends someone
+            // looking at their network for a fault in a QR code.
+            return Result.Fail("ERR_QR_INVALID");
+        }
+
+        IProcessHandle tunnel;
+        try
+        {
+            tunnel = host.Start(Arguments(wg));
+        }
+        catch (ElevationDeclined)
+        {
+            return Result.Fail("ERR_WG_ELEVATION_DECLINED");
+        }
+        catch (Exception)
+        {
+            return Result.Fail("ERR_WG_START_FAILED");
+        }
+
+        try
+        {
+            foreach (var line in config.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+            {
+                tunnel.WriteLine(line);
+            }
+            tunnel.WriteLine(ConfigTerminator);
+        }
+        catch (Exception)
+        {
+            Stop(tunnel);
+            return Result.Fail("ERR_WG_START_FAILED");
+        }
+
+        if (!WaitForReady(tunnel))
+        {
+            Stop(tunnel);
+            return Result.Fail("ERR_WG_START_FAILED");
+        }
+
+        _tunnel = tunnel;
+        return Result.Success;
+    }
+
+    /// <summary>
+    /// Takes the tunnel down. Safe to call when nothing is running, and safe to
+    /// call twice: it runs on paths that are already unwinding from a failure.
+    /// </summary>
+    public Result Disconnect()
+    {
+        var tunnel = _tunnel;
+        _tunnel = null;
+        if (tunnel is null) return Result.Success;
+
+        return Stop(tunnel) ? Result.Success : Result.Fail("ERR_WG_STOP_FAILED");
+    }
+
+    /// <summary>
+    /// Closing stdin is the ordinary way out; the kill is for a child that has
+    /// wedged. Either way the adapter goes with the process, so "stopped" is a
+    /// fact about the machine and not a hope.
+    /// </summary>
+    private static bool Stop(IProcessHandle tunnel)
+    {
+        try
+        {
+            if (!tunnel.HasExited)
+            {
+                tunnel.CloseInput();
+                if (!tunnel.WaitForExit(TimeSpan.FromSeconds(10)))
+                {
+                    tunnel.Kill();
+                    if (!tunnel.WaitForExit(TimeSpan.FromSeconds(5))) return false;
+                }
+            }
+            return true;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+        finally
+        {
+            try { tunnel.Dispose(); } catch { /* teardown must not throw */ }
+        }
+    }
+
+    private static bool WaitForReady(IProcessHandle tunnel)
+    {
+        var deadline = DateTimeOffset.UtcNow + ReadyTimeout;
+        while (DateTimeOffset.UtcNow < deadline)
+        {
+            // Null means the child's stdout ended: it exited without ever being
+            // ready, which is what a refused adapter looks like from here.
+            var line = tunnel.ReadLine();
+            if (line is null) return false;
+            if (line.Trim() == ReadyLine) return true;
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// The client's arguments. The DNS server and the tunnel address come from
+    /// the payload and the shared contract rather than being repeated here.
+    /// </summary>
+    internal static string Arguments(WgParams wg)
+    {
+        var arguments = new List<string>
+        {
+            "-name", "Relay",
+            "-address", WgClientConfig.ClientTunnelAddress,
+            "-routes", wg.AllowedIps,
+        };
+        if (!string.IsNullOrWhiteSpace(wg.Dns))
+        {
+            arguments.Add("-dns");
+            arguments.Add(wg.Dns);
+        }
+        return string.Join(' ', arguments.Select(Quote));
+    }
+
+    private static string Quote(string argument) =>
+        argument.Contains(' ') ? $"\"{argument}\"" : argument;
+}
+
+/// <summary>
+/// The real <see cref="WgTunnelSession.IProcessHost"/>: raises the elevation
+/// prompt for the tunnel process and talks to it over a private named pipe.
+///
+/// The pipe is the whole reason this is not simply a redirected child process.
+/// A process started through the elevation prompt cannot have its streams
+/// redirected — Windows' <c>runas</c> goes through ShellExecute, which has no
+/// way to hand over a handle — so the choice is a pipe or writing the client's
+/// private key to a temp file. A key on disk outlives the session, lands in
+/// backups, and is readable by anything running as that user afterwards.
+///
+/// The pipe is created before the prompt is raised and its name is the only
+/// thing on the command line, which any process on the machine can read: a name
+/// is useless to anyone who cannot open it, and the pipe allows exactly one
+/// connection and is closed the moment the tunnel stops.
+/// </summary>
+public sealed class ElevatedTunnelHost(string executablePath) : WgTunnelSession.IProcessHost
+{
+    /// <summary>Windows' code for "the user cancelled the elevation prompt".</summary>
+    private const int ErrorCancelled = 1223;
+
+    /// <summary>How long to wait for the elevated child to pick up the pipe.</summary>
+    private static readonly TimeSpan ConnectTimeout = TimeSpan.FromSeconds(60);
+
+    public WgTunnelSession.IProcessHandle Start(string arguments)
+    {
+        var name = "relay-wg-" + Guid.NewGuid().ToString("N");
+        // One instance, and the elevated child is the only thing that will ever
+        // connect. In only means "the app writes"; the client's readiness comes
+        // back the other way, so this is duplex.
+        var pipe = new System.IO.Pipes.NamedPipeServerStream(
+            name,
+            System.IO.Pipes.PipeDirection.InOut,
+            maxNumberOfServerInstances: 1,
+            System.IO.Pipes.PipeTransmissionMode.Byte,
+            System.IO.Pipes.PipeOptions.Asynchronous);
+
+        Process process;
+        try
+        {
+            var info = new ProcessStartInfo(executablePath, $"{arguments} -config-pipe {name}")
+            {
+                UseShellExecute = true,
+                Verb = "runas", // the elevation prompt, for this one process
+                CreateNoWindow = true,
+                WindowStyle = ProcessWindowStyle.Hidden,
+            };
+            process = Process.Start(info)
+                ?? throw new InvalidOperationException("no process was started");
+        }
+        catch (System.ComponentModel.Win32Exception ex) when (ex.NativeErrorCode == ErrorCancelled)
+        {
+            pipe.Dispose();
+            throw new WgTunnelSession.ElevationDeclined(ex);
+        }
+        catch
+        {
+            pipe.Dispose();
+            throw;
+        }
+
+        try
+        {
+            // Waits for the child, and stops waiting if it dies first — an
+            // elevated process that fails immediately would otherwise leave
+            // this blocked on a connection that is never coming.
+            var connected = pipe.WaitForConnectionAsync();
+            var deadline = DateTimeOffset.UtcNow + ConnectTimeout;
+            while (!connected.Wait(TimeSpan.FromMilliseconds(250)))
+            {
+                if (process.HasExited)
+                {
+                    throw new InvalidOperationException(
+                        $"the tunnel process exited with {process.ExitCode} before connecting");
+                }
+                if (DateTimeOffset.UtcNow > deadline)
+                {
+                    throw new TimeoutException("the tunnel process never connected");
+                }
+            }
+        }
+        catch
+        {
+            try { if (!process.HasExited) process.Kill(entireProcessTree: true); } catch { }
+            pipe.Dispose();
+            process.Dispose();
+            throw;
+        }
+
+        return new Handle(process, pipe);
+    }
+
+    private sealed class Handle : WgTunnelSession.IProcessHandle
+    {
+        private readonly Process _process;
+        private readonly System.IO.Pipes.NamedPipeServerStream _pipe;
+        private readonly StreamWriter _writer;
+        private readonly StreamReader _reader;
+
+        public Handle(Process process, System.IO.Pipes.NamedPipeServerStream pipe)
+        {
+            _process = process;
+            _pipe = pipe;
+            _writer = new StreamWriter(pipe) { AutoFlush = true, NewLine = "\n" };
+            _reader = new StreamReader(pipe);
+        }
+
+        public bool HasExited => _process.HasExited;
+
+        public void WriteLine(string line) => _writer.WriteLine(line);
+
+        public string? ReadLine() => _reader.ReadLine();
+
+        /// <summary>
+        /// Closing the pipe is how the tunnel is told to stop — and because the
+        /// pipe dies with this process too, a crash of the app stops the tunnel
+        /// just as reliably as a Disconnect does.
+        /// </summary>
+        public void CloseInput() => _pipe.Dispose();
+
+        public bool WaitForExit(TimeSpan timeout) => _process.WaitForExit((int)timeout.TotalMilliseconds);
+
+        public void Kill() => _process.Kill(entireProcessTree: true);
+
+        public void Dispose()
+        {
+            try { _pipe.Dispose(); } catch { }
+            try { _process.Dispose(); } catch { }
+        }
+    }
+}


### PR DESCRIPTION
The half that was missing after v1.5.0: the phone can be a WireGuard endpoint,
but nothing on Windows could dial it.

**Work in progress.** This first commit is the tunnel process and its test. The
app-side integration (elevation, lifecycle, UI, errors) follows in this same PR.

## The tunnel process

`wg/cmd/relaywg-client` — a small Go program built from the same module as the
phone's endpoint, so both ends of Full Mode share one WireGuard implementation.

It is a separate executable rather than code inside the app because creating a
network adapter and changing routes needs Administrator, and Relay is
deliberately a per-user install that never asks for it (ADR-0005). Confining the
privileged part to one short-lived process keeps that property everywhere else,
and ties the elevation prompt to a single visible action.

- **The configuration arrives on stdin and never touches disk.** It carries the
  client's private key; a key in a temp file survives a crash, a backup, and
  whoever reads the disk afterwards.
- **stdin is also the liveness channel**, so the configuration is ended by a
  sentinel rather than by EOF — reading to EOF for the first would consume the
  second and tear the tunnel down the instant it came up.
- **Teardown is safe rather than careful.** The adapter goes away with the
  process on any exit, including being killed, and Windows drops its addresses
  and routes with it. Nothing here deletes or rewrites an existing route, so
  there is no state a crash can strand.
- The phone stays reachable because it is on the local subnet, whose on-link
  route is more specific than `0.0.0.0/0` — which is also what stops the
  tunnel's own UDP from being routed into itself.

## What the new CI job proves, and what it does not

`Full Mode client (WinTun adapter)` on `windows-latest`: builds the client,
fetches WinTun (pinned by SHA-256, verified against the real download), brings up
a real adapter, waits for a **real WireGuard handshake** across it, and then
proves **Windows actually routes** the prefix it was given into that adapter —
measured at the endpoint, which decrypts what arrives. Then it closes stdin and
asserts the adapter is gone, and a final always-run step asserts the machine's
networking is as we found it.

It deliberately does **not** claim to browse the web through the tunnel. Both
ends share one routing table on a single machine, so any destination routed into
the tunnel is also routed into the tunnel when the endpoint forwards it onward.
That test would pass for the wrong reason. Traffic through a real tunnel is
already proven by the endpoint's own suite, in-process and on an Android device.

Also here: `go vet` now runs as Windows too (the client cannot be parsed on
Linux), and the endpoint's race test is scoped to the package that can run it.

---
_Generated by [Claude Code](https://claude.ai/code/session_015jP1ymLW2XP7L5MuKVthQ1)_