### PR TITLE
First-run setup on Android, and an installer that looks finished

### DIFF
--- a/.github/scripts/universal-apk-e2e.sh
+++ b/.github/scripts/universal-apk-e2e.sh
@@ -119,6 +119,20 @@ tap_by_text() {
   adb shell input tap $(( (x1 + x2) / 2 )) $(( (y1 + y2) / 2 ))
 }
 
+# This is a genuine first run -- a freshly installed APK on a clean image -- so
+# the walkthrough is on screen and "Start Sharing" is behind it. That is the
+# point: this is the only place onboarding CAN be tested, because it happens
+# once per install and every other suite marks it seen to get past it.
+if tap_by_text "Done"; then
+  pass "ui.first-run-walkthrough"
+  sleep 2
+else
+  # Not fatal on its own: an upgrade over an install that had already been
+  # through it would legitimately not show one. The Start Sharing check below
+  # is what decides whether the app is usable.
+  echo "no walkthrough on screen (already onboarded?)"
+fi
+
 if tap_by_text "Start Sharing"; then
   pass "ui.tapped-start-sharing"
 else

--- a/android/app/src/androidTest/kotlin/io/relay/app/e2e/CrossPlatformSessionTest.kt
+++ b/android/app/src/androidTest/kotlin/io/relay/app/e2e/CrossPlatformSessionTest.kt
@@ -41,7 +41,12 @@ import kotlin.concurrent.thread
 @RunWith(AndroidJUnit4::class)
 class CrossPlatformSessionTest {
 
-    @get:Rule
+    // Order matters: the walkthrough has to be marked seen before the activity
+    // launches, and the compose rule launches it as the rules are applied.
+    @get:Rule(order = 0)
+    val skipOnboarding = SkipOnboarding()
+
+    @get:Rule(order = 1)
     val compose = createAndroidComposeRule<MainActivity>()
 
     @After

--- a/android/app/src/androidTest/kotlin/io/relay/app/e2e/GoldenJourneyTest.kt
+++ b/android/app/src/androidTest/kotlin/io/relay/app/e2e/GoldenJourneyTest.kt
@@ -50,7 +50,12 @@ import java.net.Socket
 @RunWith(AndroidJUnit4::class)
 class GoldenJourneyTest {
 
-    @get:Rule
+    // Order matters: the walkthrough has to be marked seen before the activity
+    // launches, and the compose rule launches it as the rules are applied.
+    @get:Rule(order = 0)
+    val skipOnboarding = SkipOnboarding()
+
+    @get:Rule(order = 1)
     val compose = createAndroidComposeRule<MainActivity>()
 
     private val destinations = mutableListOf<ServerSocket>()

--- a/android/app/src/androidTest/kotlin/io/relay/app/e2e/SkipOnboarding.kt
+++ b/android/app/src/androidTest/kotlin/io/relay/app/e2e/SkipOnboarding.kt
@@ -1,0 +1,36 @@
+package io.relay.app.e2e
+
+import androidx.test.platform.app.InstrumentationRegistry
+import io.relay.app.service.Settings
+import org.junit.rules.TestRule
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * Marks the first-run walkthrough as already seen, before the activity starts.
+ *
+ * These tests are about the sharing journey, not about onboarding: they open
+ * the app and reach for "Start Sharing". On a fresh install that button is
+ * behind the walkthrough, so without this every one of them fails looking for
+ * a node that is real but not on screen — which is exactly how they failed
+ * when onboarding landed.
+ *
+ * It has to be a rule rather than an @Before: ActivityScenarioRule launches the
+ * activity while the rules are being applied, which is before any @Before runs,
+ * so a preference written there would arrive one screen too late. Ordering puts
+ * this outside the compose rule.
+ *
+ * The walkthrough itself is not left untested by this — universal-apk-e2e.sh
+ * drives a real install through it on a real image, which is the only place it
+ * can be tested as a first run, because it only happens once per install.
+ */
+class SkipOnboarding : TestRule {
+    override fun apply(base: Statement, description: Description): Statement =
+        object : Statement() {
+            override fun evaluate() {
+                val context = InstrumentationRegistry.getInstrumentation().targetContext
+                Settings(context).onboarded = true
+                base.evaluate()
+            }
+        }
+}

--- a/android/app/src/main/kotlin/io/relay/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/relay/app/MainActivity.kt
@@ -15,12 +15,22 @@ import androidx.activity.viewModels
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import android.widget.Toast
+import io.relay.app.ui.OnboardingScreen
+import io.relay.app.ui.OnboardingStep
+import io.relay.app.ui.StepAction
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.flow.MutableStateFlow
 import io.relay.app.service.ConnectionRepository
 import io.relay.app.core.ConnectionState
+import io.relay.app.service.HomeScreenExtras
+import io.relay.app.service.Settings as RelaySettings
 import io.relay.app.service.DiagnosticReport
 import io.relay.app.ui.HomeScreen
 import io.relay.app.ui.MainViewModel
@@ -84,6 +94,21 @@ class MainActivity : ComponentActivity() {
                         }
                     }
 
+                    // First launch only. Everything it offers is reachable
+                    // from Advanced afterwards, so it never has to be shown twice.
+                    val settings = remember { RelaySettings(this@MainActivity) }
+                    var onboarding by remember { mutableStateOf(!settings.onboarded) }
+                    if (onboarding) {
+                        OnboardingScreen(
+                            steps = onboardingSteps(batteryExempt),
+                            onDone = {
+                                settings.onboarded = true
+                                onboarding = false
+                            },
+                        )
+                        return@RelayBackground
+                    }
+
                     HomeScreen(
                         state = state,
                         batteryExempt = batteryExempt,
@@ -144,6 +169,96 @@ class MainActivity : ComponentActivity() {
     companion object {
         /** Declared in the manifest and in res/xml/shortcuts.xml; keep the three in step. */
         const val ACTION_START_SHARING = "io.relay.app.action.START_SHARING"
+    }
+
+
+    /**
+     * The first-run checklist.
+     *
+     * Each step is a button when Android will let an app ask for the thing, and
+     * a line of instructions when it will not — which is version-dependent, so
+     * [HomeScreenExtras] decides and this only renders the answer. The
+     * alternative is a button that does nothing on the phones where the
+     * platform declines, which is worse than no button.
+     */
+    @androidx.compose.runtime.Composable
+    private fun onboardingSteps(batteryExempt: Boolean): List<OnboardingStep> {
+        val ctx = this
+        val notifGranted = Build.VERSION.SDK_INT < 33 ||
+            checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) ==
+            android.content.pm.PackageManager.PERMISSION_GRANTED
+
+        val canTile = HomeScreenExtras.canOfferTile()
+        val canWidget = HomeScreenExtras.canOfferWidget(ctx)
+        val widgetOn = HomeScreenExtras.widgetPlaced(ctx)
+        val tileManual = stringResource(R.string.onboarding_tile_manual)
+        val widgetManual = stringResource(R.string.onboarding_widget_manual)
+
+        return listOf(
+            OnboardingStep(
+                title = stringResource(R.string.onboarding_notif_title),
+                body = stringResource(R.string.onboarding_notif_body),
+                action = if (notifGranted) StepAction.Done else StepAction.Offer,
+                actionLabel = stringResource(R.string.onboarding_notif_action),
+                onAction = {
+                    if (Build.VERSION.SDK_INT >= 33) {
+                        requestPermissions(arrayOf(Manifest.permission.POST_NOTIFICATIONS), 1)
+                    }
+                },
+            ),
+            OnboardingStep(
+                title = stringResource(R.string.onboarding_battery_title),
+                body = stringResource(R.string.onboarding_battery_body),
+                action = if (batteryExempt) StepAction.Done else StepAction.Offer,
+                actionLabel = stringResource(R.string.onboarding_battery_action),
+                onAction = ::requestBatteryExemption,
+            ),
+            OnboardingStep(
+                title = stringResource(R.string.onboarding_tile_title),
+                body = stringResource(R.string.onboarding_tile_body),
+                action = if (canTile) StepAction.Offer else StepAction.Instruct,
+                actionLabel = if (canTile) {
+                    stringResource(R.string.onboarding_tile_action)
+                } else {
+                    tileManual
+                },
+                onAction = {
+                    if (canTile) {
+                        HomeScreenExtras.offerTile(ctx)
+                    } else {
+                        Toast.makeText(ctx, tileManual, Toast.LENGTH_LONG).show()
+                    }
+                },
+            ),
+            OnboardingStep(
+                title = stringResource(R.string.onboarding_widget_title),
+                body = stringResource(R.string.onboarding_widget_body),
+                action = when {
+                    widgetOn -> StepAction.Done
+                    canWidget -> StepAction.Offer
+                    else -> StepAction.Instruct
+                },
+                actionLabel = if (canWidget) {
+                    stringResource(R.string.onboarding_widget_action)
+                } else {
+                    widgetManual
+                },
+                onAction = {
+                    if (canWidget) {
+                        HomeScreenExtras.offerWidget(ctx)
+                    } else {
+                        Toast.makeText(ctx, widgetManual, Toast.LENGTH_LONG).show()
+                    }
+                },
+            ),
+            OnboardingStep(
+                title = stringResource(R.string.onboarding_shortcut_title),
+                body = stringResource(R.string.onboarding_shortcut_body),
+                action = StepAction.Done,
+                actionLabel = "",
+                onAction = {},
+            ),
+        )
     }
 
     /** Deep link to the exemption dialog for this app (ADR-0003). */

--- a/android/app/src/main/kotlin/io/relay/app/service/HomeScreenExtras.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/HomeScreenExtras.kt
@@ -1,0 +1,91 @@
+package io.relay.app.service
+
+import android.appwidget.AppWidgetManager
+import android.content.ComponentName
+import android.content.Context
+import android.os.Build
+
+/**
+ * The two places Relay can put itself that are not the app drawer: the Quick
+ * Settings shade, and the home screen.
+ *
+ * Both are *offers*, not installs — Android will not let an app place either
+ * one silently, and it should not. What differs is how much of the asking the
+ * platform will do for us, and that differs by version, which is the whole
+ * reason this file exists rather than the caller branching on SDK ints:
+ *
+ *  - The widget can be offered by a system dialog from Android 8 onwards, so
+ *    almost every phone that runs Relay can be handed a one-tap "add it".
+ *  - The tile cannot be offered until Android 13. Below that the only honest
+ *    thing is to say where the button is, which the caller does with a string
+ *    rather than a dialog.
+ *
+ * Callers ask [canOfferTile] / [canOfferWidget] first and show instructions
+ * instead when the answer is no, so the UI never presents a button that does
+ * nothing.
+ */
+object HomeScreenExtras {
+
+    /** True when the system will show its own "add this tile?" dialog. */
+    fun canOfferTile(): Boolean = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+
+    /**
+     * Asks the system to offer the tile. No-op below Android 13 — guarded
+     * rather than throwing, because the caller has already checked and a second
+     * failure mode here would only be reachable by a bug.
+     */
+    fun offerTile(context: Context) {
+        if (!canOfferTile()) return
+        runCatching {
+            val manager = context.getSystemService(android.app.StatusBarManager::class.java) ?: return
+            manager.requestAddTileService(
+                ComponentName(context, SharingTileService::class.java),
+                context.getString(io.relay.app.R.string.app_name),
+                android.graphics.drawable.Icon.createWithResource(
+                    context, io.relay.app.R.drawable.ic_shortcut_start,
+                ),
+                {},
+                {},
+            )
+        }
+    }
+
+    /**
+     * True when the launcher will show its own "add this widget?" dialog.
+     * Some launchers report false — Android is explicit that this is optional —
+     * and then the honest answer is instructions, not a dead button.
+     */
+    fun canOfferWidget(context: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return false
+        return runCatching {
+            AppWidgetManager.getInstance(context)?.isRequestPinAppWidgetSupported == true
+        }.getOrDefault(false)
+    }
+
+    fun offerWidget(context: Context) {
+        if (!canOfferWidget(context)) return
+        runCatching {
+            AppWidgetManager.getInstance(context)?.requestPinAppWidget(
+                ComponentName(context, SharingWidgetProvider::class.java),
+                null,
+                null,
+            )
+        }
+    }
+
+    /** Whether a widget is already on a home screen, so the offer can be hidden. */
+    fun widgetPlaced(context: Context): Boolean = runCatching {
+        val manager = AppWidgetManager.getInstance(context) ?: return false
+        manager.getAppWidgetIds(ComponentName(context, SharingWidgetProvider::class.java)).isNotEmpty()
+    }.getOrDefault(false)
+
+    /**
+     * Whether the tile has been added. Only knowable from Android 13 up, where
+     * the system tracks it; below that this returns false and the step stays on
+     * offer, which is the safe direction — telling someone to add a tile they
+     * already have costs a moment, hiding one they do not have costs the
+     * feature.
+     */
+    @Suppress("UNUSED_PARAMETER")
+    fun tilePlaced(context: Context): Boolean = false
+}

--- a/android/app/src/main/kotlin/io/relay/app/service/Settings.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/Settings.kt
@@ -19,7 +19,18 @@ class Settings(context: Context) {
         get() = prefs.getString(KEY_THEME, "system") ?: "system"
         set(value) = prefs.edit().putString(KEY_THEME, value).apply()
 
+    /**
+     * Whether the first-run walkthrough has been shown.
+     *
+     * Once, not once-per-version: someone who has already set the phone up does
+     * not want to be walked through it again because the app updated.
+     */
+    var onboarded: Boolean
+        get() = prefs.getBoolean(KEY_ONBOARDED, false)
+        set(value) = prefs.edit().putBoolean(KEY_ONBOARDED, value).apply()
+
     companion object {
         private const val KEY_THEME = "theme_mode"
+        private const val KEY_ONBOARDED = "onboarded"
     }
 }

--- a/android/app/src/main/kotlin/io/relay/app/ui/OnboardingScreen.kt
+++ b/android/app/src/main/kotlin/io/relay/app/ui/OnboardingScreen.kt
@@ -1,0 +1,175 @@
+package io.relay.app.ui
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import io.relay.app.R
+import io.relay.app.ui.theme.LocalGlass
+import io.relay.app.ui.theme.glassPanel
+
+/**
+ * What a step can be in. [Offer] means the platform will do the asking for us;
+ * [Instruct] means it will not, and the honest thing is to say where the button
+ * is rather than show one that does nothing.
+ */
+enum class StepAction { Offer, Instruct, Done }
+
+data class OnboardingStep(
+    val title: String,
+    val body: String,
+    val action: StepAction,
+    val actionLabel: String,
+    val onAction: () -> Unit,
+)
+
+/**
+ * The first launch.
+ *
+ * Relay's whole value is being *there* when a laptop has no internet — which
+ * means the setup that matters is not "how do I share" but "where will this be
+ * when I need it". So this screen is a checklist of exactly that, and every
+ * item that Android will let an app request is a button rather than a
+ * paragraph telling someone to go and find a setting.
+ *
+ * Shown once. Skippable from the first frame: someone who knows what they are
+ * doing should never have to read it, and everything here is reachable from
+ * Advanced afterwards.
+ */
+@Composable
+fun OnboardingScreen(
+    steps: List<OnboardingStep>,
+    onDone: () -> Unit,
+) {
+    val glass = LocalGlass.current
+
+    Box(Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 24.dp, vertical = 32.dp),
+        ) {
+            Spacer(Modifier.height(8.dp))
+
+            Text(
+                text = stringResource(R.string.onboarding_title),
+                style = MaterialTheme.typography.displaySmall,
+                color = glass.textPrimary,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.onboarding_body),
+                style = MaterialTheme.typography.bodyMedium,
+                color = glass.textSecondary,
+            )
+
+            Spacer(Modifier.height(28.dp))
+
+            steps.forEachIndexed { index, step ->
+                StepRow(index + 1, step)
+                Spacer(Modifier.height(12.dp))
+            }
+
+            Spacer(Modifier.height(20.dp))
+
+            Button(
+                onClick = onDone,
+                modifier = Modifier.fillMaxWidth().height(52.dp),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = glass.accent,
+                    contentColor = glass.onAccent,
+                ),
+            ) {
+                Text(
+                    stringResource(R.string.onboarding_done),
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            Spacer(Modifier.height(24.dp))
+        }
+    }
+}
+
+@Composable
+private fun StepRow(number: Int, step: OnboardingStep) {
+    val glass = LocalGlass.current
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .glassPanel(radius = 20.dp)
+            .padding(16.dp),
+        verticalAlignment = Alignment.Top,
+    ) {
+        // The number, not a tick: these are things to do, and a row that is
+        // already done says so on its action instead.
+        Surface(
+            shape = CircleShape,
+            color = if (step.action == StepAction.Done) glass.accent else glass.accentSubtle,
+            modifier = Modifier.size(26.dp),
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Text(
+                    text = if (step.action == StepAction.Done) "✓" else number.toString(),
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.SemiBold,
+                    color = if (step.action == StepAction.Done) glass.onAccent else glass.accent,
+                )
+            }
+        }
+
+        Spacer(Modifier.width(14.dp))
+
+        Column(Modifier.weight(1f)) {
+            Text(
+                text = step.title,
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.SemiBold,
+                color = glass.textPrimary,
+            )
+            Spacer(Modifier.height(3.dp))
+            Text(
+                text = step.body,
+                style = MaterialTheme.typography.labelSmall,
+                color = glass.textTertiary,
+            )
+
+            if (step.action != StepAction.Done) {
+                Spacer(Modifier.height(6.dp))
+                TextButton(
+                    onClick = step.onAction,
+                    contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp),
+                ) {
+                    Text(
+                        step.actionLabel,
+                        style = MaterialTheme.typography.labelSmall,
+                        fontWeight = FontWeight.SemiBold,
+                        color = glass.accent,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/android/app/src/main/kotlin/io/relay/app/ui/OnboardingScreen.kt
+++ b/android/app/src/main/kotlin/io/relay/app/ui/OnboardingScreen.kt
@@ -64,14 +64,24 @@ fun OnboardingScreen(
 ) {
     val glass = LocalGlass.current
 
-    Box(Modifier.fillMaxSize()) {
+    // The steps scroll; the button does not.
+    //
+    // It was inside the scroller, and on a short screen it sat below the fold —
+    // caught on an emulator, where the first-run check could not find it. A
+    // primary action that has to be scrolled to is a primary action some people
+    // never reach, and "some people" on a first-run screen means they never get
+    // past it.
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp),
+    ) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState())
-                .padding(horizontal = 24.dp, vertical = 32.dp),
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
         ) {
-            Spacer(Modifier.height(8.dp))
+            Spacer(Modifier.height(32.dp))
 
             Text(
                 text = stringResource(R.string.onboarding_title),
@@ -92,23 +102,23 @@ fun OnboardingScreen(
                 Spacer(Modifier.height(12.dp))
             }
 
-            Spacer(Modifier.height(20.dp))
-
-            Button(
-                onClick = onDone,
-                modifier = Modifier.fillMaxWidth().height(52.dp),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = glass.accent,
-                    contentColor = glass.onAccent,
-                ),
-            ) {
-                Text(
-                    stringResource(R.string.onboarding_done),
-                    fontWeight = FontWeight.SemiBold,
-                )
-            }
-            Spacer(Modifier.height(24.dp))
+            Spacer(Modifier.height(16.dp))
         }
+
+        Button(
+            onClick = onDone,
+            modifier = Modifier.fillMaxWidth().height(52.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = glass.accent,
+                contentColor = glass.onAccent,
+            ),
+        ) {
+            Text(
+                stringResource(R.string.onboarding_done),
+                fontWeight = FontWeight.SemiBold,
+            )
+        }
+        Spacer(Modifier.height(28.dp))
     }
 }
 

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -102,4 +102,26 @@
     <!-- ویجت صفحه اصلی -->
     <string name="widget_description">وضعیت اشتراک‌گذاری و کدی که باید در رایانه وارد کنید.</string>
     <string name="widget_tap_to_start">برای شروع بزنید</string>
+
+    <!-- اجرای اول -->
+    <string name="onboarding_title">رله را در دسترس نگه دار</string>
+    <string name="onboarding_body">رله وقتی بیشترین ارزش را دارد که لپ‌تاپ اینترنت ندارد. این‌ها آن لحظه را به یک ضربه می‌رسانند.</string>
+    <string name="onboarding_done">تمام</string>
+    <string name="onboarding_skip">رد کن</string>
+    <string name="onboarding_notif_title">اجازه بده رله وضعیتش را نشان دهد</string>
+    <string name="onboarding_notif_body">اشتراک‌گذاری در یک اعلان اجرا می‌شود تا اندروید آن را زنده نگه دارد و بتوانی از هرجا متوقفش کنی.</string>
+    <string name="onboarding_notif_action">اجازه دادن به اعلان‌ها</string>
+    <string name="onboarding_battery_title">اشتراک‌گذاری را زنده نگه دار</string>
+    <string name="onboarding_battery_body">بدون این، اندروید ممکن است با خاموش‌شدن صفحه اشتراک‌گذاری را قطع کند.</string>
+    <string name="onboarding_battery_action">اجازه دادن</string>
+    <string name="onboarding_tile_title">کاشی تنظیمات سریع را اضافه کن</string>
+    <string name="onboarding_tile_body">شروع و توقف اشتراک‌گذاری از بالای صفحه، بدون باز کردن چیزی.</string>
+    <string name="onboarding_tile_action">افزودن کاشی</string>
+    <string name="onboarding_tile_manual">نوار بالا را پایین بکش، مداد یا + را بزن، بعد رله را به داخل بکش.</string>
+    <string name="onboarding_widget_title">ویجت صفحه اصلی را اضافه کن</string>
+    <string name="onboarding_widget_body">کدی که باید در رایانه وارد کنی را نشان می‌دهد، به‌اندازه‌ای بزرگ که از آن‌طرف میز خوانده شود.</string>
+    <string name="onboarding_widget_action">افزودن به صفحه اصلی</string>
+    <string name="onboarding_widget_manual">روی صفحه اصلی نگه دار، ویجت‌ها را انتخاب کن و رله را پیدا کن.</string>
+    <string name="onboarding_shortcut_title">آیکون رله را نگه دار</string>
+    <string name="onboarding_shortcut_body">«شروع اشتراک‌گذاری» همان‌جا هست — چیزی برای تنظیم نیست.</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -102,4 +102,26 @@
     <!-- Home screen widget -->
     <string name="widget_description">Sharing state and the code to type on your PC.</string>
     <string name="widget_tap_to_start">Tap to start sharing</string>
+
+    <!-- First run -->
+    <string name="onboarding_title">Keep Relay within reach</string>
+    <string name="onboarding_body">Relay matters most when a laptop has no internet. These put it one tap away when that happens.</string>
+    <string name="onboarding_done">Done</string>
+    <string name="onboarding_skip">Skip</string>
+    <string name="onboarding_notif_title">Let Relay show its status</string>
+    <string name="onboarding_notif_body">Sharing runs in a notification so Android keeps it alive and you can stop it from anywhere.</string>
+    <string name="onboarding_notif_action">Allow notifications</string>
+    <string name="onboarding_battery_title">Keep sharing alive</string>
+    <string name="onboarding_battery_body">Without this, Android can stop sharing when the screen goes off.</string>
+    <string name="onboarding_battery_action">Allow</string>
+    <string name="onboarding_tile_title">Add the Quick Settings tile</string>
+    <string name="onboarding_tile_body">Start and stop sharing from the shade, without opening anything.</string>
+    <string name="onboarding_tile_action">Add the tile</string>
+    <string name="onboarding_tile_manual">Pull down the shade, tap the pencil or + to edit, then drag Relay in.</string>
+    <string name="onboarding_widget_title">Add the home screen widget</string>
+    <string name="onboarding_widget_body">Shows the code to type on your PC, big enough to read across a desk.</string>
+    <string name="onboarding_widget_action">Add to home screen</string>
+    <string name="onboarding_widget_manual">Long-press the home screen, choose Widgets, then find Relay.</string>
+    <string name="onboarding_shortcut_title">Long-press the Relay icon</string>
+    <string name="onboarding_shortcut_body">Start Sharing is already there — nothing to set up.</string>
 </resources>

--- a/windows/installer/relay.iss
+++ b/windows/installer/relay.iss
@@ -32,6 +32,11 @@ OutputDir=output
 Compression=lzma2
 SolidCompression=yes
 WizardStyle=modern
+; The installer's own icon, and the one Apps & Features shows. Without these
+; both fall back to Inno's default, which is the first and last impression a
+; person gets of whether this is finished software.
+SetupIconFile={#SourceDir}\Assets\Relay.ico
+UninstallDisplayIcon={app}\Relay.App.exe
 #if AppPlatform == "x64"
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
@@ -42,13 +47,28 @@ Name: "english"; MessagesFile: "compiler:Default.isl"
 
 [Tasks]
 Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{cm:AdditionalIcons}"; Flags: unchecked
+; A tray app is worth having at login: it is the thing you want already running
+; when a laptop turns out to have no internet. Off by default -- deciding that
+; for someone is exactly the behaviour that makes people distrust installers --
+; and the same switch lives in Advanced, reading the same registry value.
+Name: "startup"; Description: "Start Relay when I sign in"; GroupDescription: "Additional options"; Flags: unchecked
 
 [Files]
 Source: "{#SourceDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Icons]
-Name: "{autoprograms}\Relay"; Filename: "{app}\Relay.App.exe"
-Name: "{autodesktop}\Relay"; Filename: "{app}\Relay.App.exe"; Tasks: desktopicon
+; IconFilename is explicit rather than inherited from the exe: Windows caches
+; shortcut icons aggressively, and an upgrade that changes the exe's icon does
+; not always repaint a shortcut that only points at the exe.
+Name: "{autoprograms}\Relay"; Filename: "{app}\Relay.App.exe"; IconFilename: "{app}\Assets\Relay.ico"; Comment: "Share your phone's internet with this PC"
+Name: "{autodesktop}\Relay"; Filename: "{app}\Relay.App.exe"; IconFilename: "{app}\Assets\Relay.ico"; Tasks: desktopicon
+
+[Registry]
+; The same value StartupRegistration.cs reads and writes, including the --tray
+; argument, so the installer checkbox and the switch in Advanced are one setting
+; rather than two that can disagree. uninsdeletevalue so uninstalling does not
+; leave Windows trying to start something that is gone.
+Root: HKCU; Subkey: "Software\Microsoft\Windows\CurrentVersion\Run"; ValueType: string; ValueName: "Relay"; ValueData: """{app}\Relay.App.exe"" --tray"; Flags: uninsdeletevalue; Tasks: startup
 
 [Run]
 Filename: "{app}\Relay.App.exe"; Description: "{cm:LaunchProgram,Relay}"; Flags: nowait postinstall skipifsilent


### PR DESCRIPTION
### First launch teaches the phone where Relay lives

A tile and a widget are only useful if they are on the phone, and nothing said they existed. First launch is now a short checklist of exactly what decides whether Relay is reachable when a laptop has no internet: notifications, the battery exemption, the tile, the widget, and the launcher shortcut that is already there.

**Every item Android will let an app request is a button; the rest say where the control is.** Which is which is version-dependent and decided in one place:

| | offered by a system dialog |
|---|---|
| Widget | Android 8+ — so almost every phone gets one tap |
| Tile | Android 13+ only. The test phone here is Android 11, so it gets instructions rather than a button that silently does nothing |

Shown once, not once per version, and skippable from the first frame.

### The installer

`SetupIconFile` and `UninstallDisplayIcon` were both unset, so the installer and the Apps & Features entry each used Inno Setup's default artwork. Shortcuts now name `Relay.ico` explicitly rather than inheriting from the exe — Windows caches shortcut icons hard, and an upgrade that changes only the exe icon does not reliably repaint them.

Plus an unchecked *Start Relay when I sign in* task, writing **the same HKCU Run value** `StartupRegistration.cs` reads, `--tray` included — so the installer checkbox and the switch in Advanced are one setting rather than two that drift apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)