### PR TITLE
Stop the popover throwing away what you were doing

### DIFF
--- a/android/app/src/main/kotlin/io/relay/app/net/ClientGate.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/ClientGate.kt
@@ -91,15 +91,6 @@ class ClientGate(
      * than running it here.
      */
     fun resolve(address: String, allowed: Boolean) {
-        // TEMPORARY DIAGNOSTIC (issue: the gate self-answers Allow on hardware).
-        // Records who called, because the only caller in the source is a button's
-        // onClick and something is reaching it without a touch. Kept off
-        // android.util.Log deliberately -- that is an android.jar stub on the
-        // JVM and throws in the unit tests that cover this class.
-        val caller = Throwable().stackTrace.drop(1).take(8).joinToString(" <- ") {
-            "${it.className.substringAfterLast('.')}.${it.methodName}"
-        }
-        io.relay.app.service.LocalLog.add("GATE resolve allowed=$allowed via $caller")
         val decision = if (allowed) Decision.ALLOWED else Decision.DENIED
         decisions[address] = decision
         waiters.remove(address)?.complete(decision)

--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -180,14 +180,25 @@ public sealed partial class MainWindow : Window
             HideToTray();
         };
 
-        // macOS-popover behaviour: hide when focus is lost — but never mid-scan,
-        // so a system camera prompt can't dismiss the scanner.
+        // macOS-popover behaviour: hide when focus is lost — but never while the
+        // person is part-way through something.
+        //
+        // Only scanning used to be protected, on the reasoning that a system
+        // camera prompt must not dismiss the scanner. Every other step needed
+        // the same protection and did not have it: typing a code lost the digits
+        // to any window that took focus, and waiting on the phone's approval
+        // hid the window at the worst possible moment — Full Mode's own UAC
+        // prompt takes focus, so connecting made the window disappear and left
+        // someone watching a tray icon wondering what had happened.
+        //
+        // Losing a popover you did not dismiss is bad; losing what you typed
+        // into it is worse.
         Activated += (_, e) =>
         {
             // Ignore the brief deactivation that can follow a show (if the
             // foreground grab momentarily loses), else the popover flash-hides.
             if (e.WindowActivationState == WindowActivationState.Deactivated
-                && _mode != InputMode.Scanning
+                && _mode == InputMode.None
                 && Environment.TickCount64 - _shownAtTick > 400)
             {
                 AppWindow.Hide();


### PR DESCRIPTION
Found while testing on hardware, and it was blocking both the product and the testing of it.

The popover hid on any focus loss unless the camera was open. Scanning was protected because a system camera prompt must not dismiss the scanner — but every other step needed the same protection and did not have it.

Two consequences, both hit repeatedly today on the real laptop:

- **Typing the two-digit code lost the digits** to whatever took focus. The window came back to "Ready to connect" as though nothing had been entered.
- **Waiting on the phone's approval hid the window at the worst possible moment.** Full Mode's own UAC prompt takes focus, so connecting made the popover vanish and left someone watching a tray icon with no idea whether it had worked.

The second one also made the flow untestable through UI automation — every attempt to drive it lost the window mid-connect, which is why the Full Mode hardware test could not be completed.

Now it only auto-hides while `_mode == InputMode.None`. Losing a popover you did not dismiss is bad; losing what you typed into it is worse.

Stacked on #61 (the diagnostic revert), so merge that first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
