### PR TITLE
Measure what leak protection blocks, in both directions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -181,7 +181,8 @@ jobs:
             'TestReadyIsWithheldWhenThePeerNeverAnswers',         # READY means a handshake, not merely an adapter
             'TestPeerPublicKeyIsThePeersNotTheDevices',           # an endpoint update names the peer, not the device
             'TestRoamRejectsWhatIsNotAnAddressAndPort',           # a beacon is untrusted input
-            'TestLeakProtectionLeavesLoopbackAlone'               # protecting the tunnel must not break localhost
+            'TestLeakProtectionLeavesLoopbackAlone',              # protecting the tunnel must not break localhost
+            'TestLeakProtectionBlocksWhatItShouldAndNothingElse'  # and blocks exactly what it should, no more
           )
           foreach ($name in $required) {
             if (-not ($output | Select-String -SimpleMatch "--- PASS: $name" -Quiet)) {

--- a/wg/cmd/relaywg-client/leakmatrix_windows_test.go
+++ b/wg/cmd/relaywg-client/leakmatrix_windows_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// What leak protection actually blocks, measured rather than reasoned about.
+//
+// The rules are four lines of Go and it is easy to convince yourself you know
+// what they do. The loopback bug is what that costs: "block all of
+// ALE_AUTH_CONNECT_V6" was read as "block IPv6 leaving the machine" and it
+// meant "block IPv6", localhost included. Nobody noticed until it was measured.
+//
+// So this measures. Every probe runs twice -- once with no tunnel, once with
+// the filters live -- and the assertion is on the *transition*. That is what
+// isolates the filter's effect from whatever this machine could reach anyway,
+// which a single after-the-fact probe cannot do: a runner with no IPv6 route
+// looks exactly like a runner whose IPv6 has been blocked.
+//
+// The contract being pinned, in both directions:
+//
+//	must keep working   loopback v4 and v6, ordinary IPv4, DNS to the tunnel's
+//	                    own resolver
+//	must stop working   DNS to any other resolver, IPv6 off the machine
+//
+// The first half matters as much as the second. A rule that blocks more than it
+// needs to is not "extra safe" -- it is unrelated software breaking, and the
+// user turning the whole feature off to get their machine back.
+func TestLeakProtectionBlocksWhatItShouldAndNothingElse(t *testing.T) {
+	if os.Getenv("RELAYWG_CLIENT") == "" {
+		t.Skip("RELAYWG_CLIENT is not set; CI builds the client and points this at it")
+	}
+
+	// The resolver the tunnel is told to use, and therefore the one address on
+	// port 53 that must survive.
+	const tunnelResolver = "1.1.1.1"
+	// Any other resolver. This is the leak: on a shared Wi-Fi it is the router,
+	// answering alongside the tunnel.
+	const otherResolver = "9.9.9.9"
+
+	// Listeners of our own, so "this still works" is a real connection rather
+	// than an assumption about something on the internet.
+	lan := listenOrSkip(t, "tcp4", nonLoopbackAddr(t)+":0")
+	loopback4 := listenOrSkip(t, "tcp4", "127.0.0.1:0")
+	loopback6 := listenOrSkip(t, "tcp6", "[::1]:0")
+
+	probes := []struct {
+		what        string
+		run         func() error
+		mustSurvive bool // true: must still work; false: must be blocked
+	}{
+		{"loopback IPv4", func() error { return dialTCP(loopback4) }, true},
+		{"loopback IPv6", func() error { return dialTCP(loopback6) }, true},
+		{"ordinary IPv4", func() error { return dialTCP(lan) }, true},
+		{"DNS to the tunnel's resolver", func() error { return sendUDP(tunnelResolver + ":53") }, true},
+		{"DNS to another resolver", func() error { return sendUDP(otherResolver + ":53") }, false},
+		{"IPv6 off the machine", func() error { return sendUDP("[2606:4700:4700::1111]:53") }, false},
+	}
+
+	before := make([]error, len(probes))
+	for i, probe := range probes {
+		before[i] = probe.run()
+		t.Logf("baseline   %-30s %s", probe.what, outcome(before[i]))
+	}
+
+	stop := startProtectedTunnel(t, "RelayTestMatrix", tunnelResolver)
+	defer stop()
+
+	for i, probe := range probes {
+		after := probe.run()
+		t.Logf("protected  %-30s %s", probe.what, outcome(after))
+
+		if before[i] != nil {
+			// It did not work without the tunnel either, so this machine can say
+			// nothing about it. Logged rather than passed over in silence: a
+			// green run that skipped its own assertions has proven nothing.
+			t.Logf("           %-30s NOT MEASURED: unreachable at baseline", probe.what)
+			continue
+		}
+
+		switch {
+		case probe.mustSurvive && after != nil:
+			t.Errorf("%s worked before leak protection and not after (%v).\n"+
+				"A rule is blocking more than it needs to, which breaks unrelated "+
+				"software and makes turning leak protection off look like the fix.",
+				probe.what, after)
+		case !probe.mustSurvive && after == nil:
+			t.Errorf("%s still worked with leak protection on. "+
+				"This is the leak the feature exists to close.", probe.what)
+		}
+	}
+}
+
+// startProtectedTunnel brings the client up far enough that its filters are
+// live, and returns a function that tears it down.
+//
+// No peer answers, and none is needed: the filters go in before the handshake
+// is waited for, so they are live for the whole handshake timeout.
+func startProtectedTunnel(t *testing.T, adapter, resolver string) func() {
+	t.Helper()
+
+	_, serverPublic := keyPair(t)
+	clientPrivate, _ := keyPair(t)
+
+	client := exec.Command(os.Getenv("RELAYWG_CLIENT"),
+		"-name", adapter,
+		"-address", "10.13.37.2/32",
+		// A documentation prefix, so this never takes over the runner's default
+		// route: what is under test is the filters, not the routing table.
+		"-routes", "198.51.100.0/24",
+		"-dns", resolver,
+	)
+	stdin, err := client.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin: %v", err)
+	}
+	stderr, err := client.StderrPipe()
+	if err != nil {
+		t.Fatalf("stderr: %v", err)
+	}
+	if err := client.Start(); err != nil {
+		t.Fatalf("starting the client (Administrator required): %v", err)
+	}
+	stop := func() {
+		_ = client.Process.Kill()
+		_, _ = client.Process.Wait()
+	}
+
+	fmt.Fprintf(stdin,
+		"private_key=%s\npublic_key=%s\nendpoint=127.0.0.1:9\nallowed_ip=0.0.0.0/0\n%s\n",
+		clientPrivate, serverPublic, configTerminator)
+
+	installed := make(chan bool, 1)
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, "leak protection on") {
+				installed <- true
+				return
+			}
+			if strings.Contains(line, "leak protection unavailable") {
+				installed <- false
+				return
+			}
+		}
+		installed <- false
+	}()
+
+	select {
+	case on := <-installed:
+		if !on {
+			stop()
+			t.Skip("leak protection did not install here; nothing to measure")
+		}
+	case <-time.After(30 * time.Second):
+		stop()
+		t.Fatal("the client never said whether leak protection was installed")
+	}
+	return stop
+}
+
+func listenOrSkip(t *testing.T, network, address string) string {
+	t.Helper()
+	listener, err := net.Listen(network, address)
+	if err != nil {
+		t.Skipf("cannot listen on %s %s here: %v", network, address, err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+	return listener.Addr().String()
+}
+
+func dialTCP(address string) error {
+	conn, err := net.DialTimeout("tcp", address, 4*time.Second)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+// sendUDP reports whether the machine was allowed to send at all.
+//
+// Whether an answer comes back is the network's business; what a WFP block at
+// ALE_AUTH_CONNECT changes is whether the send is permitted, and that surfaces
+// as an error on the connect or on the first write.
+func sendUDP(address string) error {
+	conn, err := net.DialTimeout("udp", address, 4*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_ = conn.SetWriteDeadline(time.Now().Add(4 * time.Second))
+	// A well-formed A query for example.com, so nothing downstream is being
+	// asked to make sense of garbage.
+	query := []byte{
+		0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
+		0x03, 0x63, 0x6f, 0x6d, 0x00, 0x00, 0x01, 0x00, 0x01,
+	}
+	_, err = conn.Write(query)
+	return err
+}
+
+func outcome(err error) string {
+	if err == nil {
+		return "allowed"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timed out (not a filter)"
+	}
+	return "refused: " + err.Error()
+}
+
+// nonLoopbackAddr is this machine's address as the routing table sees it.
+func nonLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	conn, err := net.Dial("udp4", "192.0.2.1:9")
+	if err != nil {
+		t.Skipf("no routable IPv4 address: %v", err)
+	}
+	defer conn.Close()
+	return conn.LocalAddr().(*net.UDPAddr).IP.String()
+}

--- a/wg/cmd/relaywg-client/leakmatrix_windows_test.go
+++ b/wg/cmd/relaywg-client/leakmatrix_windows_test.go
@@ -60,15 +60,16 @@ func TestLeakProtectionBlocksWhatItShouldAndNothingElse(t *testing.T) {
 		{"loopback IPv4", func() error { return dialTCP(loopback4) }, true},
 		{"loopback IPv6", func() error { return dialTCP(loopback6) }, true},
 		{"ordinary IPv4", func() error { return dialTCP(lan) }, true},
-		{"DNS to the tunnel's resolver", func() error { return sendUDP(tunnelResolver + ":53") }, true},
-		{"DNS to another resolver", func() error { return sendUDP(otherResolver + ":53") }, false},
+		{"DNS to the tunnel's resolver (UDP)", func() error { return resolve(tunnelResolver + ":53") }, true},
+		{"DNS to another resolver (UDP)", func() error { return resolve(otherResolver + ":53") }, false},
+		{"DNS to another resolver (TCP)", func() error { return dialTCP(otherResolver + ":53") }, false},
 		{"IPv6 off the machine", func() error { return sendUDP("[2606:4700:4700::1111]:53") }, false},
 	}
 
 	before := make([]error, len(probes))
 	for i, probe := range probes {
 		before[i] = probe.run()
-		t.Logf("baseline   %-30s %s", probe.what, outcome(before[i]))
+		t.Logf("baseline   %-34s %s", probe.what, outcome(before[i]))
 	}
 
 	stop := startProtectedTunnel(t, "RelayTestMatrix", tunnelResolver)
@@ -76,13 +77,13 @@ func TestLeakProtectionBlocksWhatItShouldAndNothingElse(t *testing.T) {
 
 	for i, probe := range probes {
 		after := probe.run()
-		t.Logf("protected  %-30s %s", probe.what, outcome(after))
+		t.Logf("protected  %-34s %s", probe.what, outcome(after))
 
 		if before[i] != nil {
 			// It did not work without the tunnel either, so this machine can say
 			// nothing about it. Logged rather than passed over in silence: a
 			// green run that skipped its own assertions has proven nothing.
-			t.Logf("           %-30s NOT MEASURED: unreachable at baseline", probe.what)
+			t.Logf("           %-34s NOT MEASURED: unreachable at baseline", probe.what)
 			continue
 		}
 
@@ -195,6 +196,36 @@ func dialTCP(address string) error {
 	return conn.Close()
 }
 
+// resolve asks a resolver a question and waits for its answer.
+//
+// This is the measurement that matters, and sendUDP is not it. A WFP block does
+// not always fail the send on a UDP socket -- Windows can accept the datagram
+// and drop it -- so "the send returned no error" is not "the query left". What
+// the feature is about is whether the other resolver *answers*, which is
+// exactly how the leak was seen in the first place: a leak test listing the
+// local ISP beside the tunnel's exit.
+func resolve(address string) error {
+	conn, err := net.DialTimeout("udp", address, 4*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	_ = conn.SetDeadline(time.Now().Add(5 * time.Second))
+	if _, err := conn.Write(dnsQuery); err != nil {
+		return err
+	}
+	reply := make([]byte, 512)
+	n, err := conn.Read(reply)
+	if err != nil {
+		return err
+	}
+	if n < 12 || reply[0] != dnsQuery[0] || reply[1] != dnsQuery[1] {
+		return errors.New("no matching answer")
+	}
+	return nil
+}
+
 // sendUDP reports whether the machine was allowed to send at all.
 //
 // Whether an answer comes back is the network's business; what a WFP block at
@@ -207,15 +238,16 @@ func sendUDP(address string) error {
 	}
 	defer conn.Close()
 	_ = conn.SetWriteDeadline(time.Now().Add(4 * time.Second))
-	// A well-formed A query for example.com, so nothing downstream is being
-	// asked to make sense of garbage.
-	query := []byte{
-		0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-		0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
-		0x03, 0x63, 0x6f, 0x6d, 0x00, 0x00, 0x01, 0x00, 0x01,
-	}
-	_, err = conn.Write(query)
+	_, err = conn.Write(dnsQuery)
 	return err
+}
+
+// A well-formed A query for example.com, so nothing downstream is being asked
+// to make sense of garbage.
+var dnsQuery = []byte{
+	0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
+	0x03, 0x63, 0x6f, 0x6d, 0x00, 0x00, 0x01, 0x00, 0x01,
 }
 
 func outcome(err error) string {

--- a/wg/cmd/relaywg-client/tunnel_windows_test.go
+++ b/wg/cmd/relaywg-client/tunnel_windows_test.go
@@ -304,83 +304,26 @@ func freeUDPPort(t *testing.T) int {
 
 // Leak protection must not take localhost down with IPv6.
 //
+// Kept as its own named test, separate from the matrix, because this is the one
+// the CI job lists as required: it is the regression that shipped, and a job
+// that silently stopped running it would still be green.
+//
 // The IPv6 rule is written as "all of ALE_AUTH_CONNECT_V6", and WFP classifies
 // loopback at that layer too -- so the first version of it blocked ::1 as well.
 // On Windows "localhost" resolves to ::1 before 127.0.0.1, which meant that
 // while Relay was connected, every localhost connection on the machine failed
 // or stalled: development servers, database clients, desktop apps talking to
 // their own helpers. Unrelated software breaking, blamed on the tunnel.
-//
-// This is the only place that can be caught. The endpoint's suite runs on Linux
-// with no WFP at all, and the app's own tests never start the tunnel; a runner
-// with Administrator and a real filtering engine is the whole point.
 func TestLeakProtectionLeavesLoopbackAlone(t *testing.T) {
-	binary := os.Getenv("RELAYWG_CLIENT")
-	if binary == "" {
+	if os.Getenv("RELAYWG_CLIENT") == "" {
 		t.Skip("RELAYWG_CLIENT is not set; CI builds the client and points this at it")
 	}
 	if !ipv6LoopbackWorks(t) {
 		t.Skip("this machine cannot reach ::1 even without the tunnel")
 	}
 
-	_, serverPublic := keyPair(t)
-	clientPrivate, _ := keyPair(t)
-
-	// No endpoint on the other end: the filters are installed before the
-	// handshake is waited for, so they are live for the whole timeout and this
-	// never needs a peer that answers.
-	client := exec.Command(binary,
-		"-name", "RelayTestLoopback",
-		"-address", "10.13.37.2/32",
-		"-routes", "198.51.100.0/24",
-		"-dns", "1.1.1.1",
-	)
-	stdin, err := client.StdinPipe()
-	if err != nil {
-		t.Fatalf("stdin: %v", err)
-	}
-	stderr, err := client.StderrPipe()
-	if err != nil {
-		t.Fatalf("stderr: %v", err)
-	}
-	if err := client.Start(); err != nil {
-		t.Fatalf("starting the client (Administrator required): %v", err)
-	}
-	defer func() {
-		_ = client.Process.Kill()
-		_, _ = client.Process.Wait()
-	}()
-
-	fmt.Fprintf(stdin, "private_key=%s\npublic_key=%s\nendpoint=127.0.0.1:9\nallowed_ip=0.0.0.0/0\n%s\n",
-		clientPrivate, serverPublic, configTerminator)
-
-	// Wait for the filters to be in place rather than for a fixed delay: the
-	// window this is testing opens exactly when that line is printed.
-	protected := make(chan bool, 1)
-	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if strings.Contains(line, "leak protection on") {
-				protected <- true
-				return
-			}
-			if strings.Contains(line, "leak protection unavailable") {
-				protected <- false
-				return
-			}
-		}
-		protected <- false
-	}()
-
-	select {
-	case on := <-protected:
-		if !on {
-			t.Skip("leak protection did not install here; nothing to assert about it")
-		}
-	case <-time.After(30 * time.Second):
-		t.Fatal("the client never said whether leak protection was installed")
-	}
+	stop := startProtectedTunnel(t, "RelayTestLoopback", "1.1.1.1")
+	defer stop()
 
 	if !ipv6LoopbackWorks(t) {
 		t.Fatal("::1 stopped working while leak protection was on — " +

--- a/wg/cmd/relaywg-client/wfp_windows.go
+++ b/wg/cmd/relaywg-client/wfp_windows.go
@@ -30,16 +30,6 @@ package main
 // loopback never reaches a network interface for anything to escape by.
 // TestLeakProtectionLeavesLoopbackAlone fails without it.
 //
-// The filters live in Relay's own sublayer, registered at the maximum weight.
-// They used to live in FWPM_SUBLAYER_UNIVERSAL, which avoided registering one
-// and also avoided working: that is where Windows Firewall keeps its own
-// filters, several of which permit outbound traffic at weights far above
-// anything set here, and within a sublayer the highest weight wins. The DNS
-// block was installed, reported success, and lost every arbitration it entered
-// -- which is why a leak test still listed the local resolver. Measured, not
-// deduced: TestLeakProtectionBlocksWhatItShouldAndNothingElse probes each rule
-// with the tunnel down and again with it up, and asserts on the difference.
-//
 // Every filter is added inside a session opened with FWPM_SESSION_FLAG_DYNAMIC.
 // Windows destroys the whole session, and with it every filter, when this
 // process ends — including when it is killed or crashes. That is the same
@@ -66,9 +56,8 @@ import (
 // kernel in its own test suite; a mismatch is a build failure rather than a
 // pointer handed to a driver.
 const (
-	wtFwpmFilter0Size64   = 200
-	wtFwpmSession0Size64  = 72
-	wtFwpmSublayer0Size64 = 72
+	wtFwpmFilter0Size64  = 200
+	wtFwpmSession0Size64 = 72
 )
 
 type fwpmDisplayData0 struct {
@@ -118,17 +107,6 @@ type fwpmSession0 struct {
 	_                    [7]byte
 }
 
-type fwpmSublayer0 struct {
-	subLayerKey  windows.GUID
-	displayData  fwpmDisplayData0
-	flags        uint32
-	_            [4]byte
-	providerKey  *windows.GUID
-	providerData fwpByteBlob
-	weight       uint16
-	_            [6]byte
-}
-
 type fwpmFilter0 struct {
 	filterKey           windows.GUID
 	displayData         fwpmDisplayData0
@@ -157,7 +135,6 @@ type fwpmFilter0 struct {
 // shape. These fail the build instead.
 var _ [1]struct{} = [unsafe.Sizeof(fwpmFilter0{}) - wtFwpmFilter0Size64 + 1]struct{}{}
 var _ [1]struct{} = [unsafe.Sizeof(fwpmSession0{}) - wtFwpmSession0Size64 + 1]struct{}{}
-var _ [1]struct{} = [unsafe.Sizeof(fwpmSublayer0{}) - wtFwpmSublayer0Size64 + 1]struct{}{}
 
 const (
 	fwpActionFlagTerminating = 0x00001000
@@ -205,33 +182,19 @@ var (
 		Data1: 0x632ce23b, Data2: 0x5167, Data3: 0x435c,
 		Data4: [8]byte{0x86, 0xd7, 0xe9, 0x03, 0x68, 0x4a, 0xa8, 0x0c},
 	}
-	// Relay's own sublayer.
-	//
-	// This used to be FWPM_SUBLAYER_UNIVERSAL, on the reasoning that using the
-	// built-in sublayer avoided registering one. It avoided the registration
-	// and it also avoided working: the universal sublayer is where Windows
-	// Firewall keeps its own filters, several of which permit outbound traffic
-	// at weights far above anything set here, and within a sublayer the highest
-	// weight wins. So the DNS block sat there, correctly installed, losing
-	// every arbitration it entered.
-	//
-	// Sublayers are arbitrated before the filters inside them, and this one is
-	// registered at the maximum weight, so a block here beats a permit in the
-	// universal sublayer. Traffic this sublayer says nothing about still falls
-	// through to Windows Firewall exactly as before, which is what keeps this
-	// from becoming a second firewall.
-	sublayerRelay = windows.GUID{
-		Data1: 0x2171bbec, Data2: 0xcdd2, Data3: 0x4667,
-		Data4: [8]byte{0x81, 0x80, 0x4e, 0x48, 0xc2, 0x10, 0x1b, 0x71},
+	// FWPM_SUBLAYER_UNIVERSAL. Using the built-in sublayer means no provider and
+	// no sublayer registration, which is the entire code path that failed.
+	sublayerUniversal = windows.GUID{
+		Data1: 0xeebecc03, Data2: 0xced4, Data3: 0x4380,
+		Data4: [8]byte{0x81, 0x9a, 0x27, 0x34, 0x39, 0x7b, 0x2b, 0x74},
 	}
 )
 
 var (
-	fwpuclnt             = windows.NewLazySystemDLL("fwpuclnt.dll")
-	procFwpmEngineOpen0  = fwpuclnt.NewProc("FwpmEngineOpen0")
-	procFwpmEngineClose  = fwpuclnt.NewProc("FwpmEngineClose0")
-	procFwpmFilterAdd0   = fwpuclnt.NewProc("FwpmFilterAdd0")
-	procFwpmSubLayerAdd0 = fwpuclnt.NewProc("FwpmSubLayerAdd0")
+	fwpuclnt            = windows.NewLazySystemDLL("fwpuclnt.dll")
+	procFwpmEngineOpen0 = fwpuclnt.NewProc("FwpmEngineOpen0")
+	procFwpmEngineClose = fwpuclnt.NewProc("FwpmEngineClose0")
+	procFwpmFilterAdd0  = fwpuclnt.NewProc("FwpmFilterAdd0")
 )
 
 // enableLeakProtection blocks the two ways traffic was leaving around the
@@ -259,14 +222,6 @@ func enableLeakProtection(resolvers []netip.Addr) (func(), error) {
 		return nil, fmt.Errorf("opening a filtering session: %w", windows.Errno(ret))
 	}
 	shutdown := func() { procFwpmEngineClose.Call(engine) }
-
-	// The sublayer has to exist before anything is put in it. Registered inside
-	// the dynamic session, so Windows removes it with everything else when this
-	// process ends, by any route.
-	if err := addSublayer(engine); err != nil {
-		shutdown()
-		return nil, err
-	}
 
 	// Weights are compared within the sublayer; the permits must outrank the
 	// blocks or the tunnel's own resolver would be blocked along with the rest.
@@ -354,38 +309,6 @@ func enableLeakProtection(resolvers []netip.Addr) (func(), error) {
 	return shutdown, nil
 }
 
-// addSublayer registers Relay's own sublayer at the maximum weight.
-//
-// Sublayers are arbitrated before the filters within them, so this is what
-// decides whether a block here can beat Windows Firewall's own permits. Without
-// it -- which is how this shipped -- the DNS block was installed correctly,
-// reported success, and lost every arbitration it entered.
-func addSublayer(engine uintptr) error {
-	name, _ := windows.UTF16PtrFromString("Relay")
-	description, _ := windows.UTF16PtrFromString("Relay leak protection")
-
-	sublayer := fwpmSublayer0{
-		subLayerKey: sublayerRelay,
-		displayData: fwpmDisplayData0{name: name, description: description},
-		// The highest weight there is. Anything less and the question of whether
-		// leak protection works depends on what else is installed on the
-		// machine, which is not a property worth having.
-		weight: ^uint16(0),
-	}
-
-	ret, _, _ := procFwpmSubLayerAdd0.Call(
-		engine,
-		uintptr(unsafe.Pointer(&sublayer)),
-		0,
-	)
-	runtime.KeepAlive(name)
-	runtime.KeepAlive(description)
-	if ret != 0 {
-		return fmt.Errorf("registering the filtering sublayer: %w", windows.Errno(ret))
-	}
-	return nil
-}
-
 type filterSpec struct {
 	name       string
 	layer      windows.GUID
@@ -443,7 +366,7 @@ func addFilter(engine uintptr, spec filterSpec) error {
 	filter := fwpmFilter0{
 		displayData: fwpmDisplayData0{name: name},
 		layerKey:    spec.layer,
-		subLayerKey: sublayerRelay,
+		subLayerKey: sublayerUniversal,
 		weight: fwpValue0{
 			kind:  fwpUint8,
 			value: uintptr(spec.weight),

--- a/wg/cmd/relaywg-client/wfp_windows.go
+++ b/wg/cmd/relaywg-client/wfp_windows.go
@@ -30,6 +30,16 @@ package main
 // loopback never reaches a network interface for anything to escape by.
 // TestLeakProtectionLeavesLoopbackAlone fails without it.
 //
+// The filters live in Relay's own sublayer, registered at the maximum weight.
+// They used to live in FWPM_SUBLAYER_UNIVERSAL, which avoided registering one
+// and also avoided working: that is where Windows Firewall keeps its own
+// filters, several of which permit outbound traffic at weights far above
+// anything set here, and within a sublayer the highest weight wins. The DNS
+// block was installed, reported success, and lost every arbitration it entered
+// -- which is why a leak test still listed the local resolver. Measured, not
+// deduced: TestLeakProtectionBlocksWhatItShouldAndNothingElse probes each rule
+// with the tunnel down and again with it up, and asserts on the difference.
+//
 // Every filter is added inside a session opened with FWPM_SESSION_FLAG_DYNAMIC.
 // Windows destroys the whole session, and with it every filter, when this
 // process ends — including when it is killed or crashes. That is the same
@@ -56,8 +66,9 @@ import (
 // kernel in its own test suite; a mismatch is a build failure rather than a
 // pointer handed to a driver.
 const (
-	wtFwpmFilter0Size64  = 200
-	wtFwpmSession0Size64 = 72
+	wtFwpmFilter0Size64   = 200
+	wtFwpmSession0Size64  = 72
+	wtFwpmSublayer0Size64 = 72
 )
 
 type fwpmDisplayData0 struct {
@@ -107,6 +118,17 @@ type fwpmSession0 struct {
 	_                    [7]byte
 }
 
+type fwpmSublayer0 struct {
+	subLayerKey  windows.GUID
+	displayData  fwpmDisplayData0
+	flags        uint32
+	_            [4]byte
+	providerKey  *windows.GUID
+	providerData fwpByteBlob
+	weight       uint16
+	_            [6]byte
+}
+
 type fwpmFilter0 struct {
 	filterKey           windows.GUID
 	displayData         fwpmDisplayData0
@@ -135,6 +157,7 @@ type fwpmFilter0 struct {
 // shape. These fail the build instead.
 var _ [1]struct{} = [unsafe.Sizeof(fwpmFilter0{}) - wtFwpmFilter0Size64 + 1]struct{}{}
 var _ [1]struct{} = [unsafe.Sizeof(fwpmSession0{}) - wtFwpmSession0Size64 + 1]struct{}{}
+var _ [1]struct{} = [unsafe.Sizeof(fwpmSublayer0{}) - wtFwpmSublayer0Size64 + 1]struct{}{}
 
 const (
 	fwpActionFlagTerminating = 0x00001000
@@ -182,11 +205,24 @@ var (
 		Data1: 0x632ce23b, Data2: 0x5167, Data3: 0x435c,
 		Data4: [8]byte{0x86, 0xd7, 0xe9, 0x03, 0x68, 0x4a, 0xa8, 0x0c},
 	}
-	// FWPM_SUBLAYER_UNIVERSAL. Using the built-in sublayer means no provider and
-	// no sublayer registration, which is the entire code path that failed.
-	sublayerUniversal = windows.GUID{
-		Data1: 0xeebecc03, Data2: 0xced4, Data3: 0x4380,
-		Data4: [8]byte{0x81, 0x9a, 0x27, 0x34, 0x39, 0x7b, 0x2b, 0x74},
+	// Relay's own sublayer.
+	//
+	// This used to be FWPM_SUBLAYER_UNIVERSAL, on the reasoning that using the
+	// built-in sublayer avoided registering one. It avoided the registration
+	// and it also avoided working: the universal sublayer is where Windows
+	// Firewall keeps its own filters, several of which permit outbound traffic
+	// at weights far above anything set here, and within a sublayer the highest
+	// weight wins. So the DNS block sat there, correctly installed, losing
+	// every arbitration it entered.
+	//
+	// Sublayers are arbitrated before the filters inside them, and this one is
+	// registered at the maximum weight, so a block here beats a permit in the
+	// universal sublayer. Traffic this sublayer says nothing about still falls
+	// through to Windows Firewall exactly as before, which is what keeps this
+	// from becoming a second firewall.
+	sublayerRelay = windows.GUID{
+		Data1: 0x2171bbec, Data2: 0xcdd2, Data3: 0x4667,
+		Data4: [8]byte{0x81, 0x80, 0x4e, 0x48, 0xc2, 0x10, 0x1b, 0x71},
 	}
 )
 
@@ -194,7 +230,8 @@ var (
 	fwpuclnt            = windows.NewLazySystemDLL("fwpuclnt.dll")
 	procFwpmEngineOpen0 = fwpuclnt.NewProc("FwpmEngineOpen0")
 	procFwpmEngineClose = fwpuclnt.NewProc("FwpmEngineClose0")
-	procFwpmFilterAdd0  = fwpuclnt.NewProc("FwpmFilterAdd0")
+	procFwpmFilterAdd0   = fwpuclnt.NewProc("FwpmFilterAdd0")
+	procFwpmSubLayerAdd0 = fwpuclnt.NewProc("FwpmSubLayerAdd0")
 )
 
 // enableLeakProtection blocks the two ways traffic was leaving around the
@@ -222,6 +259,14 @@ func enableLeakProtection(resolvers []netip.Addr) (func(), error) {
 		return nil, fmt.Errorf("opening a filtering session: %w", windows.Errno(ret))
 	}
 	shutdown := func() { procFwpmEngineClose.Call(engine) }
+
+	// The sublayer has to exist before anything is put in it. Registered inside
+	// the dynamic session, so Windows removes it with everything else when this
+	// process ends, by any route.
+	if err := addSublayer(engine); err != nil {
+		shutdown()
+		return nil, err
+	}
 
 	// Weights are compared within the sublayer; the permits must outrank the
 	// blocks or the tunnel's own resolver would be blocked along with the rest.
@@ -309,6 +354,38 @@ func enableLeakProtection(resolvers []netip.Addr) (func(), error) {
 	return shutdown, nil
 }
 
+// addSublayer registers Relay's own sublayer at the maximum weight.
+//
+// Sublayers are arbitrated before the filters within them, so this is what
+// decides whether a block here can beat Windows Firewall's own permits. Without
+// it -- which is how this shipped -- the DNS block was installed correctly,
+// reported success, and lost every arbitration it entered.
+func addSublayer(engine uintptr) error {
+	name, _ := windows.UTF16PtrFromString("Relay")
+	description, _ := windows.UTF16PtrFromString("Relay leak protection")
+
+	sublayer := fwpmSublayer0{
+		subLayerKey: sublayerRelay,
+		displayData: fwpmDisplayData0{name: name, description: description},
+		// The highest weight there is. Anything less and the question of whether
+		// leak protection works depends on what else is installed on the
+		// machine, which is not a property worth having.
+		weight: ^uint16(0),
+	}
+
+	ret, _, _ := procFwpmSubLayerAdd0.Call(
+		engine,
+		uintptr(unsafe.Pointer(&sublayer)),
+		0,
+	)
+	runtime.KeepAlive(name)
+	runtime.KeepAlive(description)
+	if ret != 0 {
+		return fmt.Errorf("registering the filtering sublayer: %w", windows.Errno(ret))
+	}
+	return nil
+}
+
 type filterSpec struct {
 	name       string
 	layer      windows.GUID
@@ -366,7 +443,7 @@ func addFilter(engine uintptr, spec filterSpec) error {
 	filter := fwpmFilter0{
 		displayData: fwpmDisplayData0{name: name},
 		layerKey:    spec.layer,
-		subLayerKey: sublayerUniversal,
+		subLayerKey: sublayerRelay,
 		weight: fwpValue0{
 			kind:  fwpUint8,
 			value: uintptr(spec.weight),

--- a/wg/cmd/relaywg-client/wfp_windows.go
+++ b/wg/cmd/relaywg-client/wfp_windows.go
@@ -227,9 +227,9 @@ var (
 )
 
 var (
-	fwpuclnt            = windows.NewLazySystemDLL("fwpuclnt.dll")
-	procFwpmEngineOpen0 = fwpuclnt.NewProc("FwpmEngineOpen0")
-	procFwpmEngineClose = fwpuclnt.NewProc("FwpmEngineClose0")
+	fwpuclnt             = windows.NewLazySystemDLL("fwpuclnt.dll")
+	procFwpmEngineOpen0  = fwpuclnt.NewProc("FwpmEngineOpen0")
+	procFwpmEngineClose  = fwpuclnt.NewProc("FwpmEngineClose0")
 	procFwpmFilterAdd0   = fwpuclnt.NewProc("FwpmFilterAdd0")
 	procFwpmSubLayerAdd0 = fwpuclnt.NewProc("FwpmSubLayerAdd0")
 )


### PR DESCRIPTION
Probes run twice — once with no tunnel, once with the filters live — and the assertion is on the transition, which is what separates the filter's effect from what the machine could reach anyway.

Pins both halves of the contract:

| must keep working | must stop working |
|---|---|
| loopback v4 and v6 | DNS to any other resolver |
| ordinary IPv4 | IPv6 off the machine |
| DNS to the tunnel's own resolver | |

The first column matters as much as the second: a rule that over-blocks is not extra safe, it is unrelated software breaking and the user turning the feature off to get their machine back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)