### PR TITLE
Keep the window while anything is under way, not just some things

### DIFF
--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -217,9 +217,16 @@ public sealed partial class MainWindow : Window
         {
             // Ignore the brief deactivation that can follow a show (if the
             // foreground grab momentarily loses), else the popover flash-hides.
+            // Idle is the only state where nothing is under way. The previous
+            // guard named the states to protect and missed the ones in the
+            // middle: Preparing and Advertising are the seconds while the tunnel
+            // is being built, and the window vanished right there -- during the
+            // most anxious part of connecting, and while Windows' own elevation
+            // prompt was taking focus. Error counts too: an error nobody can
+            // read is an error nobody can act on.
             if (e.WindowActivationState == WindowActivationState.Deactivated
                 && _mode == InputMode.None
-                && _controller.StateName != "Connected"
+                && _controller.StateName == "Idle"
                 && Environment.TickCount64 - _shownAtTick > 400)
             {
                 AppWindow.Hide();


### PR DESCRIPTION
My own fix in #65 named the states to protect and missed the middle ones.

`Preparing` and `Advertising` are the seconds while the tunnel is being built, and the window vanished exactly there — the most anxious part of connecting, and the moment Windows' elevation prompt takes focus. `Error` counts too: an error nobody can read is an error nobody can act on.

**Caught while retesting on hardware.** A connect attempt hid the window mid-flight, and a later Dismiss-then-reconnect never reached the phone at all — its log shows **one** pairing request where there should have been two, because the window disappeared between the two clicks.

`Idle` is the only state where nothing is under way, so it is now the only state that auto-hides. Naming the one safe case is a smaller thing to get wrong than enumerating the unsafe ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)