### PR TITLE
Stop paying the batch cost for every single packet

### DIFF
--- a/wg/netstack.go
+++ b/wg/netstack.go
@@ -43,7 +43,6 @@ const (
 	// shorter and a slow-but-live host is called dead.
 	dialTimeout = 10 * time.Second
 
-	// gVisor's own recommended queue depth for a channel endpoint.
 	// Deep enough to ride out a scheduling hiccup, shallow enough not to become
 	// a bufferbloat queue. It was 1024 -- about 1.4 MB of packets at this MTU --
 	// and on a link that actually runs at a few Mbps that is over a second of
@@ -262,9 +261,10 @@ func (d *netTun) MTU() (int, error)        { return d.mtu, nil }
 func (d *netTun) Name() (string, error)    { return "relay0", nil }
 func (d *netTun) File() *os.File           { return nil }
 func (d *netTun) Events() <-chan tun.Event { return d.events }
+
 // BatchSize is what wireguard-go sizes its buffers and crypto batches by.
 // It must match what Read is actually willing to fill.
-func (d *netTun) BatchSize() int           { return batchSize }
+func (d *netTun) BatchSize() int { return batchSize }
 
 func (d *netTun) Close() error {
 	d.closeOnce.Do(func() {

--- a/wg/netstack.go
+++ b/wg/netstack.go
@@ -44,7 +44,16 @@ const (
 	dialTimeout = 10 * time.Second
 
 	// gVisor's own recommended queue depth for a channel endpoint.
-	channelQueueDepth = 1024
+	// Deep enough to ride out a scheduling hiccup, shallow enough not to become
+	// a bufferbloat queue. It was 1024 -- about 1.4 MB of packets at this MTU --
+	// and on a link that actually runs at a few Mbps that is over a second of
+	// queue. Measured on hardware: tunnel latency went from 4 ms to 25 ms
+	// average with spikes to 121 ms while a transfer was running, which is the
+	// signature of exactly that.
+	channelQueueDepth = 256
+
+	// Matches conn.IdealBatchSize in wireguard-go. See [netTun.Read].
+	batchSize = 128
 )
 
 // netTun is a wireguard-go tun.Device backed by a gVisor stack we control.
@@ -73,6 +82,30 @@ func newNetTun(mtu int) (*netTun, error) {
 			tcp.NewProtocol, udp.NewProtocol, icmp.NewProtocol4, icmp.NewProtocol6,
 		},
 	})
+
+	// TCP options, none of which gVisor turns on by default.
+	//
+	// SACK matters most here. Without it a single lost segment costs a full
+	// retransmit-and-wait, and this traffic crosses Wi-Fi twice -- once to the
+	// phone and once back out of it -- so loss is ordinary rather than rare.
+	// Receive-buffer moderation lets a connection's window grow to the path
+	// instead of sitting at the default forever.
+	sack := tcpip.TCPSACKEnabled(true)
+	if err := s.SetTransportProtocolOption(tcp.ProtocolNumber, &sack); err != nil {
+		return nil, fmt.Errorf("relaywg: could not enable SACK: %v", err)
+	}
+	moderate := tcpip.TCPModerateReceiveBufferOption(true)
+	if err := s.SetTransportProtocolOption(tcp.ProtocolNumber, &moderate); err != nil {
+		return nil, fmt.Errorf("relaywg: could not enable receive buffer moderation: %v", err)
+	}
+	sendRange := tcpip.TCPSendBufferSizeRangeOption{Min: 4 << 10, Default: 256 << 10, Max: 4 << 20}
+	if err := s.SetTransportProtocolOption(tcp.ProtocolNumber, &sendRange); err != nil {
+		return nil, fmt.Errorf("relaywg: could not size the send buffer: %v", err)
+	}
+	recvRange := tcpip.TCPReceiveBufferSizeRangeOption{Min: 4 << 10, Default: 256 << 10, Max: 4 << 20}
+	if err := s.SetTransportProtocolOption(tcp.ProtocolNumber, &recvRange); err != nil {
+		return nil, fmt.Errorf("relaywg: could not size the receive buffer: %v", err)
+	}
 
 	endpoint := channel.New(channelQueueDepth, uint32(mtu), "")
 	if err := s.CreateNIC(nicID, endpoint); err != nil {
@@ -139,20 +172,59 @@ func (d *netTun) pumpOutbound() {
 	}
 }
 
+// Read fills as many of [bufs] as there are packets waiting.
+//
+// It used to return exactly one packet per call, with BatchSize reporting 1.
+// That is the single most expensive line in the forwarder: wireguard-go is
+// built around batches of up to conn.IdealBatchSize, and hands each batch to a
+// crypto worker as a unit. A batch of one pays the whole per-batch cost -- the
+// queue hand-off, the worker wake-up, the nonce and ring bookkeeping -- for
+// every single packet, and at 1420 bytes a packet that is the entire budget of
+// a weak phone.
+//
+// So: block for the first packet, then take everything else already queued
+// without blocking. Under load a call returns a full batch; when idle it
+// behaves exactly as before.
 func (d *netTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
+	if len(bufs) == 0 {
+		return 0, nil
+	}
+
+	read := func(packet *stack.PacketBuffer, into []byte) (int, error) {
+		defer packet.DecRef()
+		view := packet.ToView()
+		return view.Read(into)
+	}
+
+	// The first one blocks: returning zero packets would spin the caller.
 	select {
 	case <-d.closed:
 		return 0, net.ErrClosed
 	case packet := <-d.incoming:
-		defer packet.DecRef()
-		view := packet.ToView()
-		n, err := view.Read(bufs[0][offset:])
+		n, err := read(packet, bufs[0][offset:])
 		if err != nil {
 			return 0, err
 		}
 		sizes[0] = n
-		return 1, nil
 	}
+
+	count := 1
+	for count < len(bufs) {
+		select {
+		case packet := <-d.incoming:
+			n, err := read(packet, bufs[count][offset:])
+			if err != nil {
+				// The batch so far is still valid and already dequeued;
+				// dropping it to report this error would lose real packets.
+				return count, nil
+			}
+			sizes[count] = n
+			count++
+		default:
+			return count, nil
+		}
+	}
+	return count, nil
 }
 
 func (d *netTun) Write(bufs [][]byte, offset int) (int, error) {
@@ -190,7 +262,9 @@ func (d *netTun) MTU() (int, error)        { return d.mtu, nil }
 func (d *netTun) Name() (string, error)    { return "relay0", nil }
 func (d *netTun) File() *os.File           { return nil }
 func (d *netTun) Events() <-chan tun.Event { return d.events }
-func (d *netTun) BatchSize() int           { return 1 }
+// BatchSize is what wireguard-go sizes its buffers and crypto batches by.
+// It must match what Read is actually willing to fill.
+func (d *netTun) BatchSize() int           { return batchSize }
 
 func (d *netTun) Close() error {
 	d.closeOnce.Do(func() {

--- a/wg/relaywg.go
+++ b/wg/relaywg.go
@@ -167,6 +167,18 @@ func (e *Endpoint) statValue(name string) int64 {
 	return 0
 }
 
+// spliceBuffers backs every forwarded connection's two copy loops.
+//
+// io.Copy would allocate 32 KB per direction per connection. On a phone
+// carrying a laptop's whole browsing session that is a steady stream of
+// garbage to collect, on the one CPU that measurement showed to be the limit.
+var spliceBuffers = sync.Pool{
+	New: func() any {
+		b := make([]byte, 64*1024)
+		return &b
+	},
+}
+
 // forward splices two connections and returns when either side is done.
 //
 // Both directions are needed and both must be able to end the pair: a download
@@ -179,7 +191,13 @@ func forward(a, b net.Conn) {
 	done := make(chan struct{}, 2)
 	copyOneWay := func(dst, src net.Conn) {
 		_ = extendDeadline(dst)
-		_, _ = io.Copy(dst, src)
+		// Pooled, and larger than io.Copy's default 32 KB. io.Copy allocates a
+		// fresh buffer for every call, which is two allocations per connection
+		// on a device that is already the bottleneck; at 64 KB it also halves
+		// the number of round trips through the netstack per megabyte.
+		buf := spliceBuffers.Get().(*[]byte)
+		_, _ = io.CopyBuffer(dst, src, *buf)
+		spliceBuffers.Put(buf)
 		done <- struct{}{}
 	}
 	go copyOneWay(a, b)


### PR DESCRIPTION
### What the measurement said

Both machines on the same Wi-Fi, so every byte crosses the same radio twice:

| | Direct | Through Relay |
|---|---|---|
| Download | 15.47 Mbps | 4.4 – 6.6 |
| Upload | 6.21 Mbps | 4.8 – 6.3 |
| Latency to phone | 4 ms | **25 ms avg, 121 ms peak** |

`io.relay.app` reached **138% CPU** during a transfer.

**Two of my own theories died here.** Path MTU through the tunnel measured exactly 1420 with no fragmentation, so it is not MTU. And at 25 ms / 6 Mbps the bandwidth-delay product is ~19 KB — far inside any default window — so it is not the receive window either. What is left is the phone.

### Four things it was doing the expensive way

**`BatchSize()` returned 1.** wireguard-go is built around batches of up to 128 and hands each batch to a crypto worker as a unit, so a batch of one pays the whole per-batch cost — queue hand-off, worker wake-up, nonce and ring bookkeeping — *for every packet*. `Read` now blocks for the first packet, then drains whatever else is already queued.

**gVisor turns none of its TCP options on by default.** SACK is the one that matters: without it a single lost segment costs a retransmit-and-wait, and this traffic crosses Wi-Fi twice, so loss is ordinary rather than rare. Plus receive-buffer moderation and real buffer ranges.

**The queue was 1024 packets** — about 1.4 MB, which on a link running at a few Mbps is over a second of standing queue. That is what the 4 ms → 25 ms and the 121 ms spikes were. Now 256.

**The splice used `io.Copy`,** which allocates 32 KB per direction per connection. Now pooled, at 64 KB.

### Honest caveat

The numbers after this lands are the point, and they are not here yet. Also: this topology has both devices on one Wi-Fi, which is its own large penalty and is *not* what a user on a hotspot experiences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)