### PR TITLE
Draw the Persian buttons instead of fetching them

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -17,9 +17,9 @@
 
 <br>
 
-[![دانلود برای ویندوز](https://img.shields.io/badge/دانلود_برای-ویندوز-0078D4?style=for-the-badge&logo=windows&logoColor=white)](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe)
+[<img src="docs/assets/btn-windows-fa.svg" alt="دانلود برای ویندوز" height="44">](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe)
 &nbsp;
-[![دانلود برای اندروید](https://img.shields.io/badge/دانلود_برای-اندروید-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk)
+[<img src="docs/assets/btn-android-fa.svg" alt="دانلود برای اندروید" height="44">](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk)
 &nbsp;
 [![English](https://img.shields.io/badge/Read_in-English-4ADFBF?style=for-the-badge)](README.md)
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 &nbsp;
 [![Download for Android](https://img.shields.io/badge/Download_for-Android-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk)
 &nbsp;
-[![راهنمای فارسی](https://img.shields.io/badge/راهنمای-فارسی-4ADFBF?style=for-the-badge)](README.fa.md)
+[<img src="docs/assets/btn-guide-fa.svg" alt="راهنمای فارسی" height="40">](README.fa.md)
 
 <sub><a href="https://github.com/Mahdi-mortazavi/relay/releases/latest">All files &amp; release notes</a> · <a href="LICENSE">GPL-3.0</a></sub>
 

--- a/docs/assets/btn-android-fa.svg
+++ b/docs/assets/btn-android-fa.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 236 52" width="236" height="52" role="img"
+     aria-label="دانلود برای اندروید">
+  <!--
+    A download button drawn here rather than fetched from shields.io.
+
+    shields.io does not shape Arabic script: it renders each letter in its
+    isolated form, spaced and left-to-right, so "دانلود برای ویندوز" arrived as
+    "د ا ن ل و د  ب ر ا ی" and was unreadable — on the page whose readers are
+    the reason it exists. An SVG shapes it correctly, and the render is checked.
+  -->
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4BD07C"/>
+      <stop offset="100%" stop-color="#2FA85C"/>
+    </linearGradient>
+  </defs>
+  <rect width="236" height="52" rx="11" fill="url(#g)"/>
+  <text x="118" y="32" text-anchor="middle" direction="rtl"
+        font-family="Vazirmatn, 'Segoe UI', Tahoma, 'Noto Naskh Arabic', sans-serif"
+        font-size="17" font-weight="600" fill="#FFFFFF">دانلود برای اندروید</text>
+</svg>

--- a/docs/assets/btn-guide-fa.svg
+++ b/docs/assets/btn-guide-fa.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 236 52" width="236" height="52" role="img"
+     aria-label="راهنمای فارسی">
+  <!--
+    A download button drawn here rather than fetched from shields.io.
+
+    shields.io does not shape Arabic script: it renders each letter in its
+    isolated form, spaced and left-to-right, so "دانلود برای ویندوز" arrived as
+    "د ا ن ل و د  ب ر ا ی" and was unreadable — on the page whose readers are
+    the reason it exists. An SVG shapes it correctly, and the render is checked.
+  -->
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4ADFBF"/>
+      <stop offset="100%" stop-color="#2FB9A0"/>
+    </linearGradient>
+  </defs>
+  <rect width="236" height="52" rx="11" fill="url(#g)"/>
+  <text x="118" y="32" text-anchor="middle" direction="rtl"
+        font-family="Vazirmatn, 'Segoe UI', Tahoma, 'Noto Naskh Arabic', sans-serif"
+        font-size="17" font-weight="600" fill="#FFFFFF">راهنمای فارسی</text>
+</svg>

--- a/docs/assets/btn-windows-fa.svg
+++ b/docs/assets/btn-windows-fa.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 236 52" width="236" height="52" role="img"
+     aria-label="دانلود برای ویندوز">
+  <!--
+    A download button drawn here rather than fetched from shields.io.
+
+    shields.io does not shape Arabic script: it renders each letter in its
+    isolated form, spaced and left-to-right, so "دانلود برای ویندوز" arrived as
+    "د ا ن ل و د  ب ر ا ی" and was unreadable — on the page whose readers are
+    the reason it exists. An SVG shapes it correctly, and the render is checked.
+  -->
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1B8FE3"/>
+      <stop offset="100%" stop-color="#0067C0"/>
+    </linearGradient>
+  </defs>
+  <rect width="236" height="52" rx="11" fill="url(#g)"/>
+  <text x="118" y="32" text-anchor="middle" direction="rtl"
+        font-family="Vazirmatn, 'Segoe UI', Tahoma, 'Noto Naskh Arabic', sans-serif"
+        font-size="17" font-weight="600" fill="#FFFFFF">دانلود برای ویندوز</text>
+</svg>


### PR DESCRIPTION
**shields.io does not shape Arabic script.** It renders each letter in its isolated form, spaced, left-to-right — so the two download buttons on the Persian README arrived as `د ا ن ل و د  ب ر ا ی  و ی ن د و ز` and were unreadable. On the page whose readers are the reason it exists.

Seen on the live page rather than guessed at. The Latin badge sitting beside them rendered perfectly, which is exactly why nobody noticed.

Three small SVGs instead — an SVG shapes the script correctly, as the cover already demonstrated — checked in a browser rather than assumed. Every shields.io badge left in either README is Latin-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
