### PR TITLE
Stop the scrollbar sitting on top of the connected pill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,103 @@ Artifacts for every version are on the
 
 ## [Unreleased]
 
+## [2.0.0] — 2026-08-18
+
+One transport instead of two, a two-digit code that works for it, and the
+tunnel finally telling the truth about itself.
+
+### Changed — Fast Mode is gone (ADR-0009)
+
+Relay had two transports. Fast Mode was a **system-wide SOCKS5 proxy**, and it
+is removed. Not because it was broken: it was measured working on hardware, and
+`curl --socks5-hostname` returned the phone's VPN exit while the laptop's own
+exit differed.
+
+It is gone because of what it cost. A machine-wide proxy mutation, a rollback
+protocol, a crash-recovery hook, and this project's most dangerous failure — a
+stranded SOCKS proxy breaks every application on the machine, and most of the
+safety machinery in the Windows client existed for that one risk. What it bought
+was TCP-only sharing, so games, calls, installers and anything using UDP were
+never actually shared. Telegram Desktop was the common report: the browser
+worked, everything else did not, because only some programs honour a system
+proxy.
+
+There is now one transport, a real WireGuard tunnel, and **every** application
+goes through it.
+
+### Added — pair with the two digits, not just the QR
+
+Full Mode's keys live only inside the QR payload, so a laptop with no camera had
+no way in at all. Keys still cannot ride the beacon — it is broadcast and
+unauthenticated — so the beacon carries a `pairingPort` and the configuration
+comes over a short TCP exchange that is held until the person holding the phone
+allows it. The phone mints keys only after Allow, sends them once, and discards
+them when sharing stops.
+
+Phones already sharing now appear on the PC's first screen, so one click is the
+whole pairing when the list is not empty.
+
+### Added — the connected screen says what is happening
+
+A notification when the tunnel comes up, and live download and upload rates,
+totals, tunnel latency and connection duration — every figure read from the
+adapter Windows created, so it cannot drift from reality. Latency is measured to
+the tunnel's own peer and labelled as such, rather than blaming Relay for the
+round trip to a website.
+
+### Fixed
+
+- **"Connected" over a tunnel that had never handshaked.** The client reported
+  ready as soon as the WinTun adapter existed, which is equally true of a tunnel
+  whose peer is gone or whose keys have rotated. One field report showed four
+  `Connected` lines against zero peers seen by the phone. It now waits for a real
+  handshake, exits when the peer stops answering, and the app watches for that.
+- **Full Mode never reached the Connected state.** It dispatched one state
+  transition where Fast Mode dispatched two, so a live tunnel carrying traffic
+  displayed "Connecting…" with a Cancel button for as long as you cared to look.
+- **Connections opened before the tunnel stayed outside it.** Windows binds a TCP
+  connection to a source address for life, so long-lived ones — Telegram's, in
+  particular — kept leaving by the adapter they were born on. They are now closed
+  when the tunnel comes up so their owners reconnect through it; loopback and the
+  local network are left alone.
+- **The phone now says when its own VPN is swallowing the tunnel.** Android
+  routes by UID, and a full-tunnel VPN claims Relay's, so the handshake reply
+  went into the VPN instead of to the laptop. It cannot be fixed from inside the
+  app, so it is detected and named, with the one action that helps.
+- **Windows refusing to elevate from the install folder** is reported as itself.
+  Behind a junction — `%LOCALAPPDATA%\Programs` redirected to another drive —
+  ShellExecute fails before any prompt appears, and Relay used to blame other
+  VPNs.
+- **The popover stopped discarding what you were doing.** It hid on any focus
+  loss, so typed codes were lost and the window vanished mid-connect, including
+  when the elevation prompt took focus.
+- **Relay has a way back to itself.** It appears in Alt-Tab, stays put while
+  connected, and stops floating once it is no longer transient — Windows 11 hides
+  new tray icons, so the documented route back was behind a chevron.
+- **Advanced is reachable at any window size.** The window is capped by its own
+  maximum and again by the monitor's work area, and nothing scrolled, so
+  expanding Advanced pushed content under the bottom edge of a window that cannot
+  be resized.
+- **Errors stopped recommending a mode that no longer exists.**
+
+### Removed
+
+Fast Mode, the in-repo SOCKS5 server, the system-proxy session with its
+snapshot, rollback and crash-recovery hook, and the `--restore-proxy` entry
+point. Nothing Relay does now outlives its process.
+
+### Known limitations
+
+- **Sharing a phone VPN that captures Relay's UID does not work yet.** Inside the
+  VPN the tunnel's own transport is swallowed; excluded from it, the forwarded
+  traffic is the phone's plain connection. Relay detects the first case and says
+  so. Routing forwarded traffic through the VPN app's local proxy is the
+  intended fix.
+- One client per sharing session: the endpoint is configured with a single peer,
+  so the QR and the code deliver the same configuration rather than two.
+- No split tunnelling or per-application routing; the tunnel is all or nothing.
+
+
 ### Fixed — the August field reports
 
 Five separate defects, reported together and for a while assumed to be one. The

--- a/windows/Relay.App/MainWindow.xaml
+++ b/windows/Relay.App/MainWindow.xaml
@@ -36,11 +36,18 @@
             This is the outer one. The log keeps its own fixed-height scroller
             inside, so a long log scrolls within its box instead of stretching
             the window to the height of the session's history.
+
+            The right padding is the scrollbar's gutter. WinUI draws this
+            scrollbar over the content rather than beside it, so without a
+            reserved lane it landed on top of the connected pill and cut it in
+            half. ResizeToContent measures at the same reduced width, so the
+            height it computes is the height the content actually needs.
         -->
         <ScrollViewer VerticalScrollBarVisibility="Auto"
                       VerticalScrollMode="Auto"
                       HorizontalScrollMode="Disabled"
-                      HorizontalScrollBarVisibility="Disabled">
+                      HorizontalScrollBarVisibility="Disabled"
+                      Padding="0,0,12,0">
             <Grid x:Name="Content" RowSpacing="0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />

--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -32,6 +32,13 @@ public sealed partial class MainWindow : Window
     private const int MinPopupHeight = 340;
     private const int MaxPopupHeight = 640;
 
+    /// <summary>
+    /// The lane kept clear on the right for the outer scrollbar, which WinUI
+    /// draws over the content rather than beside it. Must match the
+    /// ScrollViewer's right padding in the XAML.
+    /// </summary>
+    private const int ScrollGutter = 12;
+
     private readonly AppController _controller = AppController.Instance;
 
     /// <summary>
@@ -717,7 +724,7 @@ public sealed partial class MainWindow : Window
                 // never grow to fit.
                 var padding = Root.Padding.Top + Root.Padding.Bottom;
                 Content.Measure(new Windows.Foundation.Size(
-                    PopupWidth - Root.Padding.Left - Root.Padding.Right,
+                    PopupWidth - Root.Padding.Left - Root.Padding.Right - ScrollGutter,
                     double.PositiveInfinity));
                 var desired = Math.Clamp(
                     Content.DesiredSize.Height + padding, MinPopupHeight, MaxPopupHeight);


### PR DESCRIPTION
The outer scroller from #77 made every screen reachable, but WinUI draws that
scrollbar *over* the content rather than beside it. On the connected screen it
landed across the status pill and cut Connected in half.

Two halves of one bug:

- The scrollbar had no lane of its own, so it overlaid whatever sat at the
  right edge.
- `ResizeToContent` measured the content at the full inner width, which is not
  the width the content gets once the scrollbar is up — so the height it
  computed could be short, which is what made the scrollbar appear in the first
  place.

Reserve 12px on the right and measure at that same reduced width. The constant
and the XAML padding have to agree; the comment on each says so.

Seen on hardware: 125% scaling, live tunnel, connected screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)