### PR TITLE
Fetch the update while connected; only installing waits for idle

### DIFF
--- a/windows/Relay.App.Tests/UpdateServiceTests.cs
+++ b/windows/Relay.App.Tests/UpdateServiceTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Security.Cryptography;
 using Relay.Core;
 using Xunit;
 
@@ -24,6 +25,36 @@ public class UpdateServiceTests
             });
     }
 
+    /// <summary>
+    /// Serves a real, self-consistent release: a checksum listing that matches
+    /// the installer bytes it also serves.
+    ///
+    /// Needed because the download now happens before the wait for idle. With a
+    /// listing that named some other file, "did not install while connected"
+    /// would pass because the download was refused, which proves nothing about
+    /// the rule under test.
+    /// </summary>
+    private sealed class Servable : HttpMessageHandler
+    {
+        private static readonly byte[] Payload = "pretend installer"u8.ToArray();
+
+        private static string Listing =>
+            Convert.ToHexString(SHA256.HashData(Payload)).ToLowerInvariant()
+            + "  Relay-Setup-x64.exe";
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken token)
+        {
+            var url = request.RequestUri!.ToString();
+            HttpContent content = url.EndsWith("SHA256SUMS.txt", StringComparison.Ordinal)
+                ? new StringContent(Listing)
+                : url.Contains("api.github.com", StringComparison.Ordinal)
+                    ? new StringContent(NewerRelease)
+                    : new ByteArrayContent(Payload);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        }
+    }
+
     /// <summary>A release far newer than any build could be.</summary>
     private const string NewerRelease = """
         {"tag_name":"v99.0.0","draft":false,"prerelease":false,
@@ -32,10 +63,6 @@ public class UpdateServiceTests
            {"name":"Relay-Setup-x86.exe","browser_download_url":"https://x/Relay-Setup-x86.exe"},
            {"name":"SHA256SUMS.txt","browser_download_url":"https://x/SHA256SUMS.txt"}]}
         """;
-
-    /// <summary>A listing naming a different file, so nothing here can install.</summary>
-    private const string Sums =
-        "0000000000000000000000000000000000000000000000000000000000000000  other.exe";
 
     private static UpdateCheck Check() => new("1.0.0", new HttpClient(new Canned(NewerRelease)));
 
@@ -55,7 +82,7 @@ public class UpdateServiceTests
     /// </summary>
     private static UpdateService Connected(Notices notices) =>
         new("1.0.0", () => "Connected", notices.Add, Check,
-            new UpdateInstaller(new HttpClient(new Canned(Sums))),
+            new UpdateInstaller(new HttpClient(new Servable())),
             idleWait: TimeSpan.Zero);
 
     [Fact]
@@ -94,8 +121,29 @@ public class UpdateServiceTests
         // Announced, so we know the path ran and this is not passing on an
         // empty list — and then stopped, because the installer stops Relay in
         // order to replace it and doing that during a call would drop the call.
+        //
+        // The bytes were fetched and verified first: that is deliberate, and the
+        // handler here serves a listing that genuinely matches, so nothing but
+        // the connected state can be what stopped it.
         Assert.Contains(UpdateNotice.Available, notices.Kinds);
         Assert.DoesNotContain(UpdateNotice.Installing, notices.Kinds);
+    }
+
+    [Fact]
+    public async Task FetchesTheUpdateEvenWhileTheTunnelIsUp()
+    {
+        var target = Path.Combine(Path.GetTempPath(), "Relay-update", "Relay-Setup-x64.exe");
+        if (File.Exists(target)) File.Delete(target);
+
+        await Connected(new Notices()).CheckAndMaybeInstallAsync();
+
+        // The reason this matters is not speed. Relay is used where the tunnel
+        // is the only working route to GitHub's release CDN, so waiting for
+        // "disconnected" before downloading meant waiting for the one state in
+        // which the bytes cannot be reached — and the update never landed at
+        // all. Installing still waits; fetching must not.
+        Assert.True(File.Exists(target));
+        File.Delete(target);
     }
 
     [Fact]

--- a/windows/Relay.Core/UpdateInstaller.cs
+++ b/windows/Relay.Core/UpdateInstaller.cs
@@ -65,10 +65,39 @@ public sealed class UpdateInstaller(HttpClient? http = null)
         Action<string>? run = null,
         CancellationToken token = default)
     {
-        if (string.IsNullOrWhiteSpace(update.ChecksumsUrl)) return Outcome.Unverifiable;
+        var (outcome, path) = await DownloadAsync(update, downloadDirectory, token)
+            .ConfigureAwait(false);
+        return path is null ? outcome : Run(path, run);
+    }
+
+    /// <summary>
+    /// Fetches and verifies the installer, and stops there.
+    ///
+    /// Separate from running it because the two have opposite constraints.
+    /// Running it stops Relay, so it has to wait for a moment when nothing is
+    /// connected. Downloading has to <em>not</em> wait for that — on the
+    /// networks Relay is built for, the tunnel is often the only route to
+    /// GitHub's release CDN in the first place, so "download only while
+    /// disconnected" means "download only while it is unreachable", and the
+    /// update never arrives at all. Verified on a connection that reaches
+    /// api.github.com fine and cannot reach the asset host at all.
+    ///
+    /// The cost is that the download can use the phone's data. Once per
+    /// release, for an app that has no other way to stay current, that is the
+    /// better of the two mistakes.
+    /// </summary>
+    /// <returns>
+    /// The verified installer's path, or null with the reason it is not there.
+    /// </returns>
+    public async Task<(Outcome Outcome, string? Path)> DownloadAsync(
+        UpdateCheck.Available update,
+        string? downloadDirectory = null,
+        CancellationToken token = default)
+    {
+        if (string.IsNullOrWhiteSpace(update.ChecksumsUrl)) return (Outcome.Unverifiable, null);
 
         var name = FileName(update.Url);
-        if (!name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) return Outcome.Unavailable;
+        if (!name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) return (Outcome.Unavailable, null);
 
         var directory = downloadDirectory ?? Path.Combine(Path.GetTempPath(), "Relay-update");
         var target = Path.Combine(directory, name);
@@ -84,7 +113,7 @@ public sealed class UpdateInstaller(HttpClient? http = null)
             Directory.CreateDirectory(directory);
             var sums = await _http.GetStringAsync(update.ChecksumsUrl, token).ConfigureAwait(false);
             var found = HashFor(sums, name);
-            if (found is null) return Outcome.Unverifiable;
+            if (found is null) return (Outcome.Unverifiable, null);
             expected = found;
 
             actual = await DownloadAndHashAsync(update.Url, partial, token).ConfigureAwait(false);
@@ -92,14 +121,14 @@ public sealed class UpdateInstaller(HttpClient? http = null)
         catch (Exception)
         {
             Discard(partial);
-            return Outcome.Unavailable;
+            return (Outcome.Unavailable, null);
         }
 
         if (!CryptographicOperations.FixedTimeEquals(
                 Convert.FromHexString(actual), Convert.FromHexString(expected)))
         {
             Discard(partial);
-            return Outcome.ChecksumMismatch;
+            return (Outcome.ChecksumMismatch, null);
         }
 
         try
@@ -109,12 +138,18 @@ public sealed class UpdateInstaller(HttpClient? http = null)
         catch (Exception)
         {
             Discard(partial);
-            return Outcome.Unavailable;
+            return (Outcome.Unavailable, null);
         }
 
+        return (Outcome.Started, target);
+    }
+
+    /// <summary>Runs an installer that <see cref="DownloadAsync"/> already verified.</summary>
+    public Outcome Run(string path, Action<string>? run = null)
+    {
         try
         {
-            (run ?? Launch)(target);
+            (run ?? Launch)(path);
             return Outcome.Started;
         }
         catch (Exception)

--- a/windows/Relay.Core/UpdateService.cs
+++ b/windows/Relay.Core/UpdateService.cs
@@ -131,9 +131,36 @@ public sealed class UpdateService(
             notify(UpdateNotice.Available, update.Version);
         }
 
-        // Wait for a moment where replacing the app costs nothing — bounded, so
-        // a machine that stays connected all day tries again next cycle instead
-        // of holding a thread forever.
+        // Fetch first, connected or not.
+        //
+        // This used to wait for idle before downloading, and on the networks
+        // Relay is built for that meant it could never update at all: the
+        // tunnel is frequently the only route to GitHub's release CDN, so the
+        // one moment it was willing to download was the one moment the bytes
+        // were unreachable. Measured on a connection that answers
+        // api.github.com in under a second and cannot open the asset host at
+        // all. Only running the installer has to wait, because only running it
+        // costs someone their connection.
+        var (outcome, installer) = await _installer
+            .DownloadAsync(update, token: token).ConfigureAwait(false);
+
+        if (installer is null)
+        {
+            if (outcome == UpdateInstaller.Outcome.ChecksumMismatch)
+            {
+                // Never retried quietly: the bytes on offer were not the bytes
+                // the release published.
+                notify(UpdateNotice.Refused, update.Version);
+            }
+            // Unverifiable and Unavailable both mean "try again next cycle",
+            // and neither is worth interrupting anyone about.
+            return;
+        }
+
+        // Now wait for a moment where replacing the app costs nothing —
+        // bounded, so a machine that stays connected all day tries again next
+        // cycle instead of holding a thread forever. The download is already on
+        // disk and verified, so that next cycle is cheap.
         var deadline = DateTimeOffset.UtcNow + _idleWait;
         while (currentState() != Idle && DateTimeOffset.UtcNow < deadline)
         {
@@ -148,21 +175,9 @@ public sealed class UpdateService(
         }
         if (currentState() != Idle) return;
 
-        var outcome = await _installer.InstallAsync(update, token: token).ConfigureAwait(false);
-        switch (outcome)
+        if (_installer.Run(installer) == UpdateInstaller.Outcome.Started)
         {
-            case UpdateInstaller.Outcome.Started:
-                notify(UpdateNotice.Installing, update.Version);
-                break;
-            case UpdateInstaller.Outcome.ChecksumMismatch:
-                // Never retried quietly: the bytes on offer were not the bytes
-                // the release published.
-                notify(UpdateNotice.Refused, update.Version);
-                break;
-            case UpdateInstaller.Outcome.Unverifiable:
-            case UpdateInstaller.Outcome.Unavailable:
-                // Try again on the next cycle; neither is worth a toast.
-                break;
+            notify(UpdateNotice.Installing, update.Version);
         }
     }
 }


### PR DESCRIPTION
Found on hardware.

On the connection this was tested from:

```
api.github.com      -> 200 in 0.65s
github.com          -> 200 in 1.82s
release-assets CDN  -> no response, 5 minutes, 0 bytes
```

That is not an unlucky network. It is the network Relay is built for.

The updater waited for `Idle` before downloading, so on that network it waited
for the exact state in which the release CDN is unreachable. The check found
2.6.0 on every cycle; the download produced nothing, every time, silently, and
retried in 24 hours to do the same.

Fetching is now unconditional. Only running the installer waits for idle, since
that is the part that costs someone their connection. The trade is that the
download can use phone data -- once per release, for an app that otherwise has
no way to stay current.

Also fixes a test that was passing for the wrong reason: it served a checksum
listing naming a different file, so "did not install while connected" was
satisfied by the download being refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)