### PR TITLE
Give the repo a cover that says what Relay is, in both languages

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -1,8 +1,6 @@
 <div align="center">
 
-<img src="docs/assets/android-idle.png" alt="ریلی روی گوشی اندروید" width="180">
-&nbsp;&nbsp;&nbsp;
-<img src="docs/assets/windows-idle.png" alt="ریلی روی ویندوز" width="240">
+<img src="docs/assets/cover.svg" alt="ریلی — اینترنت گوشی‌ات را با کامپیوترت به اشتراک بگذار. Share your phone's internet with your PC." width="100%">
 
 # Relay ⚡
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <div align="center">
 
-<img src="docs/assets/android-idle.png" alt="Relay running on an Android phone, sharing its connection" width="180">
-&nbsp;&nbsp;&nbsp;
-<img src="docs/assets/windows-idle.png" alt="Relay on Windows, showing the phone that is sharing" width="240">
+<img src="docs/assets/cover.svg" alt="Relay — share your phone's internet with your PC. اینترنت گوشی‌ات را با کامپیوترت به اشتراک بگذار." width="100%">
 
 # Relay ⚡
 

--- a/docs/assets/cover.svg
+++ b/docs/assets/cover.svg
@@ -1,0 +1,314 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 480" width="1200" height="480" role="img"
+     aria-label="Relay — Share your phone's internet with your PC. اینترنت گوشی‌ات را با کامپیوترت به اشتراک بگذار.">
+
+  <title>Relay — share your phone's internet with your PC</title>
+  <desc>Relay moves your phone's internet to your computer over an encrypted WireGuard tunnel. No root, no account, no server.</desc>
+
+  <defs>
+    <!-- ============================================================
+         TOKENS live in :root below. Nothing in this file is a magic
+         number that isn't traceable to one of them.
+         ============================================================ -->
+
+    <!-- Ground: near-black with a cool cast, so the mint accent reads warm against it -->
+    <linearGradient id="ground" x1="0" y1="0" x2="0.35" y2="1">
+      <stop offset="0"   stop-color="#0A0E13"/>
+      <stop offset="0.55" stop-color="#070A0E"/>
+      <stop offset="1"   stop-color="#05070A"/>
+    </linearGradient>
+
+    <!-- Aurora blobs. One accent (mint) plus two supporting hues, nothing more. -->
+    <radialGradient id="auroraMint" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#4ADFBF" stop-opacity="0.85"/>
+      <stop offset="1" stop-color="#4ADFBF" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="auroraBlue" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#2E7DFF" stop-opacity="0.62"/>
+      <stop offset="1" stop-color="#2E7DFF" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="auroraViolet" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0" stop-color="#7C5CFF" stop-opacity="0.5"/>
+      <stop offset="1" stop-color="#7C5CFF" stop-opacity="0"/>
+    </radialGradient>
+
+    <filter id="soften" x="-60%" y="-60%" width="220%" height="220%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="58"/>
+    </filter>
+
+    <!-- The lens. Liquid Glass is a LENSING material, not a flat blur: the
+         backdrop is blurred AND saturated, then the fill sits on top. -->
+    <filter id="lens" x="-25%" y="-25%" width="150%" height="150%" color-interpolation-filters="sRGB">
+      <feGaussianBlur stdDeviation="22" result="b">
+        <!-- Materialize: the surface arrives as a material, blur resolving with the scale -->
+        <animate attributeName="stdDeviation" from="46" to="22" dur="0.9s"
+                 begin="0s" fill="freeze" calcMode="spline" keySplines="0.22 1 0.36 1"/>
+      </feGaussianBlur>
+      <feColorMatrix in="b" type="saturate" values="1.9"/>
+    </filter>
+
+    <!-- Card fill: brighter at the light-catching top-leading corner -->
+    <linearGradient id="glassFill" x1="0.1" y1="0" x2="0.9" y2="1">
+      <stop offset="0"    stop-color="#FFFFFF" stop-opacity="0.13"/>
+      <stop offset="0.45" stop-color="#FFFFFF" stop-opacity="0.065"/>
+      <stop offset="1"    stop-color="#FFFFFF" stop-opacity="0.045"/>
+    </linearGradient>
+
+    <!-- Specular edge (2026: brighter) — strongest at top-leading, fading away -->
+    <linearGradient id="specular" x1="0" y1="0" x2="0.75" y2="1">
+      <stop offset="0"    stop-color="#FFFFFF" stop-opacity="0.55"/>
+      <stop offset="0.35" stop-color="#FFFFFF" stop-opacity="0.14"/>
+      <stop offset="1"    stop-color="#FFFFFF" stop-opacity="0.05"/>
+    </linearGradient>
+
+    <!-- The travelling highlight that sweeps the surface -->
+    <linearGradient id="sheen" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0"    stop-color="#FFFFFF" stop-opacity="0"/>
+      <stop offset="0.45" stop-color="#FFFFFF" stop-opacity="0.10"/>
+      <stop offset="0.5"  stop-color="#FFFFFF" stop-opacity="0.16"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.10"/>
+      <stop offset="1"    stop-color="#FFFFFF" stop-opacity="0"/>
+    </linearGradient>
+
+    <linearGradient id="beam" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0"    stop-color="#4ADFBF" stop-opacity="0"/>
+      <stop offset="0.12" stop-color="#4ADFBF" stop-opacity="0.55"/>
+      <stop offset="0.5"  stop-color="#8FF0DA" stop-opacity="0.75"/>
+      <stop offset="0.88" stop-color="#4ADFBF" stop-opacity="0.55"/>
+      <stop offset="1"    stop-color="#4ADFBF" stop-opacity="0"/>
+    </linearGradient>
+
+    <filter id="packetGlow" x="-300%" y="-300%" width="700%" height="700%">
+      <feGaussianBlur stdDeviation="3.2"/>
+    </filter>
+    <filter id="dotGlow" x="-300%" y="-300%" width="700%" height="700%">
+      <feGaussianBlur stdDeviation="2.2"/>
+    </filter>
+
+    <!-- Concentricity: card radius 42; pill radius 17 = 42 − 25 padding -->
+    <clipPath id="cardClip">
+      <rect x="230" y="110" width="740" height="260" rx="42"/>
+    </clipPath>
+  </defs>
+
+  <style>
+    :root {
+      /* ---- color ---- */
+      --label-1: rgba(255,255,255,0.97);
+      --label-2: rgba(228,240,252,0.72);
+      --label-3: rgba(214,230,248,0.56);
+      --accent:  #4ADFBF;
+      --edge-dark: rgba(0,0,0,0.42);
+
+      /* ---- motion: damping 0.8 / response 0.4 for arrivals ---- */
+      --spring: cubic-bezier(0.22, 1.02, 0.36, 1);
+      --spring-soft: cubic-bezier(0.34, 1.28, 0.52, 1);
+      --drift: cubic-bezier(0.45, 0, 0.55, 1);
+    }
+
+    /* System stack. The Persian fallbacks come first for Arabic-script glyphs
+       so the two languages sit on comparable shapes. */
+    .t {
+      font-family: "SF Pro Display", -apple-system, BlinkMacSystemFont,
+                   "Segoe UI", "Vazirmatn", "IRANSans", Tahoma, "Noto Sans Arabic",
+                   "Helvetica Neue", Arial, sans-serif;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    /* Vibrancy: text on glass is heavier and higher-contrast, never flat grey */
+    .wordmark { font-size: 74px; font-weight: 700; letter-spacing: -2.6px; fill: var(--label-1); }
+    .tag-en   { font-size: 25px; font-weight: 500; letter-spacing: -0.35px; fill: var(--label-2); }
+    .tag-fa   { font-size: 23px; font-weight: 500; letter-spacing: 0;       fill: var(--label-3); }
+    .pill-t   { font-size: 14.5px; font-weight: 600; letter-spacing: 0.15px; fill: rgba(255,255,255,0.82); }
+    .foot     { font-size: 13.5px; font-weight: 500; letter-spacing: 0.3px;  fill: rgba(210,228,246,0.40); }
+
+    /* ---------- entrance: materialize, don't fade ---------- */
+    @keyframes materialize {
+      from { opacity: 0; transform: scale(0.965); }
+      to   { opacity: 1; transform: scale(1); }
+    }
+    @keyframes rise {
+      from { opacity: 0; transform: translateY(14px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+    @keyframes rise-sm {
+      from { opacity: 0; transform: translateY(9px); }
+      to   { opacity: 1; transform: translateY(0); }
+    }
+
+    #card-group {
+      transform-box: fill-box; transform-origin: center;
+      animation: materialize 0.9s var(--spring) both;
+    }
+    #wordmark { animation: rise 0.62s var(--spring-soft) 0.30s both; }
+    #tagEn    { animation: rise 0.62s var(--spring-soft) 0.40s both; }
+    #tagFa    { animation: rise 0.62s var(--spring-soft) 0.48s both; }
+    #pills g  { animation: rise-sm 0.5s var(--spring-soft) both; }
+    #pills g:nth-child(1) { animation-delay: 0.58s; }
+    #pills g:nth-child(2) { animation-delay: 0.64s; }
+    #pills g:nth-child(3) { animation-delay: 0.70s; }
+    #pills g:nth-child(4) { animation-delay: 0.76s; }
+    #devices  { animation: rise-sm 0.7s var(--spring) 0.16s both; }
+    #footline { animation: rise-sm 0.6s var(--spring) 0.86s both; }
+
+    /* ---------- ambient loops (a reader arrives at any moment) ---------- */
+    @keyframes drift-a {
+      0%,100% { transform: translate(0,0) scale(1); }
+      50%     { transform: translate(70px,-38px) scale(1.14); }
+    }
+    @keyframes drift-b {
+      0%,100% { transform: translate(0,0) scale(1.06); }
+      50%     { transform: translate(-84px,30px) scale(0.92); }
+    }
+    @keyframes drift-c {
+      0%,100% { transform: translate(0,0) scale(0.96); }
+      50%     { transform: translate(46px,44px) scale(1.12); }
+    }
+    #blobA { animation: drift-a 21s var(--drift) infinite; }
+    #blobB { animation: drift-b 27s var(--drift) infinite; }
+    #blobC { animation: drift-c 24s var(--drift) infinite; }
+
+    /* Light travelling across the material */
+    @keyframes sweep { 0% { transform: translateX(-780px); } 100% { transform: translateX(1180px); } }
+    #sheen { animation: sweep 7.5s var(--drift) 1.3s infinite; }
+
+    /* Packets: phone → laptop, staggered, one direction because that is the
+       direction the internet actually travels here. */
+    @keyframes flow {
+      0%   { transform: translateX(0);    opacity: 0; }
+      6%   { opacity: 1; }
+      44%  { opacity: 1; }
+      56%  { opacity: 0; }          /* hidden while it passes behind the glass */
+      86%  { opacity: 1; }
+      100% { transform: translateX(852px); opacity: 0; }
+    }
+    .packet { animation: flow 3.6s linear infinite; }
+    .packet:nth-of-type(2) { animation-delay: 1.2s; }
+    .packet:nth-of-type(3) { animation-delay: 2.4s; }
+
+    @keyframes breathe { 0%,100% { opacity: 0.55; } 50% { opacity: 1; } }
+    .live { animation: breathe 2.6s var(--drift) infinite; }
+
+    @keyframes beam-pulse { 0%,100% { opacity: 0.55; } 50% { opacity: 0.95; } }
+    #beamline { animation: beam-pulse 4.2s var(--drift) infinite; }
+
+    /* ---------- accessibility ---------- */
+    @media (prefers-reduced-motion: reduce) {
+      #card-group, #wordmark, #tagEn, #tagFa, #pills g, #devices, #footline {
+        animation: none !important; opacity: 1 !important; transform: none !important;
+      }
+      #blobA, #blobB, #blobC, #sheen, .packet, .live, #beamline {
+        animation: none !important;
+      }
+      #sheen { opacity: 0; }
+      .packet { opacity: 1; }
+    }
+    @media (prefers-contrast: more) {
+      .tag-en { fill: rgba(255,255,255,0.94); }
+      .tag-fa { fill: rgba(255,255,255,0.86); }
+      .pill-t { fill: rgba(255,255,255,0.96); }
+    }
+  </style>
+
+  <!-- ===================== GROUND ===================== -->
+  <rect width="1200" height="480" fill="url(#ground)"/>
+
+  <!-- ===================== AURORA (the content behind the glass) ===================== -->
+  <g id="aurora" filter="url(#soften)">
+    <ellipse id="blobA" cx="300" cy="150" rx="250" ry="185" fill="url(#auroraMint)"/>
+    <ellipse id="blobB" cx="930" cy="360" rx="285" ry="200" fill="url(#auroraBlue)"/>
+    <ellipse id="blobC" cx="640" cy="415" rx="230" ry="150" fill="url(#auroraViolet)"/>
+  </g>
+
+  <!-- ===================== BEAM + DEVICES (behind the glass) ===================== -->
+  <g id="devices">
+    <!-- the link, dimmed where the card will sit over it -->
+    <rect id="beamline" x="178" y="249" width="852" height="2" fill="url(#beam)"/>
+
+    <!-- packets travelling phone → PC -->
+    <g transform="translate(178,250)">
+      <circle class="packet" r="3.2" fill="#4ADFBF" filter="url(#packetGlow)"/>
+      <circle class="packet" r="3.2" fill="#4ADFBF" filter="url(#packetGlow)"/>
+      <circle class="packet" r="3.2" fill="#4ADFBF" filter="url(#packetGlow)"/>
+    </g>
+
+    <!-- phone: the source -->
+    <g transform="translate(96,192)">
+      <rect x="0" y="0" width="66" height="116" rx="15"
+            fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.34)" stroke-width="1.5"/>
+      <rect x="7.5" y="9" width="51" height="92" rx="8" fill="rgba(74,223,191,0.14)"/>
+      <rect x="24" y="4.5" width="18" height="3" rx="1.5" fill="rgba(255,255,255,0.38)"/>
+      <circle class="live" cx="33" cy="55" r="9" fill="#4ADFBF" filter="url(#dotGlow)"/>
+      <circle cx="33" cy="55" r="3.6" fill="#0A0E13"/>
+    </g>
+
+    <!-- laptop: the destination -->
+    <g transform="translate(1024,196)">
+      <rect x="8" y="0" width="128" height="82" rx="10"
+            fill="rgba(255,255,255,0.06)" stroke="rgba(255,255,255,0.34)" stroke-width="1.5"/>
+      <rect x="15" y="7" width="114" height="68" rx="6" fill="rgba(46,125,255,0.14)"/>
+      <path d="M0 90 H144 A6 6 0 0 1 138 96 H6 A6 6 0 0 1 0 90 Z" fill="rgba(255,255,255,0.26)"/>
+      <circle class="live" cx="72" cy="41" r="8" fill="#4ADFBF" filter="url(#dotGlow)"/>
+    </g>
+  </g>
+
+  <!-- ===================== THE GLASS ===================== -->
+  <g id="card-group">
+    <!-- outer shadow: bigger surfaces read thicker -->
+    <rect x="230" y="110" width="740" height="260" rx="42" fill="#000" opacity="0.34"
+          filter="url(#soften)" transform="translate(0,14) scale(1)"/>
+
+    <!-- 1. lensed backdrop: the aurora itself, blurred and saturated through the card -->
+    <g clip-path="url(#cardClip)">
+      <use href="#aurora" filter="url(#lens)"/>
+      <use href="#devices" filter="url(#lens)" opacity="0.9"/>
+      <!-- 2. fill -->
+      <rect x="230" y="110" width="740" height="260" fill="url(#glassFill)"/>
+      <!-- travelling specular sheen, clipped to the surface -->
+      <rect id="sheen" x="230" y="110" width="300" height="260" fill="url(#sheen)"/>
+    </g>
+
+    <!-- 3. darkened edge (iOS 27) — separates the material from what is behind it -->
+    <rect x="230" y="110" width="740" height="260" rx="42"
+          fill="none" stroke="var(--edge-dark)" stroke-width="1.6"/>
+    <!-- 4. specular edge — the light-catching rim -->
+    <rect x="230.75" y="110.75" width="738.5" height="258.5" rx="41.25"
+          fill="none" stroke="url(#specular)" stroke-width="1.5"/>
+  </g>
+
+  <!-- ===================== CONTENT ===================== -->
+  <g class="t" text-anchor="middle">
+
+    <g id="wordmark">
+      <text class="wordmark" x="600" y="192">Relay</text>
+    </g>
+
+    <text id="tagEn" class="tag-en" x="600" y="240">Share your phone’s internet with your PC.</text>
+
+    <text id="tagFa" class="tag-fa" x="600" y="280" direction="rtl">اینترنت گوشی‌ات را با کامپیوترت به اشتراک بگذار</text>
+
+    <g id="pills">
+      <g>
+        <rect x="360" y="305" width="118" height="34" rx="17"
+              fill="rgba(255,255,255,0.07)" stroke="rgba(255,255,255,0.15)" stroke-width="1"/>
+        <text class="pill-t" x="419" y="327">WireGuard</text>
+      </g>
+      <g>
+        <rect x="492" y="305" width="92" height="34" rx="17"
+              fill="rgba(255,255,255,0.07)" stroke="rgba(255,255,255,0.15)" stroke-width="1"/>
+        <text class="pill-t" x="538" y="327">No root</text>
+      </g>
+      <g>
+        <rect x="598" y="305" width="116" height="34" rx="17"
+              fill="rgba(255,255,255,0.07)" stroke="rgba(255,255,255,0.15)" stroke-width="1"/>
+        <text class="pill-t" x="656" y="327">No account</text>
+      </g>
+      <g>
+        <rect x="728" y="305" width="112" height="34" rx="17"
+              fill="rgba(74,223,191,0.14)" stroke="rgba(74,223,191,0.34)" stroke-width="1"/>
+        <text class="pill-t" x="784" y="327" fill="#8FF0DA">Local-only</text>
+      </g>
+    </g>
+
+    <text id="footline" class="foot" x="600" y="425">Android → Windows · اندروید به ویندوز · open source, GPL-3.0</text>
+  </g>
+</svg>


### PR DESCRIPTION
The first thing anyone saw was two small screenshots and a heading — neither told a stranger what the project does, and the Persian half of the audience had to click into a second README to find out.

An animated SVG cover, built as one piece of Liquid Glass:

- **Both taglines on the same surface**, English and Persian, arriving together rather than one being a translation of the other.
- **A phone, a laptop, and packets travelling one way between them**, passing behind the glass and out the other side. That is the product in one picture, and it needs no caption in either language.
- **The material is a real lens**, not a flat panel — the aurora behind it is blurred and saturated *through* the card, with the iOS 27 darkened edge and specular rim.

CSS and SMIL only, no script, because GitHub serves this through its image proxy. It carries its own dark ground so it sits correctly on either GitHub theme, and `prefers-reduced-motion` drops every animation while leaving the composition intact — both paths rendered and checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)