### PR TITLE
EXPERIMENT: is the loopback permit over-permitting?

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -181,7 +181,8 @@ jobs:
             'TestReadyIsWithheldWhenThePeerNeverAnswers',         # READY means a handshake, not merely an adapter
             'TestPeerPublicKeyIsThePeersNotTheDevices',           # an endpoint update names the peer, not the device
             'TestRoamRejectsWhatIsNotAnAddressAndPort',           # a beacon is untrusted input
-            'TestLeakProtectionLeavesLoopbackAlone'               # protecting the tunnel must not break localhost
+            'TestLeakProtectionLeavesLoopbackAlone',              # protecting the tunnel must not break localhost
+            'TestLeakProtectionBlocksWhatItShouldAndNothingElse'  # and blocks exactly what it should, no more
           )
           foreach ($name in $required) {
             if (-not ($output | Select-String -SimpleMatch "--- PASS: $name" -Quiet)) {

--- a/wg/cmd/relaywg-client/leakmatrix_windows_test.go
+++ b/wg/cmd/relaywg-client/leakmatrix_windows_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// What leak protection actually blocks, measured rather than reasoned about.
+//
+// The rules are four lines of Go and it is easy to convince yourself you know
+// what they do. The loopback bug is what that costs: "block all of
+// ALE_AUTH_CONNECT_V6" was read as "block IPv6 leaving the machine" and it
+// meant "block IPv6", localhost included. Nobody noticed until it was measured.
+//
+// So this measures. Every probe runs twice -- once with no tunnel, once with
+// the filters live -- and the assertion is on the *transition*. That is what
+// isolates the filter's effect from whatever this machine could reach anyway,
+// which a single after-the-fact probe cannot do: a runner with no IPv6 route
+// looks exactly like a runner whose IPv6 has been blocked.
+//
+// The contract being pinned, in both directions:
+//
+//	must keep working   loopback v4 and v6, ordinary IPv4, DNS to the tunnel's
+//	                    own resolver
+//	must stop working   DNS to any other resolver, IPv6 off the machine
+//
+// The first half matters as much as the second. A rule that blocks more than it
+// needs to is not "extra safe" -- it is unrelated software breaking, and the
+// user turning the whole feature off to get their machine back.
+func TestLeakProtectionBlocksWhatItShouldAndNothingElse(t *testing.T) {
+	if os.Getenv("RELAYWG_CLIENT") == "" {
+		t.Skip("RELAYWG_CLIENT is not set; CI builds the client and points this at it")
+	}
+
+	// The resolver the tunnel is told to use, and therefore the one address on
+	// port 53 that must survive.
+	const tunnelResolver = "1.1.1.1"
+	// Any other resolver. This is the leak: on a shared Wi-Fi it is the router,
+	// answering alongside the tunnel.
+	const otherResolver = "9.9.9.9"
+
+	// Listeners of our own, so "this still works" is a real connection rather
+	// than an assumption about something on the internet.
+	lan := listenOrSkip(t, "tcp4", nonLoopbackAddr(t)+":0")
+	loopback4 := listenOrSkip(t, "tcp4", "127.0.0.1:0")
+	loopback6 := listenOrSkip(t, "tcp6", "[::1]:0")
+
+	probes := []struct {
+		what        string
+		run         func() error
+		mustSurvive bool // true: must still work; false: must be blocked
+	}{
+		{"loopback IPv4", func() error { return dialTCP(loopback4) }, true},
+		{"loopback IPv6", func() error { return dialTCP(loopback6) }, true},
+		{"ordinary IPv4", func() error { return dialTCP(lan) }, true},
+		{"DNS to the tunnel's resolver", func() error { return sendUDP(tunnelResolver + ":53") }, true},
+		{"DNS to another resolver", func() error { return sendUDP(otherResolver + ":53") }, false},
+		{"IPv6 off the machine", func() error { return sendUDP("[2606:4700:4700::1111]:53") }, false},
+	}
+
+	before := make([]error, len(probes))
+	for i, probe := range probes {
+		before[i] = probe.run()
+		t.Logf("baseline   %-30s %s", probe.what, outcome(before[i]))
+	}
+
+	stop := startProtectedTunnel(t, "RelayTestMatrix", tunnelResolver)
+	defer stop()
+
+	for i, probe := range probes {
+		after := probe.run()
+		t.Logf("protected  %-30s %s", probe.what, outcome(after))
+
+		if before[i] != nil {
+			// It did not work without the tunnel either, so this machine can say
+			// nothing about it. Logged rather than passed over in silence: a
+			// green run that skipped its own assertions has proven nothing.
+			t.Logf("           %-30s NOT MEASURED: unreachable at baseline", probe.what)
+			continue
+		}
+
+		switch {
+		case probe.mustSurvive && after != nil:
+			t.Errorf("%s worked before leak protection and not after (%v).\n"+
+				"A rule is blocking more than it needs to, which breaks unrelated "+
+				"software and makes turning leak protection off look like the fix.",
+				probe.what, after)
+		case !probe.mustSurvive && after == nil:
+			t.Errorf("%s still worked with leak protection on. "+
+				"This is the leak the feature exists to close.", probe.what)
+		}
+	}
+}
+
+// startProtectedTunnel brings the client up far enough that its filters are
+// live, and returns a function that tears it down.
+//
+// No peer answers, and none is needed: the filters go in before the handshake
+// is waited for, so they are live for the whole handshake timeout.
+func startProtectedTunnel(t *testing.T, adapter, resolver string) func() {
+	t.Helper()
+
+	_, serverPublic := keyPair(t)
+	clientPrivate, _ := keyPair(t)
+
+	client := exec.Command(os.Getenv("RELAYWG_CLIENT"),
+		"-name", adapter,
+		"-address", "10.13.37.2/32",
+		// A documentation prefix, so this never takes over the runner's default
+		// route: what is under test is the filters, not the routing table.
+		"-routes", "198.51.100.0/24",
+		"-dns", resolver,
+	)
+	stdin, err := client.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin: %v", err)
+	}
+	stderr, err := client.StderrPipe()
+	if err != nil {
+		t.Fatalf("stderr: %v", err)
+	}
+	if err := client.Start(); err != nil {
+		t.Fatalf("starting the client (Administrator required): %v", err)
+	}
+	stop := func() {
+		_ = client.Process.Kill()
+		_, _ = client.Process.Wait()
+	}
+
+	fmt.Fprintf(stdin,
+		"private_key=%s\npublic_key=%s\nendpoint=127.0.0.1:9\nallowed_ip=0.0.0.0/0\n%s\n",
+		clientPrivate, serverPublic, configTerminator)
+
+	installed := make(chan bool, 1)
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if strings.Contains(line, "leak protection on") {
+				installed <- true
+				return
+			}
+			if strings.Contains(line, "leak protection unavailable") {
+				installed <- false
+				return
+			}
+		}
+		installed <- false
+	}()
+
+	select {
+	case on := <-installed:
+		if !on {
+			stop()
+			t.Skip("leak protection did not install here; nothing to measure")
+		}
+	case <-time.After(30 * time.Second):
+		stop()
+		t.Fatal("the client never said whether leak protection was installed")
+	}
+	return stop
+}
+
+func listenOrSkip(t *testing.T, network, address string) string {
+	t.Helper()
+	listener, err := net.Listen(network, address)
+	if err != nil {
+		t.Skipf("cannot listen on %s %s here: %v", network, address, err)
+	}
+	t.Cleanup(func() { listener.Close() })
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			conn.Close()
+		}
+	}()
+	return listener.Addr().String()
+}
+
+func dialTCP(address string) error {
+	conn, err := net.DialTimeout("tcp", address, 4*time.Second)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+// sendUDP reports whether the machine was allowed to send at all.
+//
+// Whether an answer comes back is the network's business; what a WFP block at
+// ALE_AUTH_CONNECT changes is whether the send is permitted, and that surfaces
+// as an error on the connect or on the first write.
+func sendUDP(address string) error {
+	conn, err := net.DialTimeout("udp", address, 4*time.Second)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	_ = conn.SetWriteDeadline(time.Now().Add(4 * time.Second))
+	// A well-formed A query for example.com, so nothing downstream is being
+	// asked to make sense of garbage.
+	query := []byte{
+		0x12, 0x34, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x07, 0x65, 0x78, 0x61, 0x6d, 0x70, 0x6c, 0x65,
+		0x03, 0x63, 0x6f, 0x6d, 0x00, 0x00, 0x01, 0x00, 0x01,
+	}
+	_, err = conn.Write(query)
+	return err
+}
+
+func outcome(err error) string {
+	if err == nil {
+		return "allowed"
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Timeout() {
+		return "timed out (not a filter)"
+	}
+	return "refused: " + err.Error()
+}
+
+// nonLoopbackAddr is this machine's address as the routing table sees it.
+func nonLoopbackAddr(t *testing.T) string {
+	t.Helper()
+	conn, err := net.Dial("udp4", "192.0.2.1:9")
+	if err != nil {
+		t.Skipf("no routable IPv4 address: %v", err)
+	}
+	defer conn.Close()
+	return conn.LocalAddr().(*net.UDPAddr).IP.String()
+}

--- a/wg/cmd/relaywg-client/tunnel_windows_test.go
+++ b/wg/cmd/relaywg-client/tunnel_windows_test.go
@@ -304,83 +304,26 @@ func freeUDPPort(t *testing.T) int {
 
 // Leak protection must not take localhost down with IPv6.
 //
+// Kept as its own named test, separate from the matrix, because this is the one
+// the CI job lists as required: it is the regression that shipped, and a job
+// that silently stopped running it would still be green.
+//
 // The IPv6 rule is written as "all of ALE_AUTH_CONNECT_V6", and WFP classifies
 // loopback at that layer too -- so the first version of it blocked ::1 as well.
 // On Windows "localhost" resolves to ::1 before 127.0.0.1, which meant that
 // while Relay was connected, every localhost connection on the machine failed
 // or stalled: development servers, database clients, desktop apps talking to
 // their own helpers. Unrelated software breaking, blamed on the tunnel.
-//
-// This is the only place that can be caught. The endpoint's suite runs on Linux
-// with no WFP at all, and the app's own tests never start the tunnel; a runner
-// with Administrator and a real filtering engine is the whole point.
 func TestLeakProtectionLeavesLoopbackAlone(t *testing.T) {
-	binary := os.Getenv("RELAYWG_CLIENT")
-	if binary == "" {
+	if os.Getenv("RELAYWG_CLIENT") == "" {
 		t.Skip("RELAYWG_CLIENT is not set; CI builds the client and points this at it")
 	}
 	if !ipv6LoopbackWorks(t) {
 		t.Skip("this machine cannot reach ::1 even without the tunnel")
 	}
 
-	_, serverPublic := keyPair(t)
-	clientPrivate, _ := keyPair(t)
-
-	// No endpoint on the other end: the filters are installed before the
-	// handshake is waited for, so they are live for the whole timeout and this
-	// never needs a peer that answers.
-	client := exec.Command(binary,
-		"-name", "RelayTestLoopback",
-		"-address", "10.13.37.2/32",
-		"-routes", "198.51.100.0/24",
-		"-dns", "1.1.1.1",
-	)
-	stdin, err := client.StdinPipe()
-	if err != nil {
-		t.Fatalf("stdin: %v", err)
-	}
-	stderr, err := client.StderrPipe()
-	if err != nil {
-		t.Fatalf("stderr: %v", err)
-	}
-	if err := client.Start(); err != nil {
-		t.Fatalf("starting the client (Administrator required): %v", err)
-	}
-	defer func() {
-		_ = client.Process.Kill()
-		_, _ = client.Process.Wait()
-	}()
-
-	fmt.Fprintf(stdin, "private_key=%s\npublic_key=%s\nendpoint=127.0.0.1:9\nallowed_ip=0.0.0.0/0\n%s\n",
-		clientPrivate, serverPublic, configTerminator)
-
-	// Wait for the filters to be in place rather than for a fixed delay: the
-	// window this is testing opens exactly when that line is printed.
-	protected := make(chan bool, 1)
-	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			line := scanner.Text()
-			if strings.Contains(line, "leak protection on") {
-				protected <- true
-				return
-			}
-			if strings.Contains(line, "leak protection unavailable") {
-				protected <- false
-				return
-			}
-		}
-		protected <- false
-	}()
-
-	select {
-	case on := <-protected:
-		if !on {
-			t.Skip("leak protection did not install here; nothing to assert about it")
-		}
-	case <-time.After(30 * time.Second):
-		t.Fatal("the client never said whether leak protection was installed")
-	}
+	stop := startProtectedTunnel(t, "RelayTestLoopback", "1.1.1.1")
+	defer stop()
 
 	if !ipv6LoopbackWorks(t) {
 		t.Fatal("::1 stopped working while leak protection was on — " +

--- a/wg/cmd/relaywg-client/tunnel_windows_test.go
+++ b/wg/cmd/relaywg-client/tunnel_windows_test.go
@@ -315,6 +315,7 @@ func freeUDPPort(t *testing.T) int {
 // or stalled: development servers, database clients, desktop apps talking to
 // their own helpers. Unrelated software breaking, blamed on the tunnel.
 func TestLeakProtectionLeavesLoopbackAlone(t *testing.T) {
+	t.Skip("EXPERIMENT: loopback permit deliberately removed")
 	if os.Getenv("RELAYWG_CLIENT") == "" {
 		t.Skip("RELAYWG_CLIENT is not set; CI builds the client and points this at it")
 	}

--- a/wg/cmd/relaywg-client/wfp_windows.go
+++ b/wg/cmd/relaywg-client/wfp_windows.go
@@ -246,18 +246,6 @@ func enableLeakProtection(resolvers []netip.Addr) (func(), error) {
 	// Permitting it cannot leak anything. Loopback does not reach a network
 	// interface at all, so there is no adapter for it to escape by. This is the
 	// same exception wireguard-windows carves out, for the same reason.
-	for _, layer := range []windows.GUID{layerAleAuthConnectV4, layerAleAuthConnectV6} {
-		if err := addFilter(engine, filterSpec{
-			name:     "Relay: permit loopback, which never leaves the machine",
-			layer:    layer,
-			action:   fwpActionPermit,
-			weight:   weightLoopback,
-			loopback: true,
-		}); err != nil {
-			shutdown()
-			return nil, err
-		}
-	}
 
 	// IPv6, all of it. This client configures AF_INET only, so every v6
 	// connection was leaving by the physical adapter with the real address on

--- a/wg/goroutines_test.go
+++ b/wg/goroutines_test.go
@@ -1,0 +1,122 @@
+package relaywg
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// Connections must give their goroutines back.
+//
+// Nothing pinned this, and the endpoint is exactly the shape where it goes
+// wrong: every forwarded connection runs two copy goroutines and holds a
+// socket and a 64 KB buffer, and UDP -- which never says when it is finished --
+// gets one flow per DNS lookup. A leak here does not show up as a crash. It
+// shows up as a phone that is fine for ten minutes and then is not, which is
+// the hardest kind of report to act on.
+//
+// Counted rather than reasoned about, and settled with a deadline rather than a
+// sleep: goroutines exit asynchronously, so a fixed sleep either makes this
+// flaky or makes it slow.
+func TestForwardedConnectionsDoNotLeakGoroutines(t *testing.T) {
+	const (
+		connections = 40
+		// Enough slack for the runtime's own workers and the tunnel's internal
+		// goroutines to move around, far less than 2 per connection.
+		slack = 12
+	)
+
+	destination := httpServer(t, "a body worth fetching")
+
+	serverPrivate, serverPublic := keyPair(t)
+	clientPrivate, clientPublic := keyPair(t)
+	port := freeUDPPort(t)
+
+	endpoint, err := Start(fmt.Sprintf(`private_key=%s
+listen_port=%d
+public_key=%s
+allowed_ip=10.13.37.2/32
+`, serverPrivate, port, clientPublic))
+	if err != nil {
+		t.Fatalf("endpoint did not start: %v", err)
+	}
+	defer endpoint.Stop()
+
+	client, clientNet := wireguardClient(t, clientPrivate, serverPublic, port)
+	defer client.Close()
+
+	transport := &http.Transport{
+		DialContext: clientNet.DialContext,
+		// Every request gets its own connection, which is the point: pooled
+		// connections would hide exactly the leak being looked for.
+		DisableKeepAlives: true,
+	}
+	httpClient := &http.Client{Transport: transport, Timeout: 20 * time.Second}
+
+	fetch := func() error {
+		response, err := httpClient.Get("http://" + destination + "/")
+		if err != nil {
+			return err
+		}
+		_, _ = io.Copy(io.Discard, response.Body)
+		return response.Body.Close()
+	}
+
+	// Warm up until the handshake completes, so the baseline is taken with the
+	// tunnel already running rather than mid-setup.
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		if fetch() == nil {
+			break
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+	transport.CloseIdleConnections()
+	baseline := settledGoroutines(t, 0)
+
+	for i := 0; i < connections; i++ {
+		if err := fetch(); err != nil {
+			t.Fatalf("request %d through the tunnel failed: %v", i, err)
+		}
+	}
+	transport.CloseIdleConnections()
+
+	after := settledGoroutines(t, baseline+slack)
+	if after > baseline+slack {
+		buffer := make([]byte, 1<<16)
+		buffer = buffer[:runtime.Stack(buffer, true)]
+		t.Fatalf("goroutines went %d -> %d over %d connections (allowing %d).\n"+
+			"Two per forwarded connection are never returned when this breaks.\n\n%s",
+			baseline, after, connections, slack, buffer)
+	}
+	t.Logf("goroutines %d -> %d over %d connections", baseline, after, connections)
+}
+
+// settledGoroutines waits for the count to stop moving, or to fall within
+// target, whichever happens first.
+func settledGoroutines(t *testing.T, target int) int {
+	t.Helper()
+
+	deadline := time.Now().Add(15 * time.Second)
+	last := runtime.NumGoroutine()
+	stable := 0
+	for time.Now().Before(deadline) {
+		time.Sleep(200 * time.Millisecond)
+		now := runtime.NumGoroutine()
+		if target > 0 && now <= target {
+			return now
+		}
+		if now == last {
+			if stable++; stable >= 3 {
+				return now
+			}
+		} else {
+			stable = 0
+			last = now
+		}
+	}
+	return runtime.NumGoroutine()
+}


### PR DESCRIPTION
Throwaway diagnostic. Removes the loopback permit and runs the leak matrix. If DNS blocking starts working, the loopback permit is an unconditional permit rather than a loopback-only one.