### PR TITLE
Revert the approval-gate diagnostic

### DIFF
--- a/android/app/src/main/kotlin/io/relay/app/net/ClientGate.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/ClientGate.kt
@@ -91,15 +91,6 @@ class ClientGate(
      * than running it here.
      */
     fun resolve(address: String, allowed: Boolean) {
-        // TEMPORARY DIAGNOSTIC (issue: the gate self-answers Allow on hardware).
-        // Records who called, because the only caller in the source is a button's
-        // onClick and something is reaching it without a touch. Kept off
-        // android.util.Log deliberately -- that is an android.jar stub on the
-        // JVM and throws in the unit tests that cover this class.
-        val caller = Throwable().stackTrace.drop(1).take(8).joinToString(" <- ") {
-            "${it.className.substringAfterLast('.')}.${it.methodName}"
-        }
-        io.relay.app.service.LocalLog.add("GATE resolve allowed=$allowed via $caller")
         val decision = if (allowed) Decision.ALLOWED else Decision.DENIED
         decisions[address] = decision
         waiters.remove(address)?.complete(decision)


### PR DESCRIPTION
The diagnostic in #60 was merged; this takes it back out.

**There was no defect.** The gate appearing to self-approve on hardware was the maintainer watching the phone and answering the prompt. Every fast resolve was 1.7–6.2 s — human reaction time — and one of them chose **Deny**, which no code path does.

Unattended behaviour is correct, and now measured on the device:

| Condition | Result |
|---|---|
| 17 consecutive unattended runs | held 60 s, failed closed |
| Digitizer during those runs | zero touch events |
| Screen off | held 60 s, denied |
| App backgrounded | held 60 s, denied |
| Deny tapped | `ERR_PAIRING_DENIED` |
| Allow tapped | configuration delivered |

The diagnostic only added a stack trace to the user-visible log on every approval, so it comes out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
