### PR TITLE
Let Full Mode actually say it is connected

### DIFF
--- a/windows/Relay.App.Tests/ConnectionRulesTests.cs
+++ b/windows/Relay.App.Tests/ConnectionRulesTests.cs
@@ -38,4 +38,28 @@ public class ConnectionRulesTests
         Assert.False(ConnectionRules.CanTransition("Connected", "ready"));
         Assert.False(ConnectionRules.CanTransition("Error", "stop"));
     }
+
+    /// <summary>
+    /// Reaching the adapter is not reaching Connected.
+    ///
+    /// Full Mode dispatched "ready" and stopped, which leaves the machine at
+    /// Advertising -- and the window, which is a pure projection of this state,
+    /// sat on "Connecting…" with a Cancel button while a live tunnel carried
+    /// real traffic. Found only by looking at the running app on hardware: the
+    /// log line said "Connected (Full Mode)" and that is what everyone read.
+    ///
+    /// This asserts the shape of the journey rather than the call site, so it
+    /// still holds if the transport is rewritten again.
+    /// </summary>
+    [Fact]
+    public void ReachingConnectedTakesTwoTransitionsNotOne()
+    {
+        var afterReady = ConnectionRules.Target("Preparing", "ready");
+        Assert.Equal("Advertising", afterReady);
+        Assert.NotEqual("Connected", afterReady);
+
+        // The second one is the whole difference between a UI that says
+        // "Connecting…" forever and a UI that tells the truth.
+        Assert.Equal("Connected", ConnectionRules.Target("Advertising", "clientConnected"));
+    }
 }

--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -1206,8 +1206,12 @@ public sealed partial class MainWindow : Window
         var result = await Task.Run(() =>
             new PairingClient().Fetch(host, pairingPort, Environment.MachineName));
 
+        // Both lines, not just the headline: leaving the pairing detail behind
+        // put "Tap Allow on your phone" under "Setting up the connection", which
+        // is an instruction for a prompt that has already been answered.
         _mode = InputMode.None;
         BusyText.Text = Strings.Get("BusyConnecting");
+        BusyDetailText.Text = Strings.Get("BusyDetail");
 
         if (!result.Ok)
         {

--- a/windows/Relay.App/Services/AppController.cs
+++ b/windows/Relay.App/Services/AppController.cs
@@ -255,6 +255,23 @@ public sealed class AppController(IProxyStore proxyStore, IBackupStore backupSto
             try { await TunnelDisconnectLocked(); } catch { }
             return;
         }
+        // And then say so. The state machine's Connected is what the whole UI is
+        // a projection of, and Full Mode stopped one transition short of it --
+        // "ready" only reaches Advertising. So the tunnel came up, carried real
+        // traffic, and the window sat on "Connecting…" with a Cancel button for
+        // as long as you cared to look at it.
+        //
+        // It survived because the log line below says "Connected" and that is
+        // what everyone read, while the screen -- which has no UI automation on
+        // any runner, and needs a real elevation prompt to reach at all -- said
+        // something else entirely.
+        //
+        // One client, always: the tunnel has exactly one peer (ADR-0009).
+        if (!Dispatch("clientConnected"))
+        {
+            try { await TunnelDisconnectLocked(); } catch { }
+            return;
+        }
         LocalLog.Add("Connected (Full Mode)");
         StartTunnelWatch();
     }


### PR DESCRIPTION
Found by **looking at the running app** on hardware, with a live tunnel carrying 33 MB.

```
tunnel        Up, relaywg-client running
phone         "1 device connected", down 33.5 MB
routing       Find-NetRoute 1.1.1.1 -> Relay
Windows UI    "Connecting…"  +  "Tap Allow on your phone"  +  Cancel
```

Fast Mode dispatched **two** transitions to reach Connected; Full Mode dispatched one:

```
Fast:  Dispatch("ready")  ->  Dispatch("clientConnected")   => Connected
Full:  Dispatch("ready")                                     => stuck at Advertising
```

The window is a pure projection of that state (`docs/architecture.md`), so it rendered the busy screen for as long as you cared to look.

**Why it survived.** The log line immediately below said `Connected (Full Mode)` — and that is what everyone read, including me, all session. The screen disagreed, and nothing reads the screen: there is no UI automation for unpackaged WinUI 3 on any runner, and reaching this state at all needs a real elevation prompt.

Also fixes the pairing detail outliving the pairing — *"Tap Allow on your phone"* stayed under *"Setting up the connection"* after the prompt had been answered, because the headline was restored and the line under it was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)