### PR TITLE
Make a fresh session able to test on real hardware

### DIFF
--- a/.claude/skills/device-test/SKILL.md
+++ b/.claude/skills/device-test/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: device-test
+description: Run Relay against the phone plugged into this laptop and the Windows app installed on it, find what breaks, and fix it. Use when the user asks to test on real hardware, test on their phone, check pairing on their own Wi-Fi, or verify a release on their own machine. Only meaningful in a session running locally on the laptop — a cloud session has no USB device and no desktop.
+---
+
+# Testing Relay on this laptop and the phone attached to it
+
+Read [`docs/local-device-testing.md`](../../../docs/local-device-testing.md)
+first — it lists the six things this arrangement proves that CI structurally
+cannot, and the readouts to use because **neither app writes a log to disk**.
+
+Everything else is already covered on every pull request. Do not spend a session
+re-doing by hand what the device lab already does.
+
+## Before anything
+
+```bash
+adb devices          # exactly one, listed as `device`
+```
+
+`unauthorized` means the phone has not accepted this laptop's key — the prompt is
+on the phone's screen. No device at all usually means USB debugging is off, or a
+charge-only cable.
+
+Then establish which build you are testing, and say it out loud in your report:
+the **released** APK/installer (what a stranger gets) or a **local debug** build
+(what the instrumented suite installs). Conclusions about one do not transfer to
+the other — the release APK is minified and not debuggable.
+
+## The order to work in
+
+1. **The firewall check first.** It is the most likely to be broken, the most
+   damaging when it is, and the only place it can be caught. `docs/local-device-testing.md`
+   → "The firewall check". If the phone does not appear in the PC's list while it
+   is plainly showing a code, stop and diagnose that before anything else.
+2. **The pairing a user actually performs** — phone shows two digits, PC lists
+   the phone, one click connects. Check that the two screens agree.
+3. **Traffic**, through the real system proxy: `curl -x socks5h://<host>:<port> https://example.com`,
+   then a browser.
+4. **Disconnect**, and confirm the system proxy came back to the snapshot you
+   took *before* connecting. A dead proxy left in `HKCU` breaks every app on the
+   machine and is the worst failure this product has.
+5. **Full Mode**, if the phone offers it: the UAC prompt should appear once, for
+   the tunnel process only. Decline it deliberately at least once and confirm the
+   app says so (`ERR_WG_ELEVATION_DECLINED`) rather than reporting a generic
+   failure.
+
+## When you find a bug
+
+Do not fix it in place and move on. In order:
+
+1. Reproduce it deliberately — twice, so it is a bug and not a fluke.
+2. Find the layer it lives in and write the failing test **there**: a shared
+   vector if the two platforms disagree, a unit test if one platform is wrong, an
+   instrumented test if it only shows on a device. Confirm the test fails on the
+   current code.
+3. Fix it. Confirm the test passes and the hardware agrees.
+4. If the bug is structurally invisible to CI, say so in the commit message and
+   add the manual check to `docs/testing.md`. Do not imply a test covers what no
+   test can reach.
+
+Then push and open a draft PR as usual; CI is still the gate.
+
+## Reporting
+
+State plainly what you ran, on which build, what passed, and what you could not
+check. "Everything works" is not a report — name the checks. If you skipped one
+because the hardware was not in the right state (no hotspot, no second network,
+phone on a charge-only cable), say which and why rather than quietly narrowing
+the scope.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 Notable changes to Relay. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 Relay is pre-1.0, so minor versions may still change behaviour.
 
-Releases are cut per platform (`android-vX.Y.Z`, `windows-vX.Y.Z`) — see
-[`docs/release.md`](docs/release.md). Artifacts for every version are on the
+One tag ships both platforms (`vX.Y.Z`) — see [`docs/release.md`](docs/release.md).
+Artifacts for every version are on the
 [Releases page](https://github.com/Mahdi-mortazavi/relay/releases).
 
 ## [Unreleased]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,56 @@
+# Relay — notes for a Claude Code session
+
+Two apps and one shared contract. Android is Kotlin + Compose (`android/`),
+Windows is .NET 8 + WinUI 3 (`windows/`), Full Mode's tunnel is Go (`wg/`) and
+is used by both ends. `shared/` is the contract between them.
+
+Start with [`docs/architecture.md`](docs/architecture.md) and the
+[ADRs](docs/adr/). `CONTRIBUTING.md` has the rest.
+
+## The rules that are easy to break by accident
+
+**Change `/shared` first.** The wire format, the state machine, the pairing
+rules and the design tokens live there, and both platforms are asserted against
+it. Editing one platform to match the other, without moving the contract, is how
+the two apps drift — and they have, twice, both times in ways no test caught.
+
+**Every user-facing string exists in English *and* Persian.** On Windows that
+means `windows/Relay.App/Strings.cs` — the only string store, enforced by
+`StringsCoverageTests`. There used to be a second one nobody read, and six
+strings were "added" to it; the app showed users raw keys like `CodeNoDevice`
+for four releases. Do not reintroduce a `.resw`.
+
+**CI is the build system (ADR-0004).** There is no local build step in the
+normal loop: push, and the pipeline builds, tests on real devices, and can cut a
+release. Do not add a "you must install X to work on this" requirement without
+an ADR. (Testing on *your own* hardware is the deliberate exception — see
+[`docs/local-device-testing.md`](docs/local-device-testing.md).)
+
+**Green is not the same as tested.** A job that skips its only meaningful test
+is also green. `device-tests.sh` names the classes that must have run and fails
+if one silently skipped; keep that list current when adding a test that matters.
+
+**Nothing leaves the device.** No accounts, no servers, no telemetry. A change
+that adds a network call to anything but the user's own phone needs a very good
+reason and an ADR.
+
+## Where the truth is
+
+| Question | File |
+|---|---|
+| What does a pairing code mean? | `shared/pairing-beacon.md` |
+| What goes in the QR? | `shared/qr-payload.schema.json` |
+| What are the legal states? | `shared/connection-states.json` |
+| What does error X tell the user? | `docs/errors.md` |
+| What has hardware still not proven? | `docs/testing.md` |
+| How does a release get cut? | `docs/release.md` |
+
+`shared/test-vectors.json` is consumed by the Android, Windows and Go suites at
+once. Adding a vector there is usually worth more than adding a test to one side.
+
+## Testing on real hardware
+
+A phone plugged into the laptop, with the Windows app on that same laptop, tests
+the one thing CI structurally cannot: two machines, one Wi-Fi, a firewall in its
+default state. That runbook is [`docs/local-device-testing.md`](docs/local-device-testing.md),
+and the `/device-test` skill drives it.

--- a/docs/local-device-testing.md
+++ b/docs/local-device-testing.md
@@ -1,0 +1,120 @@
+# Testing on your own phone and laptop
+
+The device lab in CI is thorough and it has a hole it cannot close: the emulator
+and the Windows runner are **two different machines in two different jobs**.
+Relay's whole job is to get one machine's traffic through another over a real
+Wi-Fi, and that has never once happened in CI.
+
+A phone plugged into the laptop closes it. Not because the hardware is more
+"real" — the emulator runs the same APK — but because this is the only
+arrangement where the two apps have to find each other across a network with a
+firewall in its default state.
+
+## What this setup can prove that CI cannot
+
+| | Why CI can't |
+|---|---|
+| The PC finds the phone through an unconfigured Windows Firewall | The runner has no phone to find, and its firewall state is not a user's |
+| Pairing over real Wi-Fi (or the phone's hotspot) | The two jobs share no network |
+| The system proxy actually carrying a browser's traffic | Nothing on the runner browses |
+| Full Mode's UAC prompt, and what happens when you decline it | The runner has no interactive desktop |
+| Battery, doze, screen-off over an hour | Emulators do not sleep like phones |
+| That the phone's code and the PC's box agree, to a person holding both | No one is holding anything |
+
+Everything else — the golden journey, Full Mode's handshake, the installer's
+layout, the proxy rollback — is already covered on every pull request. **Do not
+re-do that work by hand.** This setup exists for the six rows above.
+
+## What you need on the laptop
+
+The normal loop needs no local build (ADR-0004); these are only for driving
+hardware.
+
+| | Why | Skip it if |
+|---|---|---|
+| **Claude Code** | A cloud session cannot see a USB device or your desktop | — |
+| **`adb`** (Android platform-tools, ~10 MB) | Everything on the phone side | never |
+| **Git Bash** or WSL | `.github/scripts/*.sh` are bash | you only run the Windows half |
+| **JDK 17 + Android SDK** | to run the instrumented suite against your phone | you only test the released APK by hand |
+| **.NET 8 SDK** | to run `windows/Relay.App.Tests` and `Relay.E2E.Tests` locally | you let CI run them |
+
+Phone: **Developer options → USB debugging** on, then `adb devices` must list it
+as `device` (not `unauthorized` — accept the prompt on the phone).
+
+You do **not** need Visual Studio. Building the WinUI app locally is possible but
+rarely worth it: push instead, let CI build the installer, and download it.
+
+## The two loops
+
+### 1. The released artifacts (no build, ~2 minutes)
+
+The honest version of what a stranger gets:
+
+```bash
+adb install -r Relay-android-universal.apk       # or the arm64 split
+# install Relay-Setup-x64.exe on the laptop the normal way
+```
+
+Then pair the way the README tells a user to, and watch for the things in the
+table above. This is the loop for "does the shipped thing work".
+
+### 2. The instrumented suite against your phone (needs the Android SDK)
+
+`device-tests.sh` is not emulator-specific — it drives whatever `adb` sees:
+
+```bash
+adb devices                                       # exactly one device attached
+.github/scripts/device-tests.sh ./e2e-out
+```
+
+That installs the debug + androidTest APKs, runs the golden journey, Full Mode
+and pairing discovery **on your phone**, and fails if any required class
+silently skipped. Evidence lands in `./e2e-out`.
+
+With the laptop's own Windows app instead of a runner's, the cross-platform leg
+is the interesting one:
+
+```bash
+.github/scripts/cross-platform-e2e.sh ./e2e-out   # phone holds a session, host client connects
+```
+
+## What you cannot read, and what to use instead
+
+Both apps keep their log **in memory only** — a ring buffer behind
+*Advanced → Logs*, not a file. There is nothing on disk for a script to tail.
+So instrument from outside:
+
+| Want to know | Read |
+|---|---|
+| Is the phone announcing itself? | `adb logcat -s RelayBeacon:*` |
+| Is the PC hearing it? | the phone list under the code box — it *is* the readout |
+| Did the proxy get set? | `HKCU\Software\Microsoft\Windows\CurrentVersion\Internet Settings` → `ProxyEnable`, `ProxyServer` |
+| Did the proxy get restored? | same key, compared against a snapshot taken before connecting |
+| Is traffic really flowing? | `curl -x socks5h://<phone-ip>:<port> https://example.com` |
+| Is the tunnel up (Full Mode)? | `Get-NetAdapter` for the WinTun adapter, `Get-NetRoute` for its routes |
+
+The released APK is minified and not debuggable, so `adb shell run-as io.relay.app`
+will fail against it. The instrumented suite installs the **debug** build, where
+`run-as` works — that is why the scripts can read the phone's evidence directory.
+
+## The firewall check — the one that matters most
+
+Relay's Windows listener is an unelevated app and its installer is per-user, so
+it cannot add a firewall rule. It therefore probes, and the phone answers unicast
+(`shared/pairing-beacon.md` → The probe). Verify on a machine that has **never**
+been told to allow Relay through, with the network profile set to **Public**:
+
+1. Phone: Start Sharing. Laptop: open the code box.
+2. The phone must appear in the list, with the same two digits it is showing.
+
+If it only appears after you click **Allow** on a Windows firewall prompt, the
+probe path is not working and **every fresh install will look broken**. That is a
+release-blocking bug, and this is the only place it can be caught.
+
+## Reporting what you find
+
+A bug found here needs the same standard as one found in CI: a failing test
+first, in the suite that should have caught it, then the fix. If the bug is
+structurally invisible to CI — one of the six rows at the top — say so in the
+commit and add the manual check to `docs/testing.md` instead of pretending a
+test covers it.

--- a/docs/release.md
+++ b/docs/release.md
@@ -2,9 +2,27 @@
 
 Releases are **tag-triggered only** — an ordinary push can never publish anything.
 
-| Platform | Tag | Workflow | Artifacts attached to the GitHub Release |
+**One tag, one release, both platforms.** `git push origin v1.7.0` runs
+`release.yml`, which builds the signed Android artifacts and both Windows
+installers and publishes them together, so
+`/releases/latest/download/<asset>` resolves for every platform — which is what
+the README download buttons point at.
+
+| Tag | Workflow | Artifacts attached to the GitHub Release |
+|---|---|---|
+| `v*.*.*` | `release.yml` | `Relay-android-arm64-v8a.apk`, `Relay-android-universal.apk`, `Relay-android.aab`, `Relay-Setup-x64.exe`, `Relay-Setup-x86.exe` |
+
+`release.yml` also takes a `workflow_dispatch` with a version and a `publish`
+toggle. Leave `publish` off for a dry run; turn it on to cut the release without
+pushing a tag — `gh release create` makes the tag itself, which is the only
+route from an environment where pushing tags is blocked.
+
+The per-platform workflows below still exist for shipping one platform alone.
+They are not the normal path.
+
+| Platform | Tag | Workflow | Artifacts |
 |---|---|---|---|
-| Android | `android-v*.*.*` | `android-release.yml` | `relay-arm64-v8a-<version>.apk` (signed, primary sideload artifact) + `relay-<version>.aab` |
+| Android | `android-v*.*.*` | `android-release.yml` | `relay-arm64-v8a-<version>.apk` + `relay-<version>.aab` |
 | Windows | `windows-v*.*.*` | `windows-release.yml` | `Relay-Setup-x64-<version>.exe` + `Relay-Setup-x86-<version>.exe` |
 
 Every release also carries **`SHA256SUMS.txt`**, generated in the same job that

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -3,6 +3,13 @@
 Three rungs, all provisioned by GitHub. Nothing here needs a maintainer's
 hardware, an emulator started by hand, or a device plugged into anything.
 
+One thing this arrangement structurally cannot reach: the emulator and the
+Windows runner are two machines in two jobs, so **the two apps have never once
+found each other over a real network**. A phone plugged into a laptop closes
+that gap — [`local-device-testing.md`](local-device-testing.md) is the runbook,
+and it lists exactly which six checks are worth doing there and which are
+already covered here.
+
 | Rung | Where | What it proves | Workflow |
 |---|---|---|---|
 | Unit | `ubuntu-latest` + `windows-latest` | Pure logic, and the SOCKS5 protocol over real loopback sockets | `ci.yml` |


### PR DESCRIPTION
## What this changes

Documentation and session setup only — no product code.

- `CLAUDE.md` — the project did not have one. The invariants that are easy to break by accident (contracts first, both languages, CI is the build system, green ≠ tested) and a table of where the truth actually lives.
- `docs/local-device-testing.md` — how to test on a phone plugged into the laptop, what that arrangement proves that CI **cannot**, and what to read instead of a log file.
- `.claude/skills/device-test/SKILL.md` — a `/device-test` skill for a session running locally on the laptop: the order to work in, and the standard a bug found on hardware still has to meet.
- `docs/release.md` and the `CHANGELOG.md` header — corrected; both still described per-platform tags.

## Why

The device lab is thorough and has a structural hole: **the Android emulator and the Windows runner are two machines in two jobs.** Relay's entire job is getting one machine's traffic through another over a real network, and that has never once happened in CI. Every green run is compatible with the two apps being unable to find each other at all.

That gap is exactly where the bug fixed in #51 lived, and where the probe path added there can still fail: an unelevated listener behind a default Windows Firewall on a Public profile. No runner can reproduce it. A phone plugged into a laptop can, and it is the only thing that can.

So the point of these files is not "write down how to test". It is to stop a fresh session from spending its hardware time re-running what CI already covers, and to point it at the six checks that are only available there.

Two smaller reasons:

- A new session started **cold** — no CLAUDE.md, so the string-store rule, the contracts-first rule and the no-local-build rule were things it had to rediscover from the diff. The six missing strings in #51 are what rediscovering that rule too late looks like.
- `docs/release.md` opened with a table saying releases are cut per platform (`android-v*`, `windows-v*`). Releases have been cut with a single `v*.*.*` tag for both platforms for some time — v1.7.0 included. That table is the first thing anyone reads before publishing.

## How it was verified

- [x] Unit tests pass (`CI` workflow) — no code changed; CI runs regardless
- [x] Device and cross-platform tests pass (`E2E` workflow) — unchanged
- [ ] New behaviour has a test that fails without this change — **not applicable, and worth stating plainly:** this is prose. Its claims about what CI covers were checked against `e2e.yml`, `device-tests.sh` and `cross-platform-e2e.sh` rather than written from memory.
- [ ] Verified by hand on a real phone and PC — the runbook itself has not been walked through on hardware yet. That is the next session's job, and the runbook says so rather than implying it is proven.

Specific claims that were checked rather than assumed:

| Claim | Checked against |
|---|---|
| `device-tests.sh` drives any adb-visible device, not just an emulator | the script — it calls `connectedDebugAndroidTest`, nothing emulator-specific |
| Neither app writes a log to disk | `LocalLog` on both platforms — in-memory ring buffers, surfaced only through the UI |
| `run-as` fails against the released APK | `isMinifyEnabled = true` and no `isDebuggable` in `android/app/build.gradle.kts` |
| A single `v*.*.*` tag ships both platforms | `release.yml`'s trigger and its `workflow_dispatch` inputs |

## Checklist

- [x] Shared contracts (`/shared`) were changed **first** if the wire format, state machine or tokens moved — nothing moved
- [x] User-facing strings exist in **both** English and Persian — no new strings
- [x] No new network calls, telemetry, or data leaving the device
- [x] System changes remain transactional with verified rollback — untouched
- [x] Docs updated — this PR is the docs

## Anything reviewers should look at closely

**The instruction not to re-test what CI covers.** `docs/local-device-testing.md` tells a hardware session to *skip* the golden journey, Full Mode's handshake, the installer layout and the proxy rollback, because all four already run on every PR. If any of those coverage claims is wrong, the runbook is steering someone away from a real gap. The table naming what CI can't reach is the part worth reading adversarially.

**What is not covered.** Nothing here has been executed on a phone or a Windows laptop — I have neither. The runbook is derived from the scripts and the source, and its own "what you cannot read" section exists because the obvious approach (tail a log file) does not work on either platform. The first session that runs it should expect to correct it, and should treat a step that doesn't match reality as a bug in this file.

---
_Generated by [Claude Code](https://claude.ai/code/session_015jP1ymLW2XP7L5MuKVthQ1)_