### PR TITLE
Make Advanced reachable at any window size

### DIFF
--- a/windows/Relay.App/MainWindow.xaml
+++ b/windows/Relay.App/MainWindow.xaml
@@ -14,7 +14,7 @@
         the idle screen is a small card rather than a tall panel with a hole in
         the middle of it.
     -->
-    <Grid x:Name="Root" Padding="{StaticResource WindowPadding}" RowSpacing="0">
+    <Grid x:Name="Root" Padding="{StaticResource WindowPadding}">
         <Grid.Background>
             <LinearGradientBrush StartPoint="0,0" EndPoint="0,1">
                 <GradientStop Color="{StaticResource ScrimTopColor}" Offset="0" />
@@ -22,11 +22,31 @@
             </LinearGradientBrush>
         </Grid.Background>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="Auto" />
-        </Grid.RowDefinitions>
+        <!--
+            Everything scrolls.
+
+            The window sizes itself to its content but is capped -- by
+            MaxPopupHeight, and then again by the monitor's work area, which on a
+            short screen or at 175% scaling is the smaller of the two. Without a
+            scroller, content past that cap was simply cut off with no way to
+            reach it: expanding Advanced pushed the log, the version and the
+            buttons under the bottom edge, and the window is deliberately not
+            resizable, so there was no way to get them back.
+
+            This is the outer one. The log keeps its own fixed-height scroller
+            inside, so a long log scrolls within its box instead of stretching
+            the window to the height of the session's history.
+        -->
+        <ScrollViewer VerticalScrollBarVisibility="Auto"
+                      VerticalScrollMode="Auto"
+                      HorizontalScrollMode="Disabled"
+                      HorizontalScrollBarVisibility="Disabled">
+            <Grid x:Name="Content" RowSpacing="0">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
 
         <!-- ===== Header: identity on the left, live state on the right ===== -->
         <Grid Grid.Row="0" Margin="2,0,2,18" ColumnSpacing="8">
@@ -319,5 +339,7 @@
                 </Border>
             </StackPanel>
         </Expander>
+            </Grid>
+        </ScrollViewer>
     </Grid>
 </Window>

--- a/windows/Relay.App/MainWindow.xaml
+++ b/windows/Relay.App/MainWindow.xaml
@@ -25,11 +25,11 @@
         <!--
             Everything scrolls.
 
-            The window sizes itself to its content but is capped -- by
-            MaxPopupHeight, and then again by the monitor's work area, which on a
+            The window sizes itself to its content but is capped twice: by
+            MaxPopupHeight, and again by the monitor's work area, which on a
             short screen or at 175% scaling is the smaller of the two. Without a
             scroller, content past that cap was simply cut off with no way to
-            reach it: expanding Advanced pushed the log, the version and the
+            reach it. Expanding Advanced pushed the log, the version and the
             buttons under the bottom edge, and the window is deliberately not
             resizable, so there was no way to get them back.
 

--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -710,8 +710,17 @@ public sealed partial class MainWindow : Window
         {
             try
             {
-                Root.Measure(new Windows.Foundation.Size(PopupWidth, double.PositiveInfinity));
-                var desired = Math.Clamp(Root.DesiredSize.Height, MinPopupHeight, MaxPopupHeight);
+                // Measure the content, not the scroller wrapped around it. A
+                // ScrollViewer asked for its desired size reports what it has
+                // been given rather than what it holds, so measuring the outer
+                // element would size the window to whatever it already was and
+                // never grow to fit.
+                var padding = Root.Padding.Top + Root.Padding.Bottom;
+                Content.Measure(new Windows.Foundation.Size(
+                    PopupWidth - Root.Padding.Left - Root.Padding.Right,
+                    double.PositiveInfinity));
+                var desired = Math.Clamp(
+                    Content.DesiredSize.Height + padding, MinPopupHeight, MaxPopupHeight);
                 PositionWindow((int)Math.Ceiling(desired));
             }
             catch


### PR DESCRIPTION
Expanding **Advanced** pushed the log, the version and the buttons under the bottom edge of the window, with no way to get them back.

## Root cause — two facts meeting, not one bug

```csharp
var desired = Math.Clamp(Root.DesiredSize.Height, MinPopupHeight, MaxPopupHeight);  // capped at 640
h = Math.Min(h, Math.Max(area.Height - margin * 2, 200));                            // capped again by the monitor
```

The window sizes itself to its content but is capped twice — by `MaxPopupHeight`, and then by the monitor's work area, which on a short screen or at 175% scaling is the smaller of the two.

And the only `ScrollViewer` in the entire window was the log box's own, fixed at `Height="116"`. So anything past the cap was **clipped**, and the window is deliberately not resizable — leaving no way to reach it.

## Why not just shrink it

Reducing the font or trimming the panel moves the cliff rather than removing it. The same content at 200% scaling, or on a 768px-tall screen, falls off again. The defect is that content taller than the window is unreachable — not that this particular panel is tall.

## The fix

The content scrolls. The window still prefers to size itself to fit — most states are far shorter than the cap and should not grow a scrollbar — and when it cannot, what does not fit is reachable instead of gone.

Sizing now measures the **content** rather than the scroller wrapped around it: a `ScrollViewer` reports the size it was *given*, not the size it *holds*, so measuring the outer element would have pinned the window to whatever height it already had and never grown to fit.

The log keeps its own fixed-height scroller inside, so a long log scrolls within its box instead of stretching the window to the height of the session's history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
