### PR TITLE
Follow the phone when its address changes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -177,8 +177,10 @@ jobs:
           if ($LASTEXITCODE -ne 0) { Write-Error "the Full Mode client tests failed" }
 
           $required = @(
-            'TestTheAdapterComesUpAndCarriesRoutedTraffic',  # the adapter comes up and carries routed traffic
-            'TestReadyIsWithheldWhenThePeerNeverAnswers'     # READY means a handshake, not merely an adapter
+            'TestTheAdapterComesUpAndCarriesRoutedTraffic',       # the adapter comes up and carries routed traffic
+            'TestReadyIsWithheldWhenThePeerNeverAnswers',         # READY means a handshake, not merely an adapter
+            'TestPeerPublicKeyIsThePeersNotTheDevices',           # an endpoint update names the peer, not the device
+            'TestRoamRejectsWhatIsNotAnAddressAndPort'            # a beacon is untrusted input
           )
           foreach ($name in $required) {
             if (-not ($output | Select-String -SimpleMatch "--- PASS: $name" -Quiet)) {

--- a/shared/pairing-beacon.md
+++ b/shared/pairing-beacon.md
@@ -182,6 +182,52 @@ decided and is tracked in `docs/testing.md`.
      the user pick. Ninety codes and two phones collide about one time in
      forty-five, so this is uncommon but not rare enough to leave unhandled.
 
+## Following a phone that changes address
+
+A phone's address is a DHCP lease. It changes on renewal, on rejoining the
+network, on the router rebooting — and when it does, a client that dialled the
+old one goes on dialling it. Full Mode's tunnel is the case that hurts: the PC
+is the WireGuard initiator and the phone is the responder, and WireGuard's own
+roaming only works the other way round. A responder learns an initiator's new
+address from the packets it receives; an initiator is never told anything. So
+the handshakes go to an address nobody is listening on, and the tunnel dies
+some minutes later having reported nothing but success.
+
+The beacon already carries the answer, because of what the code is:
+
+> Drawn with a cryptographically-seeded RNG at the start of each sharing
+> session, and kept for the life of that session.
+
+and because keys are per pairing and discarded when sharing stops. Together
+those give a client one inference:
+
+**A beacon with the same `code` and `state: "sharing"` from a different `host`
+is the same sharing session at a new address.** The keys it was given still
+apply, so it MAY re-point an existing tunnel at the new `host`/`port` rather
+than tearing it down and asking the person to pair again.
+
+A client that does this MUST:
+
+- Only follow while it holds a live configuration from *that* session. A code
+  is two digits and gets redrawn every session, so the same digits from a phone
+  that stopped and started sharing is a **different** session with different
+  keys, and following it would point a tunnel at an endpoint that will refuse
+  it. Holding a live tunnel is what distinguishes the two: sharing stopping
+  kills the tunnel, so a client still connected cannot be looking at a new
+  session.
+- Keep discovery running for the life of the tunnel, not only while a pairing
+  screen is open. On Windows this means continuing to probe: the firewall drops
+  unsolicited inbound UDP to an unelevated app, so beacons announcing the new
+  address do not arrive unless the PC has sent something first.
+- Treat the new address as untrusted, exactly like every other beacon field.
+  Re-pointing a tunnel is safe because it changes *where* packets are sent and
+  nothing about *who* may answer — a peer that cannot complete a handshake with
+  the existing keys gets nothing, so the worst a forged beacon achieves is the
+  tunnel this client already had, broken.
+
+A client that does not implement this is still correct; it just makes the
+person pair again after every lease change.
+
 ## The pairing exchange
 
 Two digits select a phone. This is how the PC then gets a configuration it can

--- a/wg/cmd/relaywg-client/main.go
+++ b/wg/cmd/relaywg-client/main.go
@@ -68,6 +68,10 @@ const (
 	// Ends the configuration on stdin without closing it. See [readConfig].
 	configTerminator = "END-CONFIG"
 
+	// Prefix of the line the app sends when the phone turns up at a new address,
+	// e.g. "ENDPOINT 192.168.1.14:51820". See [roam].
+	endpointPrefix = "ENDPOINT "
+
 	// Printed instead of READY when the adapter came up but the peer never
 	// answered. Distinct from a generic failure because the user's next action
 	// is different: rescan the QR, because the phone has almost certainly minted
@@ -193,11 +197,67 @@ func run(name, address, dns, routes, pipe string) error {
 		return fmt.Errorf("reporting readiness: %w", err)
 	}
 
-	waitForShutdown(reader, parentGone, peerLost(dev))
+	// The peer's key, read once: an endpoint update has to name the peer it
+	// moves, and this is the only place the configuration is still in hand.
+	peerKey := peerPublicKey(config)
+
+	waitForShutdown(reader, parentGone, peerLost(dev), func(line string) {
+		endpoint, ok := strings.CutPrefix(line, endpointPrefix)
+		if !ok {
+			return // the app says nothing else here; ignore whatever this was
+		}
+		endpoint = strings.TrimSpace(endpoint)
+		if err := roam(dev, peerKey, endpoint); err != nil {
+			fmt.Fprintf(os.Stderr, "could not follow the peer to %q: %v\n", endpoint, err)
+			return
+		}
+		fmt.Fprintf(os.Stderr, "the peer moved to %s\n", endpoint)
+	})
 	fmt.Fprintln(os.Stderr, "tearing down")
 	// The deferred Close calls remove the adapter, and Windows drops its
 	// addresses and routes with it.
 	return nil
+}
+
+// roam re-points the tunnel at the peer's new address without rebuilding it.
+//
+// WireGuard follows a peer that moves, but only in the direction this end is
+// not: a responder learns an initiator's address from the packets it receives,
+// and here the phone is the responder and the one that moves. Its address is a
+// DHCP lease, so a renewal or a rejoin is enough, and then every handshake goes
+// to an address nobody is listening on until [peerLost] tears the tunnel down —
+// which is what "worked once, then never again" looked like from the outside.
+//
+// Only the endpoint moves. The keys are untouched, so this cannot hand the
+// tunnel to anyone: an endpoint that does not hold the peer's key completes no
+// handshake and gets nothing. update_only is belt and braces on top of that —
+// a line naming an unknown key moves nothing rather than adding a second peer.
+//
+// The address must be a literal. The beacon carries one, and refusing anything
+// else keeps a name lookup — which blocks, and which the tunnel would be
+// routing — off this path entirely.
+func roam(dev *device.Device, peerKey, endpoint string) error {
+	if peerKey == "" {
+		return errors.New("the configuration named no peer to move")
+	}
+	if _, err := netip.ParseAddrPort(endpoint); err != nil {
+		return fmt.Errorf("not an address and port: %w", err)
+	}
+	return dev.IpcSet(fmt.Sprintf(
+		"public_key=%s\nupdate_only=true\nendpoint=%s\n", peerKey, endpoint))
+}
+
+// peerPublicKey returns the peer's key from an IPC configuration.
+//
+// The device's own key is private_key=, so the first public_key= line is the
+// peer's -- and there is exactly one peer, by ADR-0009.
+func peerPublicKey(config string) string {
+	for _, line := range strings.Split(config, "\n") {
+		if key, ok := strings.CutPrefix(strings.TrimSpace(line), "public_key="); ok {
+			return key
+		}
+	}
+	return ""
 }
 
 // waitForHandshake reports whether the peer answered within [within].
@@ -404,12 +464,23 @@ func readConfig(stdin *bufio.Reader) (config string, parentGone bool, err error)
 	return builder.String(), parentGone, nil
 }
 
-// waitForShutdown returns when the parent goes away or the console interrupts.
+// waitForShutdown returns when the parent goes away or the console interrupts,
+// passing each line the parent sends meanwhile to [onLine].
 //
-// Both matter. The parent closing stdin is the ordinary Disconnect; the signal
-// is what a person pressing Ctrl+C in a console window sends. Waiting on only
-// one of them leaves a tunnel running with nobody watching it.
-func waitForShutdown(channel *bufio.Reader, parentAlreadyGone bool, peerGone <-chan struct{}) {
+// Both shutdown paths matter. The parent closing stdin is the ordinary
+// Disconnect; the signal is what a person pressing Ctrl+C in a console window
+// sends. Waiting on only one of them leaves a tunnel running with nobody
+// watching it.
+//
+// The lines are new. This end of the channel used to be drained into
+// io.Discard, because the only thing it had to detect was the stream ending --
+// and reading it for content costs nothing, since it was already being read.
+func waitForShutdown(
+	channel *bufio.Reader,
+	parentAlreadyGone bool,
+	peerGone <-chan struct{},
+	onLine func(string),
+) {
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt, syscall.SIGTERM)
 
@@ -423,8 +494,11 @@ func waitForShutdown(channel *bufio.Reader, parentAlreadyGone bool, peerGone <-c
 
 	closed := make(chan struct{})
 	go func() {
-		io.Copy(io.Discard, channel)
-		close(closed)
+		defer close(closed)
+		scanner := bufio.NewScanner(channel)
+		for scanner.Scan() {
+			onLine(strings.TrimSpace(scanner.Text()))
+		}
 	}()
 
 	select {

--- a/wg/cmd/relaywg-client/roam_windows_test.go
+++ b/wg/cmd/relaywg-client/roam_windows_test.go
@@ -1,0 +1,51 @@
+package main
+
+import "testing"
+
+// The peer's key is what an endpoint update has to name, and it is read out of
+// a configuration whose first line is the *device's* key. Confusing the two
+// would send a well-formed update naming a peer that does not exist, which
+// update_only turns into silence rather than an error -- so the tunnel would
+// simply never follow the phone, with nothing logged to say why.
+func TestPeerPublicKeyIsThePeersNotTheDevices(t *testing.T) {
+	config := "private_key=aa\npublic_key=bb\nendpoint=192.168.1.14:51820\n" +
+		"allowed_ip=0.0.0.0/0\npersistent_keepalive_interval=25\n"
+
+	if got := peerPublicKey(config); got != "bb" {
+		t.Fatalf("peerPublicKey = %q, want the peer's key %q", got, "bb")
+	}
+}
+
+func TestPeerPublicKeyIsEmptyWhenThereIsNoPeer(t *testing.T) {
+	if got := peerPublicKey("private_key=aa\n"); got != "" {
+		t.Fatalf("peerPublicKey = %q, want empty", got)
+	}
+}
+
+// Everything reaching [roam] came off a broadcast beacon, so it is attacker
+// controlled. These are the cases that must not reach IpcSet at all -- a nil
+// device is safe precisely because a rejected line returns before touching it,
+// and this test would panic rather than fail if that stopped being true.
+func TestRoamRejectsWhatIsNotAnAddressAndPort(t *testing.T) {
+	for _, endpoint := range []string{
+		"",
+		// No port.
+		"192.168.1.14",
+		// A name, which would block on a lookup the tunnel is routing.
+		"phone.local:51820",
+		// Trailing junk.
+		"192.168.1.14:51820 evil",
+		// Not a port.
+		"192.168.1.14:99999",
+	} {
+		if err := roam(nil, "bb", endpoint); err == nil {
+			t.Errorf("roam accepted %q", endpoint)
+		}
+	}
+}
+
+func TestRoamRefusesWhenTheConfigurationNamedNoPeer(t *testing.T) {
+	if err := roam(nil, "", "192.168.1.14:51820"); err == nil {
+		t.Error("roam moved a peer that does not exist")
+	}
+}

--- a/windows/Relay.App.Tests/WgTunnelSessionTests.cs
+++ b/windows/Relay.App.Tests/WgTunnelSessionTests.cs
@@ -73,6 +73,47 @@ public class WgTunnelSessionTests
     }
 
     [Fact]
+    public void RoamTellsTheChildThePhonesNewAddress()
+    {
+        var process = ReadyProcess();
+        var session = new WgTunnelSession(new StubHost(process));
+        Assert.True(session.Connect(Params(), "192.168.1.13").Ok);
+
+        Assert.True(session.Roam("192.168.1.14", 51820));
+
+        // One line, after the configuration, in the form the client parses. A
+        // phone's address is a DHCP lease, and the PC is the WireGuard
+        // initiator — the direction WireGuard's own roaming does not cover.
+        Assert.Equal(
+            WgTunnelSession.EndpointPrefix + "192.168.1.14:51820", process.Written[^1]);
+    }
+
+    [Fact]
+    public void RoamDoesNothingWhenNoTunnelIsRunning()
+    {
+        var session = new WgTunnelSession(new StubHost(ReadyProcess()));
+
+        // Nothing to move, and nothing to write to. Reported rather than thrown:
+        // this runs off a beacon, on a timer, and a phone that disconnected a
+        // moment ago is ordinary rather than exceptional.
+        Assert.False(session.Roam("192.168.1.14", 51820));
+    }
+
+    [Fact]
+    public void RoamStopsAfterTheTunnelIsDisconnected()
+    {
+        var process = ReadyProcess();
+        var session = new WgTunnelSession(new StubHost(process));
+        session.Connect(Params(), "192.168.1.13");
+        var beforeDisconnect = process.Written.Count;
+
+        Assert.True(session.Disconnect().Ok);
+
+        Assert.False(session.Roam("192.168.1.14", 51820));
+        Assert.Equal(beforeDisconnect, process.Written.Count);
+    }
+
+    [Fact]
     public void ConnectHandsTheChildTheIpcConfigurationAndTheTerminator()
     {
         var process = ReadyProcess();

--- a/windows/Relay.App/MainWindow.xaml.cs
+++ b/windows/Relay.App/MainWindow.xaml.cs
@@ -120,7 +120,7 @@ public sealed partial class MainWindow : Window
         ConfigureAppWindow();
         ApplyStrings();
 
-        _controller.StateChanged += () => DispatcherQueue.TryEnqueue(Render);
+        _controller.StateChanged += () => DispatcherQueue.TryEnqueue(OnStateChanged);
         LocalLog.Changed += () => DispatcherQueue.TryEnqueue(RefreshLogs);
         // Discovery runs on its own socket thread; everything it touches here
         // is UI, so it is marshalled rather than handled where it arrives.
@@ -281,7 +281,7 @@ public sealed partial class MainWindow : Window
         // Ask the network who is there only while someone is looking. A tray
         // app that broadcasts once a second all day would be a bad neighbour,
         // and discovery is worth nothing when the window is hidden.
-        try { _discovery.SetProbing(true); } catch (Exception ex) { LocalLog.Add($"Probe failed: {ex.Message}"); }
+        UpdateProbing();
         PositionWindow(MinPopupHeight);
         _shownAtTick = Environment.TickCount64;
         AppWindow.Show();
@@ -324,9 +324,30 @@ public sealed partial class MainWindow : Window
     private void HideToTray()
     {
         StopScanning();
-        _discovery.SetProbing(false);
         _shown = false;
+        UpdateProbing();
         AppWindow.Hide();
+    }
+
+    /// <summary>
+    /// Probe while someone is looking, and while a tunnel is up.
+    ///
+    /// The second half is not for the pairing screen. It is how the tunnel
+    /// learns the phone has changed address: Windows Firewall drops
+    /// unsolicited inbound UDP to an unelevated app, and Relay's installer is
+    /// per-user so it cannot add a rule, which means the beacons announcing the
+    /// new lease do not arrive unless this end has sent something first. Stop
+    /// probing on hide and the roaming fix works only with the window open,
+    /// which is the case it is least needed in.
+    ///
+    /// ponytail: one small datagram per interface per second, and only while a
+    /// tunnel it would otherwise lose is running. Give discovery a slower
+    /// interval for this if a battery ever complains.
+    /// </summary>
+    private void UpdateProbing()
+    {
+        try { _discovery.SetProbing(_shown || _controller.StateName == "Connected"); }
+        catch (Exception ex) { LocalLog.Add($"Probe failed: {ex.Message}"); }
     }
 
     /// <summary>
@@ -1127,8 +1148,22 @@ public sealed partial class MainWindow : Window
     /// can easily beat the first beacon, and without this they are left looking
     /// at "still looking" while the phone sits in the list right below it.
     /// </summary>
+    /// <summary>
+    /// The code this session paired with, or null when we arrived by a route
+    /// that has none — the eight-character code, or a QR.
+    ///
+    /// A code is drawn once per sharing session and kept for its life
+    /// (/shared/pairing-beacon.md), so it is the only stable name the phone
+    /// has across a change of address.
+    /// </summary>
+    private string? _pairedCode;
+
     private void OnDevicesChanged()
     {
+        // Before the panel checks below: while connected the visible panel is
+        // neither of them, and following the phone matters most exactly then.
+        FollowIfMoved();
+
         if (ReferenceEquals(_visiblePanel, IdlePanel))
         {
             PopulateIdleList();
@@ -1141,6 +1176,46 @@ public sealed partial class MainWindow : Window
         // A row appearing or leaving changes how tall the panel is, and the
         // window does not resize itself.
         ResizeToContent();
+    }
+
+    /// <summary>
+    /// Re-points a live tunnel when the phone we paired with starts announcing
+    /// itself from somewhere else.
+    ///
+    /// Matching on the code alone is safe here only because the tunnel is still
+    /// up: sharing stopping kills it, so a phone that restarted sharing — and
+    /// therefore drew a fresh code and fresh keys — cannot be what this is
+    /// looking at. See /shared/pairing-beacon.md → "Following a phone that
+    /// changes address".
+    /// </summary>
+    /// <summary>
+    /// Renders, and keeps the two things that outlive the window in step with
+    /// the state: whether we are still probing, and which phone we are allowed
+    /// to follow.
+    /// </summary>
+    private void OnStateChanged()
+    {
+        if (_controller.StateName != "Connected")
+        {
+            // The session that drew this code is over. Keeping it would let the
+            // next phone to draw the same two digits look like ours.
+            _pairedCode = null;
+        }
+        UpdateProbing();
+        Render();
+    }
+
+    private void FollowIfMoved()
+    {
+        if (_pairedCode is null || _controller.StateName != "Connected") return;
+
+        var moved = _discovery.Devices.FirstOrDefault(d =>
+            d.Code == _pairedCode && d.Mode == QrPayload.ModeWireguard);
+        if (moved is null) return;
+
+        // RoamAsync is a no-op when the address has not actually changed, which
+        // is every beacon but the one that matters.
+        _ = _controller.RoamAsync(moved.Host, moved.PortNumber);
     }
 
     /// <summary>
@@ -1172,6 +1247,12 @@ public sealed partial class MainWindow : Window
             var payload = await PairAsync(device.Host, device.PairingPort!.Value, device.Name);
             if (payload is null) return; // PairAsync surfaced the reason
             await _controller.ConnectAsync(payload);
+
+            // After, not before: connecting passes through states that are not
+            // Connected, and OnStateChanged clears the code on every one of
+            // them, so a code set up front would be gone by the time it was
+            // wanted.
+            if (_controller.StateName == "Connected") _pairedCode = device.Code;
         }
         finally
         {

--- a/windows/Relay.App/Services/AppController.cs
+++ b/windows/Relay.App/Services/AppController.cs
@@ -315,6 +315,54 @@ public sealed class AppController(IProxyStore proxyStore, IBackupStore backupSto
     /// <summary>How often the tunnel is checked for having gone.</summary>
     private static readonly TimeSpan TunnelWatchInterval = TimeSpan.FromSeconds(5);
 
+    /// <summary>
+    /// Points a live tunnel at the phone's new address
+    /// (/shared/pairing-beacon.md → "Following a phone that changes address").
+    ///
+    /// Only ever called with a beacon carrying the code this session paired
+    /// with, which — because a code is drawn once per sharing session and keys
+    /// are discarded when sharing stops — means the same session at a new
+    /// lease. A different session would have killed this tunnel on its way out,
+    /// so still being Connected is what rules that case out.
+    ///
+    /// The payload's address moves with it: it is what the connected screen
+    /// shows, and a screen naming an address the tunnel no longer uses is worse
+    /// than one naming none.
+    /// </summary>
+    public async Task RoamAsync(string host, int port)
+    {
+        if (StateName != "Connected" || Payload is null) return;
+        if (Payload.Host == host && Payload.Port == port) return;
+
+        var from = $"{Payload.Host}:{Payload.Port}";
+        bool moved;
+        try
+        {
+            moved = await Task.Run(() => { lock (_sessionLock) return _tunnel.Roam(host, port); });
+        }
+        catch (Exception ex)
+        {
+            LocalLog.Add($"Could not follow the phone to {host}:{port}: {ex.Message}");
+            return;
+        }
+        if (!moved)
+        {
+            LocalLog.Add($"Could not follow the phone to {host}:{port}");
+            return;
+        }
+
+        lock (_gate)
+        {
+            // Re-checked under the lock: a Disconnect may have landed while the
+            // write was in flight, and rewriting the payload afterwards would
+            // leave the next screen describing a tunnel that is gone.
+            if (StateName != "Connected" || Payload is null) return;
+            Payload = Payload with { Host = host, Port = port };
+        }
+        LocalLog.Add($"The phone moved from {from} to {host}:{port}; the tunnel followed");
+        StateChanged?.Invoke();
+    }
+
     public void DismissError() => Dispatch("dismiss");
 
     // All ProxySession IO goes through these so a user Disconnect and the

--- a/windows/Relay.Core/WgTunnelSession.cs
+++ b/windows/Relay.Core/WgTunnelSession.cs
@@ -101,6 +101,12 @@ public sealed class WgTunnelSession(WgTunnelSession.IProcessHost processHost)
     /// <summary>Ends the configuration without closing stdin. Must match the client.</summary>
     public const string ConfigTerminator = "END-CONFIG";
 
+    /// <summary>
+    /// Prefix of the line that moves the tunnel to the phone's new address.
+    /// Must match the client.
+    /// </summary>
+    public const string EndpointPrefix = "ENDPOINT ";
+
     /// <summary>How long to wait for the adapter. Creating one is slow the first time.</summary>
     public static readonly TimeSpan ReadyTimeout = TimeSpan.FromSeconds(45);
 
@@ -176,6 +182,39 @@ public sealed class WgTunnelSession(WgTunnelSession.IProcessHost processHost)
 
         _tunnel = tunnel;
         return Result.Success;
+    }
+
+    /// <summary>
+    /// Follows the phone to a new address, keeping the tunnel that is already
+    /// up (/shared/pairing-beacon.md → "Following a phone that changes
+    /// address").
+    ///
+    /// A phone's address is a DHCP lease and the PC is the WireGuard initiator,
+    /// which is the direction WireGuard's own roaming does not cover — so a
+    /// renewed lease used to end the session some minutes later, reported as
+    /// the phone having gone away.
+    ///
+    /// Returns false rather than an error code because nothing here is worth
+    /// interrupting a working session for: the caller logs it, and if the phone
+    /// really has gone then the tunnel dies on its own and
+    /// <c>ERR_CONNECTION_LOST</c> says so from the one place that watches.
+    /// </summary>
+    public bool Roam(string host, int port)
+    {
+        var tunnel = _tunnel;
+        if (tunnel is null || tunnel.HasExited) return false;
+
+        try
+        {
+            tunnel.WriteLine($"{EndpointPrefix}{host}:{port}");
+            return true;
+        }
+        catch (Exception)
+        {
+            // The pipe is also how Disconnect is signalled, so a write failing
+            // here is very likely a tunnel that is already going down.
+            return false;
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
A phone's address is a DHCP lease. It changes on renewal, on rejoining the
network, on the router rebooting — and when it did, the tunnel went on dialling
the old one until the peer supervisor tore it down and reported the phone as
having gone away.

WireGuard follows a peer that moves, but only in the direction we are not: a
responder learns an initiator's address from the packets it receives, and here
the PC is the initiator and the phone is the one that moves. An initiator is
never told anything.

**This is what "worked once with excellent speed, then never again" was.**
Nothing was wrong with the pairing, the keys or the tunnel. Observed on hardware
this session: the laptop moved `192.168.1.13` → `192.168.1.10`, the phone turned
up at `192.168.1.14`, and a tunnel that had come up in 4 s died shortly after —
while the phone was still sharing, still broadcasting, `ServiceRecord: PRESENT`.
With the addresses held still, the same build ran 100 s without a wobble.

## The inference the beacon already supports

`/shared/pairing-beacon.md` says a code is drawn once per sharing session and
kept for its life, and that keys are per pairing and discarded when sharing
stops. So a beacon with the same `code` from a different `host` is *the same
session at a new lease*, and the keys still apply. This PR writes that inference
into the contract along with the rules a client has to follow to use it.

## What each end does

- **The client** takes an `ENDPOINT <ip>:<port>` line on the channel it already
  had — that end was being drained into `io.Discard`, so reading it for content
  costs nothing. The peer moves with `update_only`, so a malformed line can
  never add a peer. The address must be a literal: the beacon carries one, and
  refusing names keeps a blocking DNS lookup off a path the tunnel is routing.
- **The app** pushes it when a beacon carrying *this session's* code appears
  from somewhere else, and moves the payload's address with it — the connected
  screen shows that address, and one naming an endpoint the tunnel stopped using
  is worse than one naming none.
- **Discovery keeps probing while a tunnel is up.** Without this the fix works
  only with the window open, which is when it is least needed: Windows Firewall
  drops unsolicited inbound UDP to an unelevated app, and Relay's installer is
  per-user so it cannot add a rule, so the beacon announcing the new address
  never arrives unless this end has sent something first.

## Why this cannot be used against you

Only the endpoint moves; the keys are untouched. Re-pointing a tunnel changes
*where* packets go and nothing about *who* may answer, so an endpoint that does
not hold the peer's key completes no handshake and gets nothing. The worst a
forged beacon achieves is the tunnel you already had, broken — and the tunnel
watch already reports that as `ERR_CONNECTION_LOST`.

Matching on the code alone is safe **only because the tunnel is still up**:
sharing stopping kills it, so a phone that restarted sharing — and therefore
drew a fresh code and fresh keys — cannot be what this is looking at. The code
is dropped the moment the state leaves Connected, so the next phone to draw the
same two digits cannot inherit it.

## Tests

`peerPublicKey` and `roam`'s input validation are pure and tested, including
that a rejected endpoint returns *before* touching the device — the test passes
a nil device on purpose, so it panics rather than passes if that stops being
true. Both are named in `e2e.yml`'s required list, so a job that skips them
cannot come back green.

No new error codes and no new user-facing strings: a failed roam is logged, and
if the phone really has gone then the tunnel dies on its own and the one place
that watches says so.

## Not in this PR

The CHANGELOG entry — #78 is still open and owns that file for 2.0.0. This
belongs in it and I will add it once #78 lands.

Not yet proven on hardware. Forcing a lease change on this network is the next
step; everything above is reasoned from the contract and from what was measured
when the addresses moved on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
