### PR TITLE
Make the update button actually update

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,9 +4,16 @@
      "Requested internal only, but not enough space" — surfaced to the user as
      nothing more than "App not installed". "auto" lets the system place the
      app on adoptable storage when internal is tight, and changes nothing on a
-     phone with room. Relay has no widgets, no account authenticators and no
-     device-admin receiver, none of which survive being moved, so there is
-     nothing here that "auto" can break. -->
+     phone with room.
+
+     This used to say Relay had nothing that "auto" could break. It now has a
+     home screen widget, and a widget IS removed if the app is moved to
+     adoptable storage. The trade is deliberate and it is not close: a failed
+     install stops everyone, on a phone that reports nothing more useful than
+     "App not installed", while losing a widget affects only someone who has
+     both placed one and moved the app to an SD card, and is fixed by placing
+     it again. If that ever stops being the right call, internalOnly is the
+     one-word change — and the install failure comes back with it. -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     android:installLocation="auto">
 
@@ -17,6 +24,9 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <!-- Handing a downloaded APK to the system installer. Android still shows
+         its own prompt; this only allows Relay to be the app that asks. -->
+    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS" />
 
     <application
@@ -44,6 +54,20 @@
                 android:name="android.app.shortcuts"
                 android:resource="@xml/shortcuts" />
         </activity>
+
+
+        <!-- Serves the verified update APK to the package installer. Not
+             exported: the installer reads it through the one-shot read
+             permission the intent grants, and nothing else can open it. -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.updates"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/update_paths" />
+        </provider>
 
         <receiver
             android:name=".service.SharingWidgetProvider"

--- a/android/app/src/main/kotlin/io/relay/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/io/relay/app/MainActivity.kt
@@ -77,6 +77,7 @@ class MainActivity : ComponentActivity() {
                     }
 
                     val pendingClient by ConnectionRepository.clientGate.pending.collectAsState()
+                    val updateAvailable by viewModel.updateAvailable.collectAsState()
 
                     // The launcher shortcut. Honoured only from Idle: arriving
                     // here while already sharing means the person tapped it out
@@ -130,6 +131,10 @@ class MainActivity : ComponentActivity() {
                         onDismissWarning = viewModel::dismissWarning,
                         onSetTheme = viewModel::setThemeMode,
                         onClearLogs = viewModel::clearLogs,
+                        // The banner used to offer an update it had no way to
+                        // deliver: HomeScreen took this lambda, nothing passed
+                        // one, and the default was empty.
+                        onGetUpdate = viewModel::getUpdate,
                         onShareLogs = {
                             // Built here rather than in the view model because the
                             // report needs the installed version, and the share
@@ -140,6 +145,7 @@ class MainActivity : ComponentActivity() {
                             val report = DiagnosticReport.build(state, logs, version)
                             startActivity(DiagnosticReport.shareIntent(this@MainActivity, report))
                         },
+                        updateAvailable = updateAvailable,
                         pendingClient = pendingClient?.address,
                         onApproveClient = { allowed ->
                             pendingClient?.let {

--- a/android/app/src/main/kotlin/io/relay/app/service/UpdateFetcher.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/UpdateFetcher.kt
@@ -1,0 +1,159 @@
+package io.relay.app.service
+
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.content.FileProvider
+import io.relay.app.core.UpdateDownload
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+
+/**
+ * Fetches the latest release's APK, proves it is the one the release published,
+ * and hands it to the system installer.
+ *
+ * The proving is [UpdateDownload]'s job and it is not optional: nothing reaches
+ * the installer unless its SHA-256 appears in the release's own SHA256SUMS.txt.
+ * Relay carries a phone's whole connection, so an update path that installs
+ * whatever the network returned is the part of this app most worth attacking.
+ *
+ * Android then shows its own install prompt. A sideloaded app cannot install
+ * silently — that is a platform floor, not a decision made here — so this gets
+ * the bytes right and lets the system ask the last question.
+ */
+object UpdateFetcher {
+
+    private const val LATEST =
+        "https://api.github.com/repos/Mahdi-mortazavi/relay/releases/latest"
+
+    /** What the UI has to say afterwards. */
+    sealed interface Result {
+        /** Verified and handed over; Android is asking the user now. */
+        data object Installing : Result
+
+        /** Offline, rate-limited, download failed. Try later; not an alarm. */
+        data object Unavailable : Result
+
+        /** Downloaded, but not the bytes the release published. */
+        data object ChecksumMismatch : Result
+
+        /** The release published no checksums, so nothing could be verified. */
+        data object Unverifiable : Result
+    }
+
+    /**
+     * Downloads, verifies and launches the installer.
+     *
+     * Runs entirely off the main thread. Returns as soon as the system installer
+     * has been asked to open — it outlives this process, so waiting on it is not
+     * something that can work.
+     */
+    suspend fun downloadAndInstall(context: Context): Result = withContext(Dispatchers.IO) {
+        val release = runCatching { JSONObject(get(LATEST)) }.getOrNull()
+            ?: return@withContext Result.Unavailable
+
+        if (release.optBoolean("draft") || release.optBoolean("prerelease")) {
+            return@withContext Result.Unavailable
+        }
+
+        val assets = release.optJSONArray("assets") ?: return@withContext Result.Unavailable
+        val byName = buildMap {
+            for (i in 0 until assets.length()) {
+                val asset = assets.optJSONObject(i) ?: continue
+                val name = asset.optString("name").takeIf { it.isNotEmpty() } ?: continue
+                put(name, asset.optString("browser_download_url"))
+            }
+        }
+
+        val abis = Build.SUPPORTED_ABIS?.toList().orEmpty()
+        val apkName = UpdateDownload.assetFor(byName.keys.toList(), abis)
+            ?: return@withContext Result.Unavailable
+        val apkUrl = byName[apkName]?.takeIf { it.isNotEmpty() }
+            ?: return@withContext Result.Unavailable
+        val sumsUrl = byName["SHA256SUMS.txt"]?.takeIf { it.isNotEmpty() }
+            ?: return@withContext Result.Unverifiable
+
+        val checksums = runCatching { get(sumsUrl) }.getOrNull()
+            ?: return@withContext Result.Unavailable
+
+        // Its own directory, cleared each time: the previous attempt's APK is
+        // never what this run is about to verify.
+        val directory = File(context.cacheDir, "updates").apply {
+            deleteRecursively()
+            mkdirs()
+        }
+        val target = File(directory, apkName)
+
+        val downloaded = runCatching { download(apkUrl, target) }.getOrDefault(false)
+        if (!downloaded) {
+            target.delete()
+            return@withContext Result.Unavailable
+        }
+
+        when (val verdict = UpdateDownload.verify(target, checksums)) {
+            is UpdateDownload.Result.Ready -> {
+                LocalLog.add("Update $apkName verified; opening the installer")
+                launchInstaller(context, verdict.file)
+                Result.Installing
+            }
+            UpdateDownload.Result.ChecksumMismatch -> {
+                // Loud, because this is the case that must never be shrugged off.
+                LocalLog.add("Update REJECTED: $apkName did not match the published checksum")
+                Result.ChecksumMismatch
+            }
+            UpdateDownload.Result.Unverifiable -> {
+                LocalLog.add("Update rejected: no published checksum for $apkName")
+                Result.Unverifiable
+            }
+            UpdateDownload.Result.Unavailable -> Result.Unavailable
+        }
+    }
+
+    /**
+     * Hands the APK to the package installer through a content:// URI. A file://
+     * URI would throw FileUriExposedException on anything since Android 7, and
+     * the installer could not read it anyway.
+     */
+    private fun launchInstaller(context: Context, apk: File) {
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.updates", apk)
+        val intent = Intent(Intent.ACTION_VIEW).apply {
+            setDataAndType(uri, "application/vnd.android.package-archive")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        context.startActivity(intent)
+    }
+
+    private fun get(url: String): String =
+        (URL(url).openConnection() as HttpURLConnection).run {
+            setRequestProperty("User-Agent", "Relay-UpdateFetcher")
+            connectTimeout = 10_000
+            readTimeout = 15_000
+            try {
+                inputStream.bufferedReader().use { it.readText() }
+            } finally {
+                disconnect()
+            }
+        }
+
+    /** Streams to disk rather than into memory: these APKs are tens of megabytes. */
+    private fun download(url: String, target: File): Boolean {
+        val connection = URL(url).openConnection() as HttpURLConnection
+        connection.setRequestProperty("User-Agent", "Relay-UpdateFetcher")
+        connection.instanceFollowRedirects = true
+        connection.connectTimeout = 15_000
+        connection.readTimeout = 60_000
+        try {
+            if (connection.responseCode !in 200..299) return false
+            connection.inputStream.use { input ->
+                target.outputStream().use { output -> input.copyTo(output) }
+            }
+            return target.length() > 0
+        } finally {
+            connection.disconnect()
+        }
+    }
+}

--- a/android/app/src/main/kotlin/io/relay/app/ui/MainViewModel.kt
+++ b/android/app/src/main/kotlin/io/relay/app/ui/MainViewModel.kt
@@ -12,6 +12,7 @@ import io.relay.app.service.LocalLog
 import io.relay.app.service.Settings
 import io.relay.app.service.SharingService
 import io.relay.app.core.UpdateCheck
+import io.relay.app.service.UpdateFetcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import androidx.lifecycle.viewModelScope
@@ -69,6 +70,36 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
 
     fun dismissUpdate() {
         _updateAvailable.value = null
+    }
+
+    /** True while an update is being fetched, so the button cannot be tapped twice. */
+    private val _updating = MutableStateFlow(false)
+    val updating: StateFlow<Boolean> = _updating
+
+    /**
+     * Downloads the release APK, verifies it against the release's published
+     * checksums, and opens the system installer.
+     *
+     * The "Get it" button used to call nothing at all: HomeScreen took an
+     * onGetUpdate lambda, MainActivity never passed one, and the default was
+     * empty — so the banner offered an update it had no way to deliver.
+     */
+    fun getUpdate() {
+        if (_updating.value) return
+        _updating.value = true
+        viewModelScope.launch {
+            val result = UpdateFetcher.downloadAndInstall(getApplication())
+            _updating.value = false
+            when (result) {
+                UpdateFetcher.Result.Installing -> _updateAvailable.value = null
+                UpdateFetcher.Result.ChecksumMismatch ->
+                    LocalLog.add("Update refused: the download did not match the published checksum")
+                UpdateFetcher.Result.Unverifiable ->
+                    LocalLog.add("Update refused: that release published no checksums")
+                UpdateFetcher.Result.Unavailable ->
+                    LocalLog.add("Update could not be downloaded; try again later")
+            }
+        }
     }
 
     private val _batteryExempt = MutableStateFlow(readBatteryExempt())

--- a/android/app/src/main/res/xml/update_paths.xml
+++ b/android/app/src/main/res/xml/update_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Only the one directory updates are downloaded into. A provider that shared
+     the whole cache would expose every other thing Relay writes there. -->
+<paths>
+    <cache-path name="updates" path="updates/" />
+</paths>


### PR DESCRIPTION
The banner offered an update it had no way to deliver. `HomeScreen` took an `onGetUpdate` lambda, `MainActivity` never passed one, and the default was empty — so **"Get it" had been a no-op for as long as the banner has existed**.

`UpdateFetcher` is the missing half: reads the latest release, picks the APK for this device's ABI, downloads it, and hands it to `UpdateDownload` to check against the release's own `SHA256SUMS.txt`. **Only a verified file reaches the system installer.** A mismatch is logged loudly and the bytes deleted; a release with no checksums is refused rather than installed anyway.

Android still shows its own install prompt — a platform floor for a sideloaded app, not a decision made here. This gets the bytes right and lets the system ask the last question.

The `FileProvider` is scoped to the one cache directory updates land in, not the whole cache, and is not exported.

### A manifest comment that had become false

It claimed Relay had no widgets and therefore nothing `installLocation="auto"` could break. It has one now, and a widget **is** removed when an app moves to adoptable storage. The trade is now stated rather than left as a stale claim: a failed install stops everyone, on a phone that reports nothing more useful than "App not installed"; a lost widget affects only someone who both placed one and moved the app to an SD card, and is fixed by placing it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)