### PR TITLE
MEASURE-ONLY: end-to-end baseline before the hot-path fixes

### DIFF
--- a/wg/netstack_bench_test.go
+++ b/wg/netstack_bench_test.go
@@ -1,10 +1,14 @@
 package relaywg
 
 import (
+	"fmt"
 	"io"
 	"net"
+	"net/http"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"gvisor.dev/gvisor/pkg/buffer"
 	"gvisor.dev/gvisor/pkg/tcpip/stack"
@@ -125,5 +129,75 @@ func BenchmarkForward(b *testing.B) {
 			clientSide.Close()
 		}()
 		wg.Wait()
+	}
+}
+
+// BenchmarkEndToEndDownload is the whole thing: a real wireguard-go client, a
+// real Relay endpoint, and a destination that exists only outside the tunnel.
+//
+// Every other benchmark here isolates one stage. This one pays for all of them
+// at once -- the client's encryption, a UDP round trip, the endpoint's
+// decryption, gVisor's TCP reassembly, the forwarder's dial and the splice --
+// which is the number that corresponds to what a person actually sees.
+//
+// It runs on one machine, so it measures CPU rather than a link: the answer is
+// "how fast could the phone go if the radio were free", which is exactly the
+// question, because measurement has repeatedly found the phone's CPU to be the
+// limit rather than the air.
+func BenchmarkEndToEndDownload(b *testing.B) {
+	const payloadSize = 4 << 20
+
+	destination := httpServer(b, strings.Repeat("x", payloadSize))
+
+	serverPrivate, serverPublic := keyPair(b)
+	clientPrivate, clientPublic := keyPair(b)
+	port := freeUDPPort(b)
+
+	endpoint, err := Start(fmt.Sprintf(`private_key=%s
+listen_port=%d
+public_key=%s
+allowed_ip=10.13.37.2/32
+`, serverPrivate, port, clientPublic))
+	if err != nil {
+		b.Fatalf("endpoint did not start: %v", err)
+	}
+	defer endpoint.Stop()
+
+	client, clientNet := wireguardClient(b, clientPrivate, serverPublic, port)
+	defer client.Close()
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{DialContext: clientNet.DialContext},
+		Timeout:   60 * time.Second,
+	}
+
+	// The handshake takes a moment, and timing it would measure the handshake.
+	warm := time.Now().Add(20 * time.Second)
+	for time.Now().Before(warm) {
+		response, err := httpClient.Get("http://" + destination + "/")
+		if err == nil {
+			_, _ = io.Copy(io.Discard, response.Body)
+			response.Body.Close()
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(payloadSize)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		response, err := httpClient.Get("http://" + destination + "/")
+		if err != nil {
+			b.Fatalf("the tunnel stopped carrying traffic: %v", err)
+		}
+		n, err := io.Copy(io.Discard, response.Body)
+		response.Body.Close()
+		if err != nil {
+			b.Fatalf("reading through the tunnel: %v", err)
+		}
+		if n != payloadSize {
+			b.Fatalf("short read through the tunnel: %d of %d", n, payloadSize)
+		}
 	}
 }

--- a/wg/relaywg_test.go
+++ b/wg/relaywg_test.go
@@ -28,7 +28,7 @@ import (
 // addressed to somewhere it does not own, the forwarder opened a real socket,
 // and the reply made it home. That is the whole feature.
 
-func keyPair(t *testing.T) (private, public string) {
+func keyPair(t testing.TB) (private, public string) {
 	t.Helper()
 	var priv [32]byte
 	if _, err := io.ReadFull(crand.Reader, priv[:]); err != nil {
@@ -46,7 +46,7 @@ func keyPair(t *testing.T) (private, public string) {
 	return hex.EncodeToString(priv[:]), hex.EncodeToString(pub)
 }
 
-func freeUDPPort(t *testing.T) int {
+func freeUDPPort(t testing.TB) int {
 	t.Helper()
 	c, err := net.ListenPacket("udp", "127.0.0.1:0")
 	if err != nil {
@@ -212,7 +212,7 @@ func TestStopIsSafeTwiceAndOnNil(t *testing.T) {
 // Opening a UDP socket toward a routable address asks the kernel the same
 // question without netlink: nothing is sent, but the socket is bound to the
 // address the route would use.
-func nonLoopbackAddress(t *testing.T) string {
+func nonLoopbackAddress(t testing.TB) string {
 	t.Helper()
 
 	// Retried, because on a freshly booted emulator the default route appears a
@@ -267,7 +267,7 @@ func routableAddress() string {
 	return ""
 }
 
-func httpServer(t *testing.T, body string) string {
+func httpServer(t testing.TB, body string) string {
 	t.Helper()
 	// Deliberately not loopback. gVisor drops packets addressed to 127.0.0.0/8
 	// that arrive on an ordinary NIC, so a destination on loopback would make
@@ -291,7 +291,7 @@ func httpServer(t *testing.T, body string) string {
 // wireguardClient is an ordinary wireguard-go client — the same shape the
 // Windows app will be — so the test exercises the endpoint through the real
 // protocol rather than through anything built for testing.
-func wireguardClient(t *testing.T, privateKey, serverPublic string, port int) (*device.Device, *netstack.Net) {
+func wireguardClient(t testing.TB, privateKey, serverPublic string, port int) (*device.Device, *netstack.Net) {
 	t.Helper()
 	address := netip.MustParseAddr("10.13.37.2")
 	tunDevice, tunNet, err := netstack.CreateNetTUN([]netip.Addr{address}, nil, mtu)


### PR DESCRIPTION
Throwaway. Runs the same end-to-end benchmark against the code as it was before #101, so the improvement is measured rather than inferred. Will be closed unmerged.