### PR TITLE
Fix three defects on the path every byte takes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -180,7 +180,8 @@ jobs:
             'TestTheAdapterComesUpAndCarriesRoutedTraffic',       # the adapter comes up and carries routed traffic
             'TestReadyIsWithheldWhenThePeerNeverAnswers',         # READY means a handshake, not merely an adapter
             'TestPeerPublicKeyIsThePeersNotTheDevices',           # an endpoint update names the peer, not the device
-            'TestRoamRejectsWhatIsNotAnAddressAndPort'            # a beacon is untrusted input
+            'TestRoamRejectsWhatIsNotAnAddressAndPort',           # a beacon is untrusted input
+            'TestLeakProtectionLeavesLoopbackAlone'               # protecting the tunnel must not break localhost
           )
           foreach ($name in $required) {
             if (-not ($output | Select-String -SimpleMatch "--- PASS: $name" -Quiet)) {

--- a/wg/cmd/relaywg-client/tunnel_windows_test.go
+++ b/wg/cmd/relaywg-client/tunnel_windows_test.go
@@ -301,3 +301,112 @@ func freeUDPPort(t *testing.T) int {
 	defer c.Close()
 	return c.LocalAddr().(*net.UDPAddr).Port
 }
+
+// Leak protection must not take localhost down with IPv6.
+//
+// The IPv6 rule is written as "all of ALE_AUTH_CONNECT_V6", and WFP classifies
+// loopback at that layer too -- so the first version of it blocked ::1 as well.
+// On Windows "localhost" resolves to ::1 before 127.0.0.1, which meant that
+// while Relay was connected, every localhost connection on the machine failed
+// or stalled: development servers, database clients, desktop apps talking to
+// their own helpers. Unrelated software breaking, blamed on the tunnel.
+//
+// This is the only place that can be caught. The endpoint's suite runs on Linux
+// with no WFP at all, and the app's own tests never start the tunnel; a runner
+// with Administrator and a real filtering engine is the whole point.
+func TestLeakProtectionLeavesLoopbackAlone(t *testing.T) {
+	binary := os.Getenv("RELAYWG_CLIENT")
+	if binary == "" {
+		t.Skip("RELAYWG_CLIENT is not set; CI builds the client and points this at it")
+	}
+	if !ipv6LoopbackWorks(t) {
+		t.Skip("this machine cannot reach ::1 even without the tunnel")
+	}
+
+	_, serverPublic := keyPair(t)
+	clientPrivate, _ := keyPair(t)
+
+	// No endpoint on the other end: the filters are installed before the
+	// handshake is waited for, so they are live for the whole timeout and this
+	// never needs a peer that answers.
+	client := exec.Command(binary,
+		"-name", "RelayTestLoopback",
+		"-address", "10.13.37.2/32",
+		"-routes", "198.51.100.0/24",
+		"-dns", "1.1.1.1",
+	)
+	stdin, err := client.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin: %v", err)
+	}
+	stderr, err := client.StderrPipe()
+	if err != nil {
+		t.Fatalf("stderr: %v", err)
+	}
+	if err := client.Start(); err != nil {
+		t.Fatalf("starting the client (Administrator required): %v", err)
+	}
+	defer func() {
+		_ = client.Process.Kill()
+		_, _ = client.Process.Wait()
+	}()
+
+	fmt.Fprintf(stdin, "private_key=%s\npublic_key=%s\nendpoint=127.0.0.1:9\nallowed_ip=0.0.0.0/0\n%s\n",
+		clientPrivate, serverPublic, configTerminator)
+
+	// Wait for the filters to be in place rather than for a fixed delay: the
+	// window this is testing opens exactly when that line is printed.
+	protected := make(chan bool, 1)
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, "leak protection on") {
+				protected <- true
+				return
+			}
+			if strings.Contains(line, "leak protection unavailable") {
+				protected <- false
+				return
+			}
+		}
+		protected <- false
+	}()
+
+	select {
+	case on := <-protected:
+		if !on {
+			t.Skip("leak protection did not install here; nothing to assert about it")
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("the client never said whether leak protection was installed")
+	}
+
+	if !ipv6LoopbackWorks(t) {
+		t.Fatal("::1 stopped working while leak protection was on — " +
+			"this blocks localhost for every application on the machine")
+	}
+}
+
+// ipv6LoopbackWorks reports whether a TCP connection to ::1 completes.
+func ipv6LoopbackWorks(t *testing.T) bool {
+	t.Helper()
+
+	listener, err := net.Listen("tcp6", "[::1]:0")
+	if err != nil {
+		return false
+	}
+	defer listener.Close()
+	go func() {
+		if conn, err := listener.Accept(); err == nil {
+			conn.Close()
+		}
+	}()
+
+	conn, err := net.DialTimeout("tcp6", listener.Addr().String(), 5*time.Second)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}

--- a/wg/cmd/relaywg-client/wfp_windows.go
+++ b/wg/cmd/relaywg-client/wfp_windows.go
@@ -22,6 +22,14 @@ package main
 // a phone that changes address still works, which a blanket block would have
 // killed.
 //
+// One exception is carved back out: loopback is permitted above both blocks.
+// "Block all of ALE_AUTH_CONNECT_V6" turned out to mean all of it, loopback
+// included, and on Windows "localhost" resolves to ::1 before 127.0.0.1 — so
+// the first version of this broke every localhost connection on the machine
+// for as long as Relay was connected. Permitting it cannot leak, because
+// loopback never reaches a network interface for anything to escape by.
+// TestLeakProtectionLeavesLoopbackAlone fails without it.
+//
 // Every filter is added inside a session opened with FWPM_SESSION_FLAG_DYNAMIC.
 // Windows destroys the whole session, and with it every filter, when this
 // process ends — including when it is killed or crashes. That is the same

--- a/wg/cmd/relaywg-client/wfp_windows.go
+++ b/wg/cmd/relaywg-client/wfp_windows.go
@@ -134,10 +134,15 @@ const (
 	fwpActionPermit          = 0x00000002 | fwpActionFlagTerminating
 
 	fwpMatchEqual = 0
+	// FWP_MATCH_FLAGS_ALL_SET, the seventh member of FWP_MATCH_TYPE.
+	fwpMatchFlagsAllSet = 6
 
 	fwpUint8  = 1
 	fwpUint16 = 2
 	fwpUint32 = 3
+
+	// FWP_CONDITION_FLAG_IS_LOOPBACK: the packet never leaves the machine.
+	fwpConditionFlagIsLoopback = 0x00000001
 
 	fwpmSessionFlagDynamic = 0x00000001
 	rpcCAuthnWinNT         = 10
@@ -163,6 +168,11 @@ var (
 	conditionIPRemoteAddress = windows.GUID{
 		Data1: 0xb235ae9a, Data2: 0x1d64, Data3: 0x49b8,
 		Data4: [8]byte{0xa4, 0x4c, 0x5f, 0xf3, 0xd9, 0x09, 0x50, 0x45},
+	}
+	// FWPM_CONDITION_FLAGS, which carries FWP_CONDITION_FLAG_IS_LOOPBACK.
+	conditionFlags = windows.GUID{
+		Data1: 0x632ce23b, Data2: 0x5167, Data3: 0x435c,
+		Data4: [8]byte{0x86, 0xd7, 0xe9, 0x03, 0x68, 0x4a, 0xa8, 0x0c},
 	}
 	// FWPM_SUBLAYER_UNIVERSAL. Using the built-in sublayer means no provider and
 	// no sublayer registration, which is the entire code path that failed.
@@ -208,9 +218,38 @@ func enableLeakProtection(resolvers []netip.Addr) (func(), error) {
 	// Weights are compared within the sublayer; the permits must outrank the
 	// blocks or the tunnel's own resolver would be blocked along with the rest.
 	const (
-		weightBlock  = 8
-		weightPermit = 12
+		weightBlock    = 8
+		weightPermit   = 12
+		weightLoopback = 14
 	)
+
+	// Loopback first, and above everything else.
+	//
+	// The IPv6 block below is written as "all of ALE_AUTH_CONNECT_V6", and that
+	// is literally all of it: WFP classifies loopback at this layer too, so it
+	// took ::1 with it. On Windows "localhost" resolves to ::1 before
+	// 127.0.0.1, which means that while Relay was connected, every localhost
+	// connection on the machine -- a development server, a database client, a
+	// desktop app talking to its own helper -- either failed outright or sat
+	// out a connect attempt before falling back to IPv4. That is not a leak
+	// being closed; it is unrelated software being broken, and it made "turn
+	// leak protection off" the fix for a machine that had gone slow.
+	//
+	// Permitting it cannot leak anything. Loopback does not reach a network
+	// interface at all, so there is no adapter for it to escape by. This is the
+	// same exception wireguard-windows carves out, for the same reason.
+	for _, layer := range []windows.GUID{layerAleAuthConnectV4, layerAleAuthConnectV6} {
+		if err := addFilter(engine, filterSpec{
+			name:     "Relay: permit loopback, which never leaves the machine",
+			layer:    layer,
+			action:   fwpActionPermit,
+			weight:   weightLoopback,
+			loopback: true,
+		}); err != nil {
+			shutdown()
+			return nil, err
+		}
+	}
 
 	// IPv6, all of it. This client configures AF_INET only, so every v6
 	// connection was leaving by the physical adapter with the real address on
@@ -270,12 +309,25 @@ type filterSpec struct {
 	remotePort uint16
 	remoteIPv4 netip.Addr
 	hasRemote  bool
+	// Matches only traffic Windows has already decided is loopback, rather
+	// than trusting an address: ::1 is not the only way to reach yourself.
+	loopback bool
 }
 
 func addFilter(engine uintptr, spec filterSpec) error {
 	name, _ := windows.UTF16PtrFromString(spec.name)
 
-	conditions := make([]fwpmFilterCondition0, 0, 2)
+	conditions := make([]fwpmFilterCondition0, 0, 3)
+	if spec.loopback {
+		conditions = append(conditions, fwpmFilterCondition0{
+			fieldKey:  conditionFlags,
+			matchType: fwpMatchFlagsAllSet,
+			conditionValue: fwpConditionValue0{
+				kind:  fwpUint32,
+				value: uintptr(fwpConditionFlagIsLoopback),
+			},
+		})
+	}
 	if spec.remotePort != 0 {
 		conditions = append(conditions, fwpmFilterCondition0{
 			fieldKey:  conditionIPRemotePort,

--- a/wg/forward_test.go
+++ b/wg/forward_test.go
@@ -7,18 +7,24 @@ import (
 	"time"
 )
 
-// A connection that is busy must not be torn down.
+// A download must not be torn down while it is downloading.
 //
-// This is the test that was missing. forward set a deadline once, five minutes
-// out, and called the variable holding it an idle timeout -- so a connection
-// carrying traffic the whole time died at exactly five minutes, and a download,
-// a call or an SSH session died with it. Nothing in the suite noticed, because
-// nothing ran a connection for longer than its own timeout.
+// This is the test that was missing, and it has now caught two separate bugs.
+// The original forward set a deadline once, five minutes out, and called the
+// variable holding it an idle timeout -- so a connection carrying traffic the
+// whole time died at exactly five minutes, and a download, a call or an SSH
+// session died with it.
+//
+// The first fix then failed this too, for a better reason: it gave each
+// direction its own idle timeout. A download is silent upstream from beginning
+// to end, so that reaped every download at the timeout -- sooner than the bug
+// it replaced. The traffic below only ever flows one way, deliberately, because
+// that is the shape that breaks.
 //
 // Written against a short idle so it takes milliseconds rather than minutes:
 // what is under test is whether the deadline moves with the traffic, and that
 // is the same question at any scale.
-func TestABusyConnectionOutlivesTheIdleTimeout(t *testing.T) {
+func TestADownloadOutlivesTheIdleTimeout(t *testing.T) {
 	t.Parallel()
 
 	const idle = 100 * time.Millisecond

--- a/wg/forward_test.go
+++ b/wg/forward_test.go
@@ -1,0 +1,82 @@
+package relaywg
+
+import (
+	"bytes"
+	"net"
+	"testing"
+	"time"
+)
+
+// A connection that is busy must not be torn down.
+//
+// This is the test that was missing. forward set a deadline once, five minutes
+// out, and called the variable holding it an idle timeout -- so a connection
+// carrying traffic the whole time died at exactly five minutes, and a download,
+// a call or an SSH session died with it. Nothing in the suite noticed, because
+// nothing ran a connection for longer than its own timeout.
+//
+// Written against a short idle so it takes milliseconds rather than minutes:
+// what is under test is whether the deadline moves with the traffic, and that
+// is the same question at any scale.
+func TestABusyConnectionOutlivesTheIdleTimeout(t *testing.T) {
+	t.Parallel()
+
+	const idle = 100 * time.Millisecond
+	// Long enough that a deadline armed once at the start has expired several
+	// times over by the end.
+	const runFor = 600 * time.Millisecond
+
+	clientSide, tunnelSide := net.Pipe()
+	remoteSide, originSide := net.Pipe()
+	go forward(tunnelSide, remoteSide, idle)
+
+	chunk := []byte("still here")
+	deadline := time.Now().Add(runFor)
+	sent := 0
+
+	go func() {
+		for time.Now().Before(deadline) {
+			if _, err := originSide.Write(chunk); err != nil {
+				return
+			}
+			time.Sleep(idle / 4)
+		}
+		originSide.Close()
+	}()
+
+	got := make([]byte, len(chunk))
+	for time.Now().Before(deadline) {
+		_ = clientSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+		n, err := clientSide.Read(got)
+		if err != nil {
+			t.Fatalf("the splice died after %d chunks with %v; a busy connection "+
+				"must not be reaped by an idle timeout", sent, err)
+		}
+		if !bytes.Equal(got[:n], chunk[:n]) {
+			t.Fatalf("corrupted chunk %d: %q", sent, got[:n])
+		}
+		sent++
+	}
+	if sent == 0 {
+		t.Fatal("nothing crossed the splice at all")
+	}
+}
+
+// And a connection that is genuinely idle must be reaped, or UDP would hold a
+// socket and two goroutines per DNS lookup for the life of the session.
+func TestAnIdleConnectionIsReaped(t *testing.T) {
+	t.Parallel()
+
+	const idle = 100 * time.Millisecond
+
+	clientSide, tunnelSide := net.Pipe()
+	remoteSide, _ := net.Pipe()
+	go forward(tunnelSide, remoteSide, idle)
+
+	// Nothing is ever written, so the deadline is never pushed forward and the
+	// splice must give up and close this end.
+	_ = clientSide.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, err := clientSide.Read(make([]byte, 1)); err == nil {
+		t.Fatal("an idle splice should have closed, but the read succeeded")
+	}
+}

--- a/wg/forward_test.go
+++ b/wg/forward_test.go
@@ -27,44 +27,43 @@ import (
 func TestADownloadOutlivesTheIdleTimeout(t *testing.T) {
 	t.Parallel()
 
-	const idle = 100 * time.Millisecond
-	// Long enough that a deadline armed once at the start has expired several
-	// times over by the end.
-	const runFor = 600 * time.Millisecond
+	const (
+		idle     = 200 * time.Millisecond
+		interval = 50 * time.Millisecond
+		// Long enough that a deadline armed once at the start expires several
+		// times over before the last chunk arrives.
+		chunks = 12
+	)
 
 	clientSide, tunnelSide := net.Pipe()
 	remoteSide, originSide := net.Pipe()
 	go forward(tunnelSide, remoteSide, idle)
 
 	chunk := []byte("still here")
-	deadline := time.Now().Add(runFor)
-	sent := 0
 
+	// Only ever downstream. That is the shape that breaks: the upstream
+	// direction of a download is silent from the first byte to the last.
 	go func() {
-		for time.Now().Before(deadline) {
+		defer originSide.Close()
+		for i := 0; i < chunks; i++ {
 			if _, err := originSide.Write(chunk); err != nil {
 				return
 			}
-			time.Sleep(idle / 4)
+			time.Sleep(interval)
 		}
-		originSide.Close()
 	}()
 
 	got := make([]byte, len(chunk))
-	for time.Now().Before(deadline) {
-		_ = clientSide.SetReadDeadline(time.Now().Add(2 * time.Second))
+	for i := 0; i < chunks; i++ {
+		_ = clientSide.SetReadDeadline(time.Now().Add(5 * time.Second))
 		n, err := clientSide.Read(got)
 		if err != nil {
-			t.Fatalf("the splice died after %d chunks with %v; a busy connection "+
-				"must not be reaped by an idle timeout", sent, err)
+			t.Fatalf("the splice died after %d of %d chunks with %v; a transfer "+
+				"that is still moving must not be reaped as idle", i, chunks, err)
 		}
-		if !bytes.Equal(got[:n], chunk[:n]) {
-			t.Fatalf("corrupted chunk %d: %q", sent, got[:n])
+		if !bytes.Equal(got[:n], chunk) {
+			t.Fatalf("corrupted chunk %d: %q", i, got[:n])
 		}
-		sent++
-	}
-	if sent == 0 {
-		t.Fatal("nothing crossed the splice at all")
 	}
 }
 

--- a/wg/netstack.go
+++ b/wg/netstack.go
@@ -64,12 +64,14 @@ const (
 type netTun struct {
 	stack    *stack.Stack
 	endpoint *channel.Endpoint
-	incoming chan *stack.PacketBuffer
 	events   chan tun.Event
 	mtu      int
 
+	// Cancelled by Close, so a Read blocked on an empty queue returns instead
+	// of waiting for a packet that is never coming.
+	ctx       context.Context
+	cancel    context.CancelFunc
 	closeOnce sync.Once
-	closed    chan struct{}
 }
 
 func newNetTun(mtu int) (*netTun, error) {
@@ -139,36 +141,45 @@ func newNetTun(mtu int) (*netTun, error) {
 		{Destination: header.IPv6EmptySubnet, NIC: nicID},
 	})
 
+	ctx, cancel := context.WithCancel(context.Background())
 	device := &netTun{
 		stack:    s,
 		endpoint: endpoint,
-		incoming: make(chan *stack.PacketBuffer, channelQueueDepth),
 		events:   make(chan tun.Event, 2),
 		mtu:      mtu,
-		closed:   make(chan struct{}),
+		ctx:      ctx,
+		cancel:   cancel,
 	}
 	device.events <- tun.EventUp
 
-	go device.pumpOutbound()
 	return device, nil
 }
 
-// pumpOutbound moves packets the stack wants to send into the queue wireguard-go
-// reads from. channel.Endpoint hands them over one at a time and blocks, so it
-// needs a goroutine of its own.
-func (d *netTun) pumpOutbound() {
-	for {
-		packet := d.endpoint.ReadContext(context.Background())
-		if packet == nil {
-			return // endpoint closed
+// copyPacket flattens one packet into [into] and always releases it.
+//
+// Deliberately not packet.ToView(), which is what this used to call. ToView
+// takes a *View and a chunk from gVisor's own pools and hands back a copy --
+// and nothing here ever called Release on it, so every packet the tunnel
+// carried in either direction leaked two pooled objects. The pools then never
+// recycled anything and the garbage collector chased the difference, on a phone,
+// on the single CPU that measurement keeps identifying as the limit.
+//
+// AsSlices borrows the packet's own storage instead: one copy into the caller's
+// buffer, nothing taken from a pool, nothing to give back.
+//
+// Reports false rather than truncating. A packet larger than the buffer cannot
+// happen at this MTU, and if it ever did, half a packet is worse than none.
+func copyPacket(packet *stack.PacketBuffer, into []byte) (int, bool) {
+	defer packet.DecRef()
+
+	written := 0
+	for _, slice := range packet.AsSlices() {
+		if written+len(slice) > len(into) {
+			return 0, false
 		}
-		select {
-		case d.incoming <- packet:
-		case <-d.closed:
-			packet.DecRef()
-			return
-		}
+		written += copy(into[written:], slice)
 	}
+	return written, true
 }
 
 // Read fills as many of [bufs] as there are packets waiting.
@@ -184,44 +195,45 @@ func (d *netTun) pumpOutbound() {
 // So: block for the first packet, then take everything else already queued
 // without blocking. Under load a call returns a full batch; when idle it
 // behaves exactly as before.
+//
+// It now reads the endpoint directly. There used to be a goroutine draining the
+// endpoint into a second channel of the same depth, which bought nothing and
+// cost two things: a scheduler hand-off for every packet on the hottest path in
+// the program, and a second queue -- so the buffering that was deliberately cut
+// to 256 packets to stop the tunnel bloating to 121 ms under load was in fact
+// still 512.
 func (d *netTun) Read(bufs [][]byte, sizes []int, offset int) (int, error) {
 	if len(bufs) == 0 {
 		return 0, nil
 	}
 
-	read := func(packet *stack.PacketBuffer, into []byte) (int, error) {
-		defer packet.DecRef()
-		view := packet.ToView()
-		return view.Read(into)
-	}
-
+	count := 0
 	// The first one blocks: returning zero packets would spin the caller.
-	select {
-	case <-d.closed:
-		return 0, net.ErrClosed
-	case packet := <-d.incoming:
-		n, err := read(packet, bufs[0][offset:])
-		if err != nil {
-			return 0, err
+	for count == 0 {
+		packet := d.endpoint.ReadContext(d.ctx)
+		if packet == nil {
+			return 0, net.ErrClosed
+		}
+		n, ok := copyPacket(packet, bufs[0][offset:])
+		if !ok {
+			continue // oversized; drop it and wait for a real one
 		}
 		sizes[0] = n
+		count = 1
 	}
 
-	count := 1
+	// Then everything already queued, without blocking.
 	for count < len(bufs) {
-		select {
-		case packet := <-d.incoming:
-			n, err := read(packet, bufs[count][offset:])
-			if err != nil {
-				// The batch so far is still valid and already dequeued;
-				// dropping it to report this error would lose real packets.
-				return count, nil
-			}
-			sizes[count] = n
-			count++
-		default:
-			return count, nil
+		packet := d.endpoint.Read()
+		if packet == nil {
+			break
 		}
+		n, ok := copyPacket(packet, bufs[count][offset:])
+		if !ok {
+			continue
+		}
+		sizes[count] = n
+		count++
 	}
 	return count, nil
 }
@@ -268,7 +280,7 @@ func (d *netTun) BatchSize() int { return batchSize }
 
 func (d *netTun) Close() error {
 	d.closeOnce.Do(func() {
-		close(d.closed)
+		d.cancel()
 		d.endpoint.Close()
 		d.stack.Close()
 		close(d.events)
@@ -305,7 +317,7 @@ func (d *netTun) installForwarders() {
 		}
 		req.Complete(false)
 
-		go forward(gonet.NewTCPConn(&wq, ep), outbound)
+		go forward(gonet.NewTCPConn(&wq, ep), outbound, tcpIdleTimeout)
 	})
 	d.stack.SetTransportProtocolHandler(tcp.ProtocolNumber, tcpForwarder.HandlePacket)
 
@@ -326,7 +338,7 @@ func (d *netTun) installForwarders() {
 			return
 		}
 
-		go forward(gonet.NewUDPConn(d.stack, &wq, ep), outbound)
+		go forward(gonet.NewUDPConn(d.stack, &wq, ep), outbound, udpIdleTimeout)
 	})
 	d.stack.SetTransportProtocolHandler(udp.ProtocolNumber, udpForwarder.HandlePacket)
 }

--- a/wg/netstack_bench_test.go
+++ b/wg/netstack_bench_test.go
@@ -110,7 +110,7 @@ func BenchmarkForward(b *testing.B) {
 		clientSide, tunnelSide := net.Pipe()
 		remoteSide, originSide := net.Pipe()
 
-		go forward(tunnelSide, remoteSide)
+		go forward(tunnelSide, remoteSide, tcpIdleTimeout)
 
 		var wg sync.WaitGroup
 		wg.Add(2)

--- a/wg/relaywg.go
+++ b/wg/relaywg.go
@@ -242,15 +242,23 @@ func copyUntilIdle(dst, src net.Conn, idle time.Duration, seen *activity, done c
 	buf := spliceBuffers.Get().(*[]byte)
 	defer spliceBuffers.Put(buf)
 
+	// The deadline currently armed on the sockets. Re-arming allocates a
+	// runtime timer, and doing it on every read cost sixty allocations per
+	// megabyte for no benefit -- the deadline only has to be roughly right,
+	// because an early expiry is caught below and simply re-armed.
+	var armed time.Time
 	for {
 		// Armed from when the pair last moved, so a direction that is quiet
 		// because the other one is busy wakes up and goes back to waiting.
-		_ = src.SetReadDeadline(seen.last().Add(idle))
+		if want := seen.last().Add(idle); want.Sub(armed) > idle/2 {
+			armed = want
+			_ = src.SetReadDeadline(want)
+			_ = dst.SetWriteDeadline(want)
+		}
 
 		n, readErr := src.Read(*buf)
 		if n > 0 {
 			seen.mark()
-			_ = dst.SetWriteDeadline(time.Now().Add(idle))
 			if _, writeErr := dst.Write((*buf)[:n]); writeErr != nil {
 				return
 			}

--- a/wg/relaywg.go
+++ b/wg/relaywg.go
@@ -23,7 +23,6 @@ package relaywg
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net"
 	"strconv"
 	"strings"
@@ -43,10 +42,20 @@ const (
 	// Matches WireGuard's own default and leaves room under a 1500-byte path.
 	mtu = 1420
 
-	// How long a forwarded connection may sit with nothing crossing it. UDP has
-	// no close, so without this every DNS lookup would leak a goroutine and a
-	// socket for the life of the session.
-	idleTimeout = 5 * time.Minute
+	// How long a forwarded connection may sit with nothing crossing it.
+	//
+	// TCP says when it is done, so this is only the backstop for a peer that
+	// vanished without a FIN.
+	tcpIdleTimeout = 5 * time.Minute
+
+	// UDP never says it is done, so this is the only thing that reaps it -- and
+	// a browsing session opens one flow per DNS lookup, each holding two
+	// goroutines, a socket and a 64 KB buffer until it is reaped. Five minutes
+	// of that on a phone is hundreds of megabytes and thousands of goroutines
+	// for exchanges that ended in milliseconds. A minute is still generous for
+	// the flows that legitimately persist: QUIC and games keep themselves
+	// alive, and anything that does not is finished.
+	udpIdleTimeout = 60 * time.Second
 )
 
 // Endpoint is one running Full Mode session. It is safe to call Stop on an
@@ -184,27 +193,57 @@ var spliceBuffers = sync.Pool{
 // Both directions are needed and both must be able to end the pair: a download
 // finishes when the remote closes, an upload when the client does, and waiting
 // for the wrong one hangs the transfer.
-func forward(a, b net.Conn) {
+func forward(a, b net.Conn, idle time.Duration) {
 	defer a.Close()
 	defer b.Close()
 
 	done := make(chan struct{}, 2)
-	copyOneWay := func(dst, src net.Conn) {
-		_ = extendDeadline(dst)
-		// Pooled, and larger than io.Copy's default 32 KB. io.Copy allocates a
-		// fresh buffer for every call, which is two allocations per connection
-		// on a device that is already the bottleneck; at 64 KB it also halves
-		// the number of round trips through the netstack per megabyte.
-		buf := spliceBuffers.Get().(*[]byte)
-		_, _ = io.CopyBuffer(dst, src, *buf)
-		spliceBuffers.Put(buf)
-		done <- struct{}{}
-	}
-	go copyOneWay(a, b)
-	go copyOneWay(b, a)
+	go copyUntilIdle(a, b, idle, done)
+	go copyUntilIdle(b, a, idle, done)
 	<-done
 }
 
-func extendDeadline(c net.Conn) error {
-	return c.SetDeadline(time.Now().Add(idleTimeout))
+// copyUntilIdle copies until the source ends, the destination fails, or nothing
+// crosses for [idle].
+//
+// The deadline moves forward as data flows, which is what an idle timeout is
+// and what this was documented to be. What it actually did was call SetDeadline
+// once, to five minutes from the moment the connection opened, and never touch
+// it again -- so every forwarded connection was torn down five minutes after it
+// started no matter how busy it was. A large download, a video call, an SSH
+// session and a websocket all died at the same mark, which from the outside is
+// indistinguishable from a flaky network, and is exactly what a user reported
+// as instability.
+func copyUntilIdle(dst, src net.Conn, idle time.Duration, done chan<- struct{}) {
+	defer func() { done <- struct{}{} }()
+
+	// Pooled, and larger than io.Copy's default 32 KB. io.Copy allocates a
+	// fresh buffer for every call, which is two allocations per connection on a
+	// device that is already the bottleneck; at 64 KB it also halves the number
+	// of round trips through the netstack per megabyte.
+	buf := spliceBuffers.Get().(*[]byte)
+	defer spliceBuffers.Put(buf)
+
+	// Rearmed only once it is more than half spent. SetDeadline arms a runtime
+	// timer, and doing that twice per 64 KB buys nothing when the deadline is
+	// measured in minutes.
+	var armed time.Time
+	for {
+		if now := time.Now(); now.Sub(armed) > idle/2 {
+			armed = now
+			deadline := now.Add(idle)
+			_ = src.SetReadDeadline(deadline)
+			_ = dst.SetWriteDeadline(deadline)
+		}
+
+		n, readErr := src.Read(*buf)
+		if n > 0 {
+			if _, writeErr := dst.Write((*buf)[:n]); writeErr != nil {
+				return
+			}
+		}
+		if readErr != nil {
+			return
+		}
+	}
 }

--- a/wg/relaywg.go
+++ b/wg/relaywg.go
@@ -27,6 +27,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.zx2c4.com/wireguard/conn"
@@ -197,11 +198,28 @@ func forward(a, b net.Conn, idle time.Duration) {
 	defer a.Close()
 	defer b.Close()
 
+	// One clock for the pair, not one per direction. A download is silent
+	// upstream for its whole length and a upload is silent downstream, so a
+	// per-direction timeout reaps exactly the transfers it exists to protect.
+	var seen activity
+	seen.mark()
+
 	done := make(chan struct{}, 2)
-	go copyUntilIdle(a, b, idle, done)
-	go copyUntilIdle(b, a, idle, done)
+	go copyUntilIdle(a, b, idle, &seen, done)
+	go copyUntilIdle(b, a, idle, &seen, done)
 	<-done
 }
+
+// activity is when either direction of a pair last moved a byte.
+type activity struct {
+	nanos atomic.Int64
+}
+
+func (a *activity) mark() { a.nanos.Store(time.Now().UnixNano()) }
+
+func (a *activity) last() time.Time { return time.Unix(0, a.nanos.Load()) }
+
+func (a *activity) idleFor() time.Duration { return time.Since(a.last()) }
 
 // copyUntilIdle copies until the source ends, the destination fails, or nothing
 // crosses for [idle].
@@ -214,7 +232,7 @@ func forward(a, b net.Conn, idle time.Duration) {
 // session and a websocket all died at the same mark, which from the outside is
 // indistinguishable from a flaky network, and is exactly what a user reported
 // as instability.
-func copyUntilIdle(dst, src net.Conn, idle time.Duration, done chan<- struct{}) {
+func copyUntilIdle(dst, src net.Conn, idle time.Duration, seen *activity, done chan<- struct{}) {
 	defer func() { done <- struct{}{} }()
 
 	// Pooled, and larger than io.Copy's default 32 KB. io.Copy allocates a
@@ -224,25 +242,31 @@ func copyUntilIdle(dst, src net.Conn, idle time.Duration, done chan<- struct{}) 
 	buf := spliceBuffers.Get().(*[]byte)
 	defer spliceBuffers.Put(buf)
 
-	// Rearmed only once it is more than half spent. SetDeadline arms a runtime
-	// timer, and doing that twice per 64 KB buys nothing when the deadline is
-	// measured in minutes.
-	var armed time.Time
 	for {
-		if now := time.Now(); now.Sub(armed) > idle/2 {
-			armed = now
-			deadline := now.Add(idle)
-			_ = src.SetReadDeadline(deadline)
-			_ = dst.SetWriteDeadline(deadline)
-		}
+		// Armed from when the pair last moved, so a direction that is quiet
+		// because the other one is busy wakes up and goes back to waiting.
+		_ = src.SetReadDeadline(seen.last().Add(idle))
 
 		n, readErr := src.Read(*buf)
 		if n > 0 {
+			seen.mark()
+			_ = dst.SetWriteDeadline(time.Now().Add(idle))
 			if _, writeErr := dst.Write((*buf)[:n]); writeErr != nil {
 				return
 			}
+			seen.mark()
 		}
 		if readErr != nil {
+			// A timeout only ends things if the whole pair has gone quiet. The
+			// first version of this checked only its own direction, and the
+			// test that caught it is the one worth keeping: a download is
+			// silent upstream from beginning to end, so that version killed
+			// every download at the timeout instead of at five minutes, which
+			// is a worse bug than the one it was fixing.
+			var timeout net.Error
+			if errors.As(readErr, &timeout) && timeout.Timeout() && seen.idleFor() < idle {
+				continue
+			}
 			return
 		}
 	}

--- a/windows/Relay.App/Services/LeakProtection.cs
+++ b/windows/Relay.App/Services/LeakProtection.cs
@@ -23,6 +23,13 @@ namespace Relay.App.Services;
 /// than remembered so the value cannot drift from what the tunnel was actually
 /// started with.
 ///
+/// Loopback is exempt. The IPv6 rule is "all of ALE_AUTH_CONNECT_V6", and WFP
+/// classifies loopback at that layer too, so it took ::1 with it — and Windows
+/// resolves "localhost" to ::1 first, so while connected, every localhost
+/// connection on the machine failed or stalled. That was unrelated software
+/// breaking and being blamed on the tunnel. Permitting loopback cannot leak:
+/// it never reaches a network interface.
+///
 /// This was briefly a switch that recorded an intent nothing acted on:
 /// wireguard-windows' firewall package needs a service SID, which an elevated
 /// user process does not have, so it refused before installing anything. The


### PR DESCRIPTION
Found by reading the packet path end to end, then measuring it. Benchmarks were
committed to `main` first, so the before numbers are measured rather than
remembered.

### A pooled buffer leaked for every packet

The read path called `packet.ToView()` and never released it. `ToView` takes a
`*View` **and** a chunk from gVisor's own pools and hands back a copy; without
`Release()` neither goes back, so the pools never recycled and the collector
chased the difference — per packet, on a phone, on the one CPU that measurement
keeps naming as the limit. `AsSlices` borrows the packet's own storage instead.

### A goroutine hop and a hidden second queue

A goroutine drained the endpoint into a second channel of the same depth. It
bought nothing and cost a scheduler hand-off per packet on the hottest loop in
the program — and a second queue, so the buffering deliberately cut to 256
packets (to stop the tunnel bloating to 121 ms under load) was really still 512.

### Every connection died at five minutes

`forward` called `SetDeadline` once, five minutes out, and named the constant an
idle timeout. It was an absolute one, so a connection carrying traffic the whole
time was still torn down five minutes after it opened. Large downloads, video
calls, SSH and websockets all die at the same mark — indistinguishable from a
flaky network, and reported as instability. The deadline now moves with the
traffic, and UDP is reaped after a minute instead of five: it never says it is
done, and a browsing session opens one flow per DNS lookup, each holding two
goroutines, a socket and a 64 KB buffer.

`forward_test.go` covers both directions of that: a busy connection must outlive
the timeout, an idle one must not.

### Leak protection took `localhost` down with IPv6

The IPv6 block was written as "all of `ALE_AUTH_CONNECT_V6`", and that is
literally all of it — WFP classifies loopback at that layer too, so it took
`::1` with it. On Windows `localhost` resolves to `::1` before `127.0.0.1`, so
while Relay was connected every localhost connection on the machine either
failed or sat out a connect attempt first. That is not a leak being closed, it
is unrelated software being broken, and it made "turn leak protection off" the
fix for a machine that had gone slow.

Permitting loopback cannot leak: it never reaches a network interface, so there
is no adapter for it to escape by. Same exception `wireguard-windows` carves
out, for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)