### PR TITLE
Stop redrawing two surfaces once a second for a change neither shows

### DIFF
--- a/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
@@ -88,14 +88,29 @@ class SharingService : Service() {
         super.onCreate()
         createChannel()
         scope.launch {
+            // Only when something these two actually show has changed.
+            //
+            // The byte counters update once a second while connected, and every
+            // one of those used to rebuild the notification and push a fresh
+            // RemoteViews across a binder to the launcher. Neither surface
+            // displays bytes -- the notification counts devices, the widget
+            // shows the code -- so that was a cross-process round trip every
+            // second to redraw the identical pixels, on the CPU that is already
+            // the bottleneck. A user reported 2.2 as slower than 2.0 at
+            // transferring data; the widget push is what 2.2 added.
+            var shown: String? = null
             ConnectionRepository.state.collectLatest { state ->
+                val signature = visibleSignature(state)
+                if (signature == shown) return@collectLatest
+                shown = signature
+
                 if (state !is ConnectionState.Idle) {
                     notificationManager.notify(NOTIFICATION_ID, buildNotification(state))
                 }
                 // The widget lives in the launcher's process and cannot watch a
-                // flow, so every state change has to be pushed to it. Idle is
-                // included deliberately: the transition a widget most needs to
-                // hear about is sharing stopping.
+                // flow, so it has to be pushed. Idle is included deliberately:
+                // the transition a widget most needs to hear about is sharing
+                // stopping.
                 SharingWidgetProvider.refresh(this@SharingService)
             }
         }
@@ -541,6 +556,23 @@ class SharingService : Service() {
                 NotificationManager.IMPORTANCE_LOW,
             )
         )
+    }
+
+    /**
+     * Everything the notification and the widget can actually display, and
+     * nothing else. Two states with the same signature look identical on
+     * screen, so redrawing between them is work with no observer.
+     *
+     * Deliberately excludes bytesUp and bytesDown: they change every second and
+     * neither surface shows them.
+     */
+    private fun visibleSignature(state: ConnectionState): String = when (state) {
+        is ConnectionState.Idle -> "idle"
+        is ConnectionState.Preparing -> "preparing"
+        is ConnectionState.Advertising -> "advertising:${state.shortCode}:${state.reconnecting}"
+        is ConnectionState.Connected ->
+            "connected:${state.shortCode}:${state.clientCount}:${state.reconnecting}"
+        is ConnectionState.Error -> "error:${state.code}"
     }
 
     private fun buildNotification(state: ConnectionState): Notification {


### PR DESCRIPTION
A user reported **2.2 as slower than 2.0** at moving data, upload especially. This is what 2.2 added to the per-second path.

While connected the byte counters update every second (`PEER_POLL_MS`). Each update is a state change, and the collector rebuilt the foreground notification **and pushed a fresh `RemoteViews` across a binder into the launcher process** — on the phone CPU that measurement already showed to be the limit.

**Neither surface displays bytes.** The notification counts devices; the widget shows the pairing code. So that was a cross-process round trip every second to redraw identical pixels.

The collector now compares a signature of exactly what the two can display — state, code, client count, reconnecting — and skips when nothing visible moved.

The notification rebuild was there in 2.0 as well, so this fixes waste that predates the regression too.

**What this does not claim:** that it explains the whole reported slowdown. It is one measured cost removed, on the device with the least to spare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)