### PR TITLE
Ask the person even when they are not looking at the app

### DIFF
--- a/android/app/src/main/kotlin/io/relay/app/net/ClientGate.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/ClientGate.kt
@@ -72,15 +72,31 @@ class ClientGate(
             val answer = CompletableDeferred<Decision>()
             waiters[address] = answer
             _pending.value = Pending(address)
+            var answered = true
             val decision = try {
                 withTimeout(timeoutMs) { answer.await() }
             } catch (_: TimeoutCancellationException) {
+                answered = false
                 Decision.DENIED
             } finally {
                 waiters.remove(address)
                 _pending.value = null
             }
-            decisions[address] = decision
+            // Only a person's answer is remembered.
+            //
+            // Refusing on silence is right and stays: a phone in a pocket must
+            // fail closed. Recording that refusal was not. Nobody decided
+            // anything, and yet every later attempt from that computer was
+            // turned away in milliseconds without anyone being asked -- so the
+            // one prompt that was missed was the only prompt there would ever
+            // be, and the person was left pressing Connect against a phone that
+            // had quietly stopped listening to them.
+            //
+            // Reproduced on hardware: one missed prompt, and the next request
+            // came back ERR_PAIRING_DENIED in 0.03s with no dialog. The only
+            // way out was restarting sharing, which is what toggling a VPN
+            // happens to do -- which is why this was reported as a VPN bug.
+            if (answered) decisions[address] = decision
             decision == Decision.ALLOWED
         }
     }

--- a/android/app/src/main/kotlin/io/relay/app/service/ApprovalNotice.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/ApprovalNotice.kt
@@ -1,0 +1,103 @@
+package io.relay.app.service
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import io.relay.app.R
+
+/**
+ * Asks the person to allow a computer, when they are not looking at the app.
+ *
+ * The approval prompt was a dialog inside the app's own screen and nothing
+ * else. That works for the person who is holding the phone and watching it, and
+ * for nobody else -- and nobody else is the normal case: you press Connect on
+ * the laptop, because that is where you are looking, while the phone sits on
+ * the desk showing the launcher or nothing at all. Then the prompt appears on a
+ * screen no one can see, times out, and the connection is refused.
+ *
+ * Verified on a device before this existed: with Relay in the background the
+ * request timed out after twenty seconds having posted nothing whatsoever --
+ * no dialog, no notification, no sound.
+ *
+ * So it is asked here too, with the answer available from the shade. High
+ * importance on purpose: this is a question that expires, and one the person
+ * has to answer for anything to work. It is also the only notification Relay
+ * sends that is allowed to interrupt.
+ */
+object ApprovalNotice {
+
+    private const val CHANNEL_ID = "approval"
+    private const val NOTIFICATION_ID = 3
+
+    /** Shows the request, or does nothing if notifications are not granted. */
+    fun show(context: Context, address: String) {
+        runCatching {
+            val manager = context.getSystemService(NotificationManager::class.java) ?: return
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                manager.createNotificationChannel(
+                    NotificationChannel(
+                        CHANNEL_ID,
+                        context.getString(R.string.approval_channel),
+                        NotificationManager.IMPORTANCE_HIGH,
+                    ),
+                )
+            }
+
+            val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+                .setSmallIcon(R.drawable.ic_shortcut_start)
+                .setContentTitle(context.getString(R.string.approval_title))
+                .setContentText(context.getString(R.string.approval_body, address))
+                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                .setCategory(NotificationCompat.CATEGORY_CALL)
+                // Not dismissible by a swipe: a question that vanishes when
+                // brushed past is one the person will be told they answered.
+                .setOngoing(true)
+                .setAutoCancel(false)
+                .addAction(
+                    0,
+                    context.getString(R.string.approval_deny),
+                    answer(context, SharingService.ACTION_DENY_CLIENT, address, 1),
+                )
+                .addAction(
+                    0,
+                    context.getString(R.string.approval_allow),
+                    answer(context, SharingService.ACTION_ALLOW_CLIENT, address, 2),
+                )
+                .build()
+
+            NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, notification)
+        }
+    }
+
+    /** Clears it once the question has been answered, however it was answered. */
+    fun clear(context: Context) {
+        runCatching { NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID) }
+    }
+
+    /**
+     * One tap, carrying the address it is about.
+     *
+     * The address travels in the intent rather than being read from whatever is
+     * pending at the moment the tap lands: two computers can arrive together,
+     * and answering the question you were shown must not answer a different one
+     * that replaced it.
+     *
+     * Distinct request codes, or Android would hand the second action the first
+     * one's intent and both buttons would mean the same thing.
+     */
+    private fun answer(context: Context, action: String, address: String, code: Int) =
+        PendingIntent.getService(
+            context,
+            code,
+            Intent(context, SharingService::class.java)
+                .setAction(action)
+                .putExtra(SharingService.EXTRA_CLIENT_ADDRESS, address),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE,
+        )
+}

--- a/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
@@ -116,6 +116,23 @@ class SharingService : Service() {
             }
         }
 
+        // Ask about a waiting computer even when nobody is looking at the app.
+        //
+        // The dialog in MainActivity only reaches someone already watching the
+        // screen, which is the opposite of the normal case: you press Connect
+        // on the laptop, because that is where you are, and the phone is face
+        // down on the desk. Before this, that request simply timed out having
+        // shown nothing at all.
+        scope.launch {
+            ConnectionRepository.clientGate.pending.collect { waiting ->
+                if (waiting == null) {
+                    ApprovalNotice.clear(this@SharingService)
+                } else {
+                    ApprovalNotice.show(this@SharingService, waiting.address)
+                }
+            }
+        }
+
         // The only update check that reaches someone who never opens the app.
         //
         // Relay is designed to be started from the tile, the widget or a
@@ -159,6 +176,16 @@ class SharingService : Service() {
                 }
             }
             ACTION_STOP -> stopSharing()
+            ACTION_ALLOW_CLIENT, ACTION_DENY_CLIENT -> {
+                val address = intent.getStringExtra(EXTRA_CLIENT_ADDRESS)
+                if (address != null) {
+                    ConnectionRepository.clientGate.resolve(
+                        address,
+                        allowed = intent.action == ACTION_ALLOW_CLIENT,
+                    )
+                }
+                ApprovalNotice.clear(this)
+            }
         }
         return START_STICKY
     }
@@ -639,6 +666,11 @@ class SharingService : Service() {
     companion object {
         const val ACTION_START = "io.relay.app.action.START"
         const val ACTION_STOP = "io.relay.app.action.STOP"
+
+        /** Answers to the approval notification, carrying the address asked about. */
+        const val ACTION_ALLOW_CLIENT = "io.relay.app.action.ALLOW_CLIENT"
+        const val ACTION_DENY_CLIENT = "io.relay.app.action.DENY_CLIENT"
+        const val EXTRA_CLIENT_ADDRESS = "io.relay.app.extra.CLIENT_ADDRESS"
         const val CHANNEL_ID = "sharing"
         const val NOTIFICATION_ID = 1
         const val HOTSPOT_POLL_MS = 2000L

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -126,4 +126,9 @@
     <string name="onboarding_shortcut_body">«شروع اشتراک‌گذاری» همان‌جا هست — چیزی برای تنظیم نیست.</string>
     <string name="update_channel">به‌روزرسانی‌ها</string>
     <string name="update_notice_body">برای باز کردن رله و نصب آن بزنید.</string>
+    <string name="approval_channel">درخواست‌های اتصال</string>
+    <string name="approval_title">به این کامپیوتر اجازه می‌دهید؟</string>
+    <string name="approval_body">%1$s می‌خواهد از اینترنت شما استفاده کند.</string>
+    <string name="approval_allow">اجازه بده</string>
+    <string name="approval_deny">رد کن</string>
 </resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -126,4 +126,9 @@
     <string name="onboarding_shortcut_body">Start Sharing is already there — nothing to set up.</string>
     <string name="update_channel">Updates</string>
     <string name="update_notice_body">Tap to open Relay and install it.</string>
+    <string name="approval_channel">Connection requests</string>
+    <string name="approval_title">Allow this computer?</string>
+    <string name="approval_body">%1$s wants to share your connection.</string>
+    <string name="approval_allow">Allow</string>
+    <string name="approval_deny">Deny</string>
 </resources>

--- a/android/app/src/test/kotlin/io/relay/app/ClientGateTest.kt
+++ b/android/app/src/test/kotlin/io/relay/app/ClientGateTest.kt
@@ -35,6 +35,29 @@ class ClientGateTest {
     }
 
     @Test
+    fun `a missed prompt does not silence every later attempt`() = runTest {
+        // The bug this pins, reproduced on a device before it was found here:
+        // press Connect on the laptop while the phone is face down, miss the
+        // prompt, and every attempt afterwards came back ERR_PAIRING_DENIED in
+        // milliseconds with no dialog at all. The one prompt that was missed
+        // was the only prompt there would ever be.
+        //
+        // Refusing on silence is correct and stays -- a phone in a pocket must
+        // fail closed. What was wrong was remembering it: nobody decided
+        // anything, so there is nothing to remember.
+        val gate = ClientGate(timeoutMs = 50)
+
+        assertFalse("silence must still refuse", gate.authorize("192.168.1.8"))
+
+        // The person picks the phone up and the laptop tries again. They must
+        // be asked, not refused on the strength of a question they never saw.
+        val second = async { gate.authorize("192.168.1.8") }
+        waitForPrompt(gate, "192.168.1.8")
+        gate.resolve("192.168.1.8", allowed = true)
+        assertTrue("a second attempt must ask again", second.await())
+    }
+
+    @Test
     fun `an approved address is not asked about twice`() = runTest {
         val gate = ClientGate()
         val first = async { gate.authorize("192.168.1.7") }


### PR DESCRIPTION
A user reported that with a VPN up on the phone the approval popup never appears, and that turning the VPN off fixes it. Reproduced on hardware — the VPN is a red herring. Two real faults:

**The prompt only existed inside the app's own screen.** That reaches someone already watching the phone and nobody else, which is the opposite of the normal case: you press Connect on the laptop because that is where you are looking, while the phone lies face down on the desk. Measured with Relay backgrounded — the request timed out after 20s having posted *nothing at all*: no dialog, no notification, no sound.

**A timeout was recorded as a decision.** Refusing on silence is right and stays — a phone in a pocket must fail closed. Remembering it was not: nobody decided anything, so the one prompt that was missed became the only prompt there would ever be. Measured — the next request returned `ERR_PAIRING_DENIED` in 0.03s with no dialog. The only escape was restarting sharing, and toggling a VPN happens to restart sharing. That is the entire VPN connection.

The question is now also asked in the notification shade, at high importance with Allow and Deny on it, and the answer carries the address it was shown for so two computers arriving together cannot answer each other's question.

A regression test pins both halves: silence still refuses, but a later attempt is asked again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
