### PR TITLE
Stop clipping the instruction text on the first-run screen

### DIFF
--- a/android/app/src/main/kotlin/io/relay/app/ui/OnboardingScreen.kt
+++ b/android/app/src/main/kotlin/io/relay/app/ui/OnboardingScreen.kt
@@ -166,19 +166,40 @@ private fun StepRow(number: Int, step: OnboardingStep) {
                 color = glass.textTertiary,
             )
 
-            if (step.action != StepAction.Done) {
-                Spacer(Modifier.height(6.dp))
-                TextButton(
-                    onClick = step.onAction,
-                    contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp),
-                ) {
+            when (step.action) {
+                // Something to press: the platform will do the asking.
+                StepAction.Offer -> {
+                    Spacer(Modifier.height(6.dp))
+                    TextButton(
+                        onClick = step.onAction,
+                        contentPadding = androidx.compose.foundation.layout.PaddingValues(0.dp),
+                    ) {
+                        Text(
+                            step.actionLabel,
+                            style = MaterialTheme.typography.labelSmall,
+                            fontWeight = FontWeight.SemiBold,
+                            color = glass.accent,
+                        )
+                    }
+                }
+                // Where the control is, when the platform will not ask for us.
+                //
+                // Plain text, not a button. It was a TextButton with zero
+                // content padding, and the wrapped instruction came out with
+                // the first character of each line shaved off — a button lays
+                // its label out as one line and clips what does not fit. It
+                // also was not a button in any useful sense: pressing it only
+                // repeated the same sentence in a toast.
+                StepAction.Instruct -> {
+                    Spacer(Modifier.height(6.dp))
                     Text(
                         step.actionLabel,
                         style = MaterialTheme.typography.labelSmall,
-                        fontWeight = FontWeight.SemiBold,
+                        fontWeight = FontWeight.Medium,
                         color = glass.accent,
                     )
                 }
+                StepAction.Done -> Unit
             }
         }
     }


### PR DESCRIPTION
Seen on the phone, on the real first run:

> ⌐ull down the shade, tap the pencil or + to edit,
> ʰhen drag Relay in.

The Quick Settings step shows *where the control is* on Android 11, since the platform will not offer a tile below 13 — and that text was rendered in a `TextButton` with zero content padding. A button lays its label out as a single line and clips what does not fit, which a two-line instruction always will.

It also was not a button in any useful sense: pressing it repeated the same sentence in a toast.

Instruction rows are plain text now. Rows that really do have something to press are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)