### PR TITLE
Test the shapes real traffic takes, through a real tunnel

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -184,6 +184,8 @@ jobs:
             'TestLeakProtectionLeavesLoopbackAlone',              # protecting the tunnel must not break localhost
             'TestLeakProtectionBlocksWhatItShouldAndNothingElse'  # and blocks exactly what it should, no more
           )
+          # The endpoint's own reliability shapes run in the CI workflow; these
+          # are the ones that need Windows.
           foreach ($name in $required) {
             if (-not ($output | Select-String -SimpleMatch "--- PASS: $name" -Quiet)) {
               Write-Error "$name did not run — this job proves nothing without it"

--- a/wg/cmd/relaywg-client/leakmatrix_windows_test.go
+++ b/wg/cmd/relaywg-client/leakmatrix_windows_test.go
@@ -45,6 +45,9 @@ func TestLeakProtectionBlocksWhatItShouldAndNothingElse(t *testing.T) {
 	// Any other resolver. This is the leak: on a shared Wi-Fi it is the router,
 	// answering alongside the tunnel.
 	const otherResolver = "9.9.9.9"
+	// A host that answers on 443 and ignores 51820, used only to ask whether
+	// the machine was *allowed* to try.
+	const vpnProbe = "1.1.1.1"
 
 	// Listeners of our own, so "this still works" is a real connection rather
 	// than an assumption about something on the internet.
@@ -63,6 +66,14 @@ func TestLeakProtectionBlocksWhatItShouldAndNothingElse(t *testing.T) {
 		{"DNS to the tunnel's resolver (UDP)", func() error { return resolve(tunnelResolver + ":53") }, true},
 		{"DNS to another resolver (UDP)", func() error { return resolve(otherResolver + ":53") }, false},
 		{"DNS to another resolver (TCP)", func() error { return dialTCP(otherResolver + ":53") }, false},
+		// VPN coexistence, as far as one machine can show it. Every VPN's
+		// transport is UDP or TCP on a port that is not 53 -- WireGuard on
+		// 51820, OpenVPN on 1194, anything tunnelling over 443. Relay's rules
+		// touch port 53 and IPv6 and nothing else, and this is what says so out
+		// loud: if a rule ever grows to block more, another VPN on this machine
+		// stops working and Relay gets the blame.
+		{"a VPN's UDP transport (non-53)", func() error { return sendUDP(vpnProbe + ":51820") }, true},
+		{"a VPN's TCP transport (443)", func() error { return dialTCP(vpnProbe + ":443") }, true},
 		{"IPv6 off the machine", func() error { return sendUDP("[2606:4700:4700::1111]:53") }, false},
 	}
 

--- a/wg/relaywg.go
+++ b/wg/relaywg.go
@@ -47,7 +47,7 @@ const (
 	//
 	// TCP says when it is done, so this is only the backstop for a peer that
 	// vanished without a FIN.
-	tcpIdleTimeout = 5 * time.Minute
+	defaultTCPIdleTimeout = 5 * time.Minute
 
 	// UDP never says it is done, so this is the only thing that reaps it -- and
 	// a browsing session opens one flow per DNS lookup, each holding two
@@ -56,7 +56,18 @@ const (
 	// for exchanges that ended in milliseconds. A minute is still generous for
 	// the flows that legitimately persist: QUIC and games keep themselves
 	// alive, and anything that does not is finished.
-	udpIdleTimeout = 60 * time.Second
+	defaultUDPIdleTimeout = 60 * time.Second
+)
+
+// The timeouts the forwarders actually use.
+//
+// Variables rather than constants for one reason: the reliability tests have to
+// watch a connection cross an idle timeout and come out the other side, and at
+// five minutes each that is a suite nobody runs. Nothing outside the tests ever
+// writes them, and the values are the constants above.
+var (
+	tcpIdleTimeout = defaultTCPIdleTimeout
+	udpIdleTimeout = defaultUDPIdleTimeout
 )
 
 // Endpoint is one running Full Mode session. It is safe to call Stop on an

--- a/wg/reliability_test.go
+++ b/wg/reliability_test.go
@@ -1,0 +1,323 @@
+package relaywg
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"golang.zx2c4.com/wireguard/tun/netstack"
+)
+
+// The shapes real traffic actually takes, through a real tunnel.
+//
+// The suite already proved that one HTTP request and one UDP datagram survive
+// the trip. That is the "does it work at all" question, and it is not the one
+// users report against: what breaks is a download that is still going after
+// five minutes, an SSH session that says nothing for a while, a phone whose
+// endpoint restarted, a transfer that arrives subtly wrong. Every one of those
+// is a shape, and none of them was covered.
+//
+// These run against the same in-process pairing the other end-to-end tests use:
+// a real wireguard-go client, real encryption, a real gVisor stack, and real
+// sockets on the far side. What they cannot cover is anything about a radio or
+// a suspended machine -- Wi-Fi changes and sleep/wake need hardware, and are
+// named as such in the report rather than faked here.
+
+// tunnelPair brings up an endpoint and a client and returns the client's stack.
+func tunnelPair(t *testing.T) (*netstack.Net, func()) {
+	t.Helper()
+
+	serverPrivate, serverPublic := keyPair(t)
+	clientPrivate, clientPublic := keyPair(t)
+	port := freeUDPPort(t)
+
+	endpoint, err := Start(fmt.Sprintf(`private_key=%s
+listen_port=%d
+public_key=%s
+allowed_ip=10.13.37.2/32
+`, serverPrivate, port, clientPublic))
+	if err != nil {
+		t.Fatalf("endpoint did not start: %v", err)
+	}
+
+	client, clientNet := wireguardClient(t, clientPrivate, serverPublic, port)
+	return clientNet, func() {
+		client.Close()
+		endpoint.Stop()
+	}
+}
+
+// dialThroughTunnel retries until the handshake has completed.
+func dialThroughTunnel(t *testing.T, clientNet *netstack.Net, address string) net.Conn {
+	t.Helper()
+
+	deadline := time.Now().Add(25 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := clientNet.Dial("tcp", address)
+		if err == nil {
+			return conn
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Fatalf("nothing could be dialled through the tunnel to %s", address)
+	return nil
+}
+
+// echoServer accepts one connection and copies it back.
+func echoServer(t *testing.T) string {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", nonLoopbackAddress(t)+":0")
+	if err != nil {
+		t.Fatalf("echo server: %v", err)
+	}
+	t.Cleanup(func() { listener.Close() })
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				return
+			}
+			go func() {
+				defer conn.Close()
+				_, _ = io.Copy(conn, conn)
+			}()
+		}
+	}()
+	return listener.Addr().String()
+}
+
+// A connection that is still working must not be reaped, through the whole
+// tunnel rather than across a pipe.
+//
+// forward_test.go pins the same rule directly on the splice. This pins it where
+// it is actually reached: through the gVisor stack, through the forwarder, on a
+// connection the client opened. A download crossing the five-minute mark is the
+// case users reported, and the idle timeout is shortened here rather than
+// waiting five minutes for it.
+func TestALongRunningConnectionSurvivesTheIdleTimeout(t *testing.T) {
+	restore := shortenIdleTimeouts(t, 400*time.Millisecond)
+	defer restore()
+
+	destination := echoServer(t)
+	clientNet, stop := tunnelPair(t)
+	defer stop()
+
+	conn := dialThroughTunnel(t, clientNet, destination)
+	defer conn.Close()
+
+	// Quiet stretches longer than half the timeout, repeated well past it.
+	message := []byte("still here")
+	reply := make([]byte, len(message))
+	for i := 0; i < 8; i++ {
+		_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+		if _, err := conn.Write(message); err != nil {
+			t.Fatalf("write %d died after %v of a working connection: %v",
+				i, time.Duration(i)*300*time.Millisecond, err)
+		}
+		if _, err := io.ReadFull(conn, reply); err != nil {
+			t.Fatalf("read %d died on a working connection: %v", i, err)
+		}
+		if !bytes.Equal(reply, message) {
+			t.Fatalf("echo %d came back as %q", i, reply)
+		}
+		time.Sleep(300 * time.Millisecond)
+	}
+}
+
+// Bulk transfer, both directions, checked for integrity rather than for volume.
+//
+// Throughput is measured by the benchmarks. What this asks is whether several
+// megabytes arrive *exactly* -- a packet path that drops, duplicates or
+// reorders under load is a corruption bug, and a size check would not see it.
+func TestBulkTransferArrivesIntactInBothDirections(t *testing.T) {
+	const size = 4 << 20
+
+	payload := make([]byte, size)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatalf("payload: %v", err)
+	}
+	want := sha256.Sum256(payload)
+
+	destination := echoServer(t)
+	clientNet, stop := tunnelPair(t)
+	defer stop()
+
+	conn := dialThroughTunnel(t, clientNet, destination)
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(90 * time.Second))
+
+	// Upload and download at once, which is also the case that deadlocks a
+	// splice that waits on the wrong direction.
+	uploaded := make(chan error, 1)
+	go func() {
+		_, err := conn.Write(payload)
+		uploaded <- err
+	}()
+
+	returned := make([]byte, size)
+	if _, err := io.ReadFull(conn, returned); err != nil {
+		t.Fatalf("only part of the data came back: %v", err)
+	}
+	if err := <-uploaded; err != nil {
+		t.Fatalf("upload failed: %v", err)
+	}
+
+	if got := sha256.Sum256(returned); got != want {
+		t.Fatalf("what came back is not what went out: %x != %x", got, want)
+	}
+}
+
+// The SSH and websocket shape: open, then long silences with small messages in
+// both directions, for much longer than the idle timeout.
+//
+// This is the shape the five-minute bug destroyed most visibly, and it is not
+// the same as the download shape: traffic goes both ways, but rarely.
+func TestAnInteractiveSessionSurvivesLongSilences(t *testing.T) {
+	restore := shortenIdleTimeouts(t, 400*time.Millisecond)
+	defer restore()
+
+	destination := echoServer(t)
+	clientNet, stop := tunnelPair(t)
+	defer stop()
+
+	conn := dialThroughTunnel(t, clientNet, destination)
+	defer conn.Close()
+
+	for i := 0; i < 6; i++ {
+		// Silence longer than half the idle timeout, every time.
+		time.Sleep(250 * time.Millisecond)
+
+		keystroke := []byte(fmt.Sprintf("keystroke-%d\n", i))
+		_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+		if _, err := conn.Write(keystroke); err != nil {
+			t.Fatalf("the session died on keystroke %d: %v", i, err)
+		}
+		echo := make([]byte, len(keystroke))
+		if _, err := io.ReadFull(conn, echo); err != nil {
+			t.Fatalf("no echo for keystroke %d: %v", i, err)
+		}
+		if !bytes.Equal(echo, keystroke) {
+			t.Fatalf("keystroke %d came back as %q", i, echo)
+		}
+	}
+}
+
+// UDP has to survive silence too, and it is the one that cannot say so.
+//
+// A UDP flow is reaped by the idle timeout alone, so a flow that keeps being
+// used must keep being renewed. DNS is the common case; a game or a QUIC
+// session is the one that would notice.
+func TestAUdpFlowSurvivesBeingUsedSlowly(t *testing.T) {
+	restore := shortenIdleTimeouts(t, 400*time.Millisecond)
+	defer restore()
+
+	destination := udpEchoServer(t)
+	clientNet, stop := tunnelPair(t)
+	defer stop()
+
+	var conn net.Conn
+	deadline := time.Now().Add(25 * time.Second)
+	for time.Now().Before(deadline) {
+		candidate, err := clientNet.Dial("udp", destination)
+		if err == nil {
+			conn = candidate
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if conn == nil {
+		t.Fatal("no UDP flow could be opened through the tunnel")
+	}
+	defer conn.Close()
+
+	reply := make([]byte, 64)
+	for i := 0; i < 5; i++ {
+		message := []byte(fmt.Sprintf("datagram-%d", i))
+		_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+		if _, err := conn.Write(message); err != nil {
+			t.Fatalf("datagram %d could not be sent: %v", i, err)
+		}
+		n, err := conn.Read(reply)
+		if err != nil {
+			t.Fatalf("datagram %d was never answered: %v", i, err)
+		}
+		if !bytes.Equal(reply[:n], message) {
+			t.Fatalf("datagram %d came back as %q", i, reply[:n])
+		}
+		time.Sleep(250 * time.Millisecond)
+	}
+}
+
+// The phone's endpoint going away and coming back.
+//
+// This is the ordinary case, not an exotic one: sharing stops and starts, the
+// app is killed, the service is restarted by the system. What must not happen
+// is the old endpoint leaving something behind that stops the new one working
+// -- a held port, a live forwarder, a stack that was never closed.
+func TestTrafficFlowsAgainAfterTheEndpointRestarts(t *testing.T) {
+	destination := echoServer(t)
+
+	serverPrivate, serverPublic := keyPair(t)
+	clientPrivate, clientPublic := keyPair(t)
+	port := freeUDPPort(t)
+
+	config := fmt.Sprintf(`private_key=%s
+listen_port=%d
+public_key=%s
+allowed_ip=10.13.37.2/32
+`, serverPrivate, port, clientPublic)
+
+	endpoint, err := Start(config)
+	if err != nil {
+		t.Fatalf("endpoint did not start: %v", err)
+	}
+	client, clientNet := wireguardClient(t, clientPrivate, serverPublic, port)
+	defer client.Close()
+
+	exchange := func(stage string) {
+		t.Helper()
+		conn := dialThroughTunnel(t, clientNet, destination)
+		defer conn.Close()
+		_ = conn.SetDeadline(time.Now().Add(20 * time.Second))
+		message := []byte("hello " + stage)
+		if _, err := conn.Write(message); err != nil {
+			t.Fatalf("%s: write: %v", stage, err)
+		}
+		echo := make([]byte, len(message))
+		if _, err := io.ReadFull(conn, echo); err != nil {
+			t.Fatalf("%s: read: %v", stage, err)
+		}
+	}
+
+	exchange("before the restart")
+
+	endpoint.Stop()
+
+	// Same port and same keys, which is what a phone that restarted sharing
+	// without re-pairing would present.
+	restarted, err := Start(config)
+	if err != nil {
+		t.Fatalf("the endpoint did not come back on the same port: %v", err)
+	}
+	defer restarted.Stop()
+
+	exchange("after the restart")
+}
+
+// shortenIdleTimeouts makes the reaping observable in a test rather than in
+// five minutes, and puts the real values back afterwards.
+//
+// Not parallel-safe, and deliberately so: these tests do not call t.Parallel.
+func shortenIdleTimeouts(t *testing.T, idle time.Duration) func() {
+	t.Helper()
+	previousTCP, previousUDP := tcpIdleTimeout, udpIdleTimeout
+	tcpIdleTimeout, udpIdleTimeout = idle, idle
+	return func() { tcpIdleTimeout, udpIdleTimeout = previousTCP, previousUDP }
+}


### PR DESCRIPTION
The suite proved one HTTP request and one datagram survive the trip. That is "does it work at all", and it is not what gets reported.

Five shapes, all against a real wireguard-go client, real encryption, a real gVisor stack and real sockets: long-running, bulk transfer (hash-checked, both directions at once), interactive (SSH/websocket), UDP slow-use, and endpoint restart.

Idle timeouts become variables so these run in seconds rather than five minutes each; nothing outside the tests writes them.

The leak matrix gains two VPN-coexistence probes — every VPN transport is UDP or TCP on a non-53 port, and the rules must leave those alone.

Wi-Fi change and sleep/wake are deliberately absent: they need hardware and are reported as untested rather than approximated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)