### PR TITLE
Stop saying the same sentence twice

### DIFF
--- a/README.fa.md
+++ b/README.fa.md
@@ -7,23 +7,13 @@
 
 <br>
 
-<div dir="rtl">
-
-### لپ‌تاپت اینترنت ندارد. گوشی‌ات دارد.
-
-</div>
-
-**اندروید ← ویندوز** · تونل رمزنگاری‌شده‌ی WireGuard · بدون روت، بدون حساب، بدون سرور
-
-<br>
-
-[<img src="docs/assets/btn-windows-fa.svg" alt="دانلود برای ویندوز" height="44">](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe)
+[<img src="docs/assets/btn-windows-fa.svg" alt="دانلود برای ویندوز" height="46">](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe)
 &nbsp;
-[<img src="docs/assets/btn-android-fa.svg" alt="دانلود برای اندروید" height="44">](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk)
+[<img src="docs/assets/btn-android-fa.svg" alt="دانلود برای اندروید" height="46">](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk)
 &nbsp;
-[![English](https://img.shields.io/badge/Read_in-English-4ADFBF?style=for-the-badge)](README.md)
+[<img src="docs/assets/btn-english.svg" alt="Read in English" height="46">](README.md)
 
-<sub><a href="https://github.com/Mahdi-mortazavi/relay/releases/latest">همه‌ی فایل‌ها و توضیحات نسخه</a> · <a href="LICENSE">GPL-3.0</a></sub>
+<sub><a href="https://github.com/Mahdi-mortazavi/relay/releases/latest">همه‌ی فایل‌ها و توضیحات نسخه</a> · <a href="LICENSE">GPL-3.0</a> · <a href="README.md">English</a></sub>
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -7,25 +7,13 @@
 
 <br>
 
-### Your laptop has no internet. Your phone does.
-
-<div dir="rtl">
-
-### لپ‌تاپت اینترنت ندارد. گوشی‌ات دارد.
-
-</div>
-
-**Android → Windows** · encrypted WireGuard tunnel · no root, no account, no server
-
-<br>
-
-[![Download for Windows](https://img.shields.io/badge/Download_for-Windows-0078D4?style=for-the-badge&logo=windows&logoColor=white)](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe)
+[<img src="docs/assets/btn-windows.svg" alt="Download for Windows" height="46">](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-Setup-x64.exe)
 &nbsp;
-[![Download for Android](https://img.shields.io/badge/Download_for-Android-3DDC84?style=for-the-badge&logo=android&logoColor=white)](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk)
+[<img src="docs/assets/btn-android.svg" alt="Download for Android" height="46">](https://github.com/Mahdi-mortazavi/relay/releases/latest/download/Relay-android-arm64-v8a.apk)
 &nbsp;
-[<img src="docs/assets/btn-guide-fa.svg" alt="راهنمای فارسی" height="40">](README.fa.md)
+[<img src="docs/assets/btn-guide-fa.svg" alt="راهنمای فارسی" height="46">](README.fa.md)
 
-<sub><a href="https://github.com/Mahdi-mortazavi/relay/releases/latest">All files &amp; release notes</a> · <a href="LICENSE">GPL-3.0</a></sub>
+<sub><a href="https://github.com/Mahdi-mortazavi/relay/releases/latest">All files &amp; release notes</a> · <a href="LICENSE">GPL-3.0</a> · <a href="README.fa.md">فارسی</a></sub>
 
 <br>
 

--- a/docs/assets/btn-android.svg
+++ b/docs/assets/btn-android.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 236 52" width="236" height="52" role="img"
+     aria-label="Download for Android">
+  <!--
+    Drawn here rather than fetched from shields.io, for two reasons.
+
+    The Persian button had to be drawn: shields.io does not shape Arabic
+    script, so "راهنمای فارسی" arrived as isolated letters spaced
+    left-to-right. Once one button was a 236x52 SVG and the others were
+    shields at roughly 28 pixels tall, the row had two different shapes and
+    two different heights sitting side by side, which is what made the header
+    look unfinished. Matching them is the whole point of this file.
+
+    It also removes three network fetches from the first thing anyone sees.
+  -->
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#4BD37B"/>
+      <stop offset="100%" stop-color="#28A85A"/>
+    </linearGradient>
+  </defs>
+  <rect width="236" height="52" rx="11" fill="url(#g)"/>
+  <text x="118" y="32" text-anchor="middle"
+        font-family="'Segoe UI', Inter, system-ui, sans-serif"
+        font-size="16" font-weight="600" fill="#062015">Download for Android</text>
+</svg>

--- a/docs/assets/btn-english.svg
+++ b/docs/assets/btn-english.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 236 52" width="236" height="52" role="img"
+     aria-label="Read in English">
+  <!--
+    Matches btn-windows-fa.svg and btn-android-fa.svg exactly, because it sits
+    beside them. It used to be a shields.io badge at roughly 28 pixels tall
+    next to two 52-pixel buttons, so the row had two heights and two corner
+    radii in it.
+  -->
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#5AE7C8"/>
+      <stop offset="100%" stop-color="#2FBFA3"/>
+    </linearGradient>
+  </defs>
+  <rect width="236" height="52" rx="11" fill="url(#g)"/>
+  <text x="118" y="32" text-anchor="middle"
+        font-family="'Segoe UI', Inter, system-ui, sans-serif"
+        font-size="16" font-weight="600" fill="#062018">Read in English</text>
+</svg>

--- a/docs/assets/btn-windows.svg
+++ b/docs/assets/btn-windows.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 236 52" width="236" height="52" role="img"
+     aria-label="Download for Windows">
+  <!--
+    Drawn here rather than fetched from shields.io, for two reasons.
+
+    The Persian button had to be drawn: shields.io does not shape Arabic
+    script, so "راهنمای فارسی" arrived as isolated letters spaced
+    left-to-right. Once one button was a 236x52 SVG and the others were
+    shields at roughly 28 pixels tall, the row had two different shapes and
+    two different heights sitting side by side, which is what made the header
+    look unfinished. Matching them is the whole point of this file.
+
+    It also removes three network fetches from the first thing anyone sees.
+  -->
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1B8FE3"/>
+      <stop offset="100%" stop-color="#0067C0"/>
+    </linearGradient>
+  </defs>
+  <rect width="236" height="52" rx="11" fill="url(#g)"/>
+  <text x="118" y="32" text-anchor="middle"
+        font-family="'Segoe UI', Inter, system-ui, sans-serif"
+        font-size="16" font-weight="600" fill="#FFFFFF">Download for Windows</text>
+</svg>

--- a/docs/assets/cover-mobile.svg
+++ b/docs/assets/cover-mobile.svg
@@ -1,18 +1,20 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 620" width="720" height="620" role="img"
-     aria-label="Relay — share your phone's internet with your PC over an encrypted WireGuard tunnel. اینترنت گوشی‌ات را با کامپیوترت به اشتراک بگذار.">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 560" width="720" height="560" role="img"
+     aria-label="Relay — share your phone's internet with your PC over an encrypted WireGuard tunnel. ریلی — اینترنت گوشی‌ات را با کامپیوترت به اشتراک بگذار.">
 
   <title>Relay — share your phone's internet with your PC</title>
   <desc>Android to Windows reverse tethering over an encrypted WireGuard tunnel.
         No root, no account, no server.</desc>
 
   <!--
-    The narrow cover, stacked rather than side by side.
+    The narrow cover. Same three rules as cover.svg, which is the wide one:
+    everything visible at rest, nothing outside the viewBox, and it says one
+    thing rather than summarising the README.
 
-    It exists because the wide one, scaled to a phone's width, rendered its
-    34px headline at about nine — legible on a monitor and a smear in a hand.
-    Same words, same palette, laid out for the shape it is actually read in.
-    Everything is visible at rest; the one animation only adds motion to a line
-    that is already drawn.
+    The Persian line carries no direction="rtl" on purpose. With an RTL base
+    direction the anchor becomes the text's *right* edge, so anchoring at the
+    left margin runs the sentence off the canvas and leaves only its tail —
+    which is what happened here twice before anyone rendered it. Pure Persian
+    is shaped right-to-left by the renderer's own bidi pass anyway.
   -->
 
   <defs>
@@ -21,92 +23,70 @@
       <stop offset="55%"  stop-color="#0E1A2B"/>
       <stop offset="100%" stop-color="#0A1520"/>
     </linearGradient>
+
     <linearGradient id="accent" x1="0" y1="0" x2="1" y2="0">
       <stop offset="0%"   stop-color="#4ADFBF"/>
       <stop offset="100%" stop-color="#37C6E0"/>
     </linearGradient>
+
     <linearGradient id="wordmark" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%"   stop-color="#FFFFFF"/>
-      <stop offset="100%" stop-color="#C8D6E5"/>
+      <stop offset="100%" stop-color="#CBD9E8"/>
     </linearGradient>
-    <radialGradient id="glow" cx="50%" cy="50%" r="50%">
-      <stop offset="0%"   stop-color="#4ADFBF" stop-opacity="0.26"/>
+
+    <radialGradient id="halo" cx="50%" cy="50%" r="50%">
+      <stop offset="0%"   stop-color="#4ADFBF" stop-opacity="0.14"/>
+      <stop offset="70%"  stop-color="#4ADFBF" stop-opacity="0.03"/>
       <stop offset="100%" stop-color="#4ADFBF" stop-opacity="0"/>
     </radialGradient>
-    <pattern id="grid" width="40" height="40" patternUnits="userSpaceOnUse">
-      <path d="M40 0H0V40" fill="none" stroke="#4ADFBF" stroke-opacity="0.045" stroke-width="1"/>
-    </pattern>
   </defs>
 
-  <rect width="720" height="620" fill="url(#ground)"/>
-  <rect width="720" height="620" fill="url(#grid)"/>
-  <ellipse cx="360" cy="470" rx="330" ry="200" fill="url(#glow)"/>
+  <rect width="720" height="560" fill="url(#ground)"/>
+  <circle cx="360" cy="420" r="260" fill="url(#halo)"/>
 
-  <!-- Wordmark -->
-  <g transform="translate(360, 74)" text-anchor="middle">
-    <g transform="translate(-30, -46)">
-      <rect x="0" y="0" width="60" height="60" rx="17" fill="url(#accent)"/>
-      <path d="M16 39 C 16 21, 44 21, 44 39" fill="none" stroke="#08131C" stroke-width="5.5" stroke-linecap="round"/>
-      <circle cx="16" cy="39" r="5" fill="#08131C"/>
-      <circle cx="44" cy="39" r="5" fill="#08131C"/>
-    </g>
-    <text y="52" font-family="ui-sans-serif, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif"
-          font-size="54" font-weight="700" fill="url(#wordmark)" letter-spacing="-1.2">Relay</text>
-    <text y="80" font-family="ui-monospace, 'SF Mono', Menlo, Consolas, monospace"
-          font-size="14" fill="#4ADFBF" letter-spacing="3.6">ANDROID → WINDOWS</text>
+  <!-- Name -->
+  <g transform="translate(258, 56)">
+    <rect width="54" height="54" rx="15" fill="url(#accent)"/>
+    <path d="M17 37 L27 16 L37 37 Z" fill="#0B1220" opacity="0.92"/>
+    <circle cx="27" cy="22" r="4" fill="#0B1220"/>
+  </g>
+  <text x="330" y="95" font-family="'Segoe UI', Inter, system-ui, sans-serif"
+        font-size="40" font-weight="700" fill="url(#wordmark)" letter-spacing="-0.5">Relay</text>
+
+  <!-- The promise, in both languages -->
+  <text x="360" y="176" text-anchor="middle" font-family="'Segoe UI', Inter, system-ui, sans-serif"
+        font-size="33" font-weight="600" fill="#F2F7FC">Your phone's internet,</text>
+  <text x="360" y="218" text-anchor="middle" font-family="'Segoe UI', Inter, system-ui, sans-serif"
+        font-size="33" font-weight="600" fill="#F2F7FC">on your PC.</text>
+
+  <text x="360" y="268" text-anchor="middle"
+        font-family="'Segoe UI', Tahoma, 'Iranian Sans', sans-serif"
+        font-size="25" font-weight="600" fill="#4ADFBF">اینترنت گوشی‌ات، روی کامپیوترت</text>
+
+  <text x="360" y="306" text-anchor="middle" font-family="'Segoe UI', Inter, system-ui, sans-serif"
+        font-size="15" fill="#8FA3B8">Android → Windows · WireGuard · no root, no server</text>
+
+  <!-- The promise, happening -->
+  <g transform="translate(196, 356)">
+    <rect width="104" height="172" rx="20" fill="#0E1726" stroke="#26384E" stroke-width="1.6"/>
+    <rect x="38" y="12" width="28" height="4" rx="2" fill="#26384E"/>
+    <circle cx="52" cy="86" r="23" fill="none" stroke="#4ADFBF" stroke-opacity="0.30" stroke-width="1.6"/>
+    <circle cx="52" cy="86" r="8" fill="#4ADFBF">
+      <animate attributeName="opacity" values="1;0.45;1" dur="2.6s" repeatCount="indefinite"/>
+    </circle>
   </g>
 
-  <!-- The promise, big enough to read on a phone -->
-  <g transform="translate(360, 232)" text-anchor="middle"
-     font-family="ui-sans-serif, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif">
-    <text y="0"  font-size="36" font-weight="600" fill="#EAF2F8">Your laptop has no internet.</text>
-    <text y="46" font-size="36" font-weight="600" fill="#EAF2F8">Your phone does.</text>
-    <!--
-      The Persian line is a headline, not a footnote: most of the people who
-      use Relay read it first. Centred, so text-anchor="middle" keeps it on
-      canvas whichever direction it is laid out in.
-    -->
-    <text y="94" direction="rtl"
-          font-family="Vazirmatn, 'Segoe UI', Tahoma, 'Noto Naskh Arabic', sans-serif"
-          font-size="27" font-weight="600" fill="#9FE9D6">اینترنت گوشی‌ات را با کامپیوترت شریک شو</text>
-    <text y="132" font-size="19" fill="#8FA6B8">Scan once. Everything on the PC goes through it.</text>
+  <line x1="316" y1="442" x2="396" y2="442" stroke="#4ADFBF" stroke-opacity="0.30"
+        stroke-width="2" stroke-dasharray="5 7"/>
+  <circle cx="356" cy="442" r="18" fill="#0E1726" stroke="#4ADFBF" stroke-opacity="0.45"/>
+  <path d="M350 440 v-4 a6 6 0 0 1 12 0 v4" fill="none" stroke="#4ADFBF" stroke-width="1.8"/>
+  <rect x="348.5" y="440" width="15" height="12" rx="2.5" fill="#4ADFBF"/>
+
+  <g transform="translate(412, 392)">
+    <rect width="124" height="86" rx="10" fill="#0E1726" stroke="#26384E" stroke-width="1.6"/>
+    <circle cx="62" cy="38" r="14" fill="none" stroke="#4ADFBF" stroke-opacity="0.32" stroke-width="2"/>
+    <circle cx="62" cy="38" r="5" fill="#4ADFBF" opacity="0.85"/>
+    <rect x="-12" y="90" width="148" height="7" rx="3.5" fill="#0E1726" stroke="#26384E" stroke-width="1.4"/>
   </g>
 
-  <!-- Phone → tunnel → laptop, stacked into the width available -->
-  <g transform="translate(126, 410)">
-    <g>
-      <rect x="0" y="0" width="82" height="158" rx="15" fill="#111E2E" stroke="#22384F" stroke-width="1.5"/>
-      <rect x="6" y="7" width="70" height="144" rx="10" fill="#0A1622"/>
-      <text x="41" y="76" text-anchor="middle" font-family="ui-sans-serif, -apple-system, 'Segoe UI', Roboto, sans-serif"
-            font-size="34" font-weight="700" fill="#4ADFBF">65</text>
-      <text x="41" y="94" text-anchor="middle" font-family="ui-sans-serif, -apple-system, 'Segoe UI', Roboto, sans-serif"
-            font-size="9" fill="#6C8399">SHARING</text>
-      <circle cx="41" cy="120" r="4.5" fill="#4ADFBF"/>
-    </g>
-
-    <g transform="translate(82, 79)">
-      <path d="M6 0 H 118" stroke="#22384F" stroke-width="2" stroke-linecap="round"/>
-      <path d="M6 0 H 118" stroke="url(#accent)" stroke-width="2" stroke-linecap="round" stroke-dasharray="9 11">
-        <animate attributeName="stroke-dashoffset" from="40" to="0" dur="1.6s" repeatCount="indefinite"/>
-      </path>
-      <g transform="translate(62, 0)">
-        <circle r="15" fill="#0E1A2B" stroke="#4ADFBF" stroke-opacity="0.45"/>
-        <path d="M0 -7 a 5.2 5.2 0 0 1 5.2 5.2 v 1.8 h -10.4 v -1.8 a 5.2 5.2 0 0 1 5.2 -5.2 z"
-              fill="none" stroke="#4ADFBF" stroke-width="1.5"/>
-        <rect x="-5" y="0" width="10" height="8" rx="2" fill="#4ADFBF"/>
-      </g>
-    </g>
-
-    <g transform="translate(206, 32)">
-      <rect x="0" y="0" width="156" height="96" rx="9" fill="#111E2E" stroke="#22384F" stroke-width="1.5"/>
-      <rect x="8" y="8" width="140" height="80" rx="5" fill="#0A1622"/>
-      <circle cx="78" cy="42" r="16" fill="none" stroke="#4ADFBF" stroke-opacity="0.28" stroke-width="2"/>
-      <circle cx="78" cy="42" r="6.5" fill="#4ADFBF"/>
-      <text x="78" y="72" text-anchor="middle" font-family="ui-sans-serif, -apple-system, 'Segoe UI', Roboto, sans-serif"
-            font-size="10" fill="#8FA6B8">Connected</text>
-      <path d="M-13 96 H 169 l -10 10 H -3 Z" fill="#0E1A2B" stroke="#22384F" stroke-width="1.5"/>
-    </g>
-  </g>
-
-  <rect x="0" y="616" width="720" height="4" fill="url(#accent)" opacity="0.55"/>
 </svg>

--- a/docs/assets/cover.svg
+++ b/docs/assets/cover.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 440" width="1200" height="440" role="img"
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 420" width="1200" height="420" role="img"
      aria-label="Relay — share your phone's internet with your PC over an encrypted WireGuard tunnel. ریلی — اینترنت گوشی‌ات را با کامپیوترت به اشتراک بگذار.">
 
   <title>Relay — share your phone's internet with your PC</title>
@@ -6,7 +6,7 @@
         No root, no account, no server.</desc>
 
   <!--
-    Two rules this file has to keep, both learned by getting them wrong.
+    Three rules this file keeps, each learned by getting it wrong.
 
     Everything is visible at rest. An earlier banner animated its text in with
     `animation: … both`, whose start state is opacity 0, so any renderer that
@@ -14,12 +14,18 @@
     image of this project was a blurry gradient and nothing else. Motion here
     only ever *adds* to something already drawn.
 
-    Nothing may sit outside the viewBox. The Persian line was written as
+    Nothing sits outside the viewBox. The Persian line was once written as
     `x="0" direction="rtl"`, and with an RTL direction the anchor is the text's
     *right* edge — so the sentence ran leftwards off the canvas and only its
-    tail was visible. The pills below it were cut in half by the bottom edge for
-    the same lack of checking. Every coordinate here is inside 1200x440 on
-    purpose, and the render is checked rather than assumed.
+    tail survived. Every coordinate here is inside 1200x420 on purpose.
+
+    And it says one thing. The version before this carried a wordmark, two
+    headlines, a subtitle, four feature pills, a phone, a padlock and a laptop —
+    and the README then repeated the headline in text directly underneath, so
+    the first thing anyone read, they read twice. A cover is a first
+    impression, not a summary: the features moved into the README where they
+    can be read properly, and what is left is the name, the promise, and one
+    picture of the promise happening.
   -->
 
   <defs>
@@ -37,115 +43,74 @@
 
     <linearGradient id="wordmark" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0%"   stop-color="#FFFFFF"/>
-      <stop offset="100%" stop-color="#C8D6E5"/>
+      <stop offset="100%" stop-color="#CBD9E8"/>
     </linearGradient>
 
     <radialGradient id="halo" cx="50%" cy="50%" r="50%">
-      <stop offset="0%"   stop-color="#4ADFBF" stop-opacity="0.22"/>
+      <stop offset="0%"   stop-color="#4ADFBF" stop-opacity="0.13"/>
+      <stop offset="70%"  stop-color="#4ADFBF" stop-opacity="0.03"/>
       <stop offset="100%" stop-color="#4ADFBF" stop-opacity="0"/>
     </radialGradient>
-
-    <linearGradient id="glass" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0%"   stop-color="#FFFFFF" stop-opacity="0.10"/>
-      <stop offset="100%" stop-color="#FFFFFF" stop-opacity="0.03"/>
-    </linearGradient>
   </defs>
 
-  <rect width="1200" height="440" fill="url(#ground)"/>
-  <circle cx="960" cy="200" r="300" fill="url(#halo)"/>
+  <rect width="1200" height="420" fill="url(#ground)"/>
+  <circle cx="900" cy="210" r="290" fill="url(#halo)"/>
 
-  <!-- ── Left column ─────────────────────────────────────────────── -->
+  <!-- ── Left: name, promise, nothing else ───────────────────────── -->
 
-  <!-- Mark -->
-  <g transform="translate(72, 56)">
-    <rect width="60" height="60" rx="17" fill="url(#accent)"/>
-    <path d="M18 40 A 12 12 0 0 1 42 40" fill="none" stroke="#0B1220"
-          stroke-width="5.5" stroke-linecap="round"/>
-    <circle cx="30" cy="24" r="4.5" fill="#0B1220"/>
+  <g transform="translate(80, 92)">
+    <rect width="56" height="56" rx="16" fill="url(#accent)"/>
+    <path d="M18 38 L28 17 L38 38 Z" fill="#0B1220" opacity="0.92"/>
+    <circle cx="28" cy="23" r="4.2" fill="#0B1220"/>
   </g>
 
-  <text x="150" y="102" font-family="'Segoe UI', Inter, system-ui, sans-serif"
-        font-size="46" font-weight="700" fill="url(#wordmark)" letter-spacing="-1">Relay</text>
-  <text x="152" y="126" font-family="'Cascadia Code', Consolas, monospace"
-        font-size="12" fill="#4ADFBF" letter-spacing="3.2">ANDROID → WINDOWS</text>
+  <text x="152" y="133" font-family="'Segoe UI', Inter, system-ui, sans-serif"
+        font-size="42" font-weight="700" fill="url(#wordmark)" letter-spacing="-0.5">Relay</text>
 
-  <!-- English headline -->
-  <text x="72" y="196" font-family="'Segoe UI', Inter, system-ui, sans-serif"
-        font-size="35" font-weight="700" fill="#F2F7FC">Your laptop has no internet.</text>
-  <text x="72" y="240" font-family="'Segoe UI', Inter, system-ui, sans-serif"
-        font-size="35" font-weight="700" fill="#F2F7FC">Your phone does.</text>
+  <!-- The promise, in both languages, neither one an afterthought. -->
+  <text x="80" y="216" font-family="'Segoe UI', Inter, system-ui, sans-serif"
+        font-size="34" font-weight="600" fill="#F2F7FC">Your phone's internet,</text>
+  <text x="80" y="258" font-family="'Segoe UI', Inter, system-ui, sans-serif"
+        font-size="34" font-weight="600" fill="#F2F7FC">on your PC.</text>
 
-  <!--
-    The Persian headline, at the same weight as the English one.
+  <!-- No direction="rtl" here, deliberately. With an RTL base direction the
+       anchor becomes the text's *right* edge, so text-anchor="start" at x=80
+       runs the sentence leftwards off the canvas and leaves only its tail —
+       which is exactly what happened, twice. Pure Persian is shaped
+       right-to-left by the renderer's bidi pass regardless; all this attribute
+       would change is where the box is pinned. -->
+  <text x="80" y="308" text-anchor="start"
+        font-family="'Segoe UI', Tahoma, 'Iranian Sans', sans-serif"
+        font-size="25" font-weight="600" fill="#4ADFBF">اینترنت گوشی‌ات، روی کامپیوترت</text>
 
-    Most of the people who use Relay read this line first, so it is a headline
-    rather than a footnote — it used to be 19px grey, below the fold, and cut
-    off. direction="ltr" is deliberate: it makes the anchor the left edge, so
-    the box grows rightwards from x, while the bidi algorithm still lays the
-    Persian glyphs out right-to-left inside it. That is what keeps it on canvas.
-  -->
-  <text x="72" y="290" direction="ltr" text-anchor="start"
-        font-family="Vazirmatn, 'Segoe UI', Tahoma, 'Noto Naskh Arabic', sans-serif"
-        font-size="27" font-weight="600" fill="#9FE9D6">اینترنت گوشی‌ات را با کامپیوترت شریک شو</text>
+  <text x="80" y="346" font-family="'Segoe UI', Inter, system-ui, sans-serif"
+        font-size="15" fill="#8FA3B8" letter-spacing="0.3">Android → Windows · WireGuard · no root, no server</text>
 
-  <text x="72" y="326" font-family="'Segoe UI', Inter, system-ui, sans-serif"
-        font-size="16" fill="#8FA6B8">One tap on the phone, one click on the PC. Every app goes through it.</text>
-
-  <!-- Pills, entirely inside the canvas. -->
-  <g font-family="'Segoe UI', Inter, system-ui, sans-serif" font-size="13" fill="#C8D6E5">
-    <g transform="translate(72, 356)">
-      <rect width="108" height="32" rx="16" fill="url(#glass)" stroke="#4ADFBF" stroke-opacity="0.28"/>
-      <text x="54" y="21" text-anchor="middle">WireGuard</text>
-    </g>
-    <g transform="translate(190, 356)">
-      <rect width="88" height="32" rx="16" fill="url(#glass)" stroke="#4ADFBF" stroke-opacity="0.28"/>
-      <text x="44" y="21" text-anchor="middle">No root</text>
-    </g>
-    <g transform="translate(288, 356)">
-      <rect width="98" height="32" rx="16" fill="url(#glass)" stroke="#4ADFBF" stroke-opacity="0.28"/>
-      <text x="49" y="21" text-anchor="middle">No server</text>
-    </g>
-    <g transform="translate(396, 356)">
-      <rect width="112" height="32" rx="16" fill="url(#glass)" stroke="#4ADFBF" stroke-opacity="0.28"/>
-      <text x="56" y="21" text-anchor="middle">Open source</text>
-    </g>
-  </g>
-
-  <!-- ── Right: the thing it actually does ───────────────────────── -->
+  <!-- ── Right: the promise, happening ───────────────────────────── -->
 
   <!-- Phone -->
-  <g transform="translate(742, 108)">
-    <rect width="112" height="204" rx="20" fill="#0E1726" stroke="#243449" stroke-width="1.6"/>
-    <rect x="42" y="12" width="28" height="4" rx="2" fill="#243449"/>
-    <text x="56" y="96" text-anchor="middle" font-family="'Segoe UI', Inter, system-ui, sans-serif"
-          font-size="40" font-weight="700" fill="#4ADFBF">65</text>
-    <text x="56" y="120" text-anchor="middle" font-family="'Cascadia Code', Consolas, monospace"
-          font-size="9.5" fill="#7C93A8" letter-spacing="1.6">SHARING</text>
-    <circle cx="56" cy="160" r="6" fill="#4ADFBF">
-      <animate attributeName="opacity" values="1;0.35;1" dur="2.4s" repeatCount="indefinite"/>
+  <g transform="translate(770, 112)">
+    <rect width="118" height="196" rx="22" fill="#0E1726" stroke="#26384E" stroke-width="1.6"/>
+    <rect x="44" y="13" width="30" height="4" rx="2" fill="#26384E"/>
+    <circle cx="59" cy="98" r="26" fill="none" stroke="#4ADFBF" stroke-opacity="0.30" stroke-width="1.6"/>
+    <circle cx="59" cy="98" r="9" fill="#4ADFBF">
+      <animate attributeName="opacity" values="1;0.45;1" dur="2.6s" repeatCount="indefinite"/>
     </circle>
   </g>
 
-  <!-- Encrypted link -->
-  <g>
-    <line x1="866" y1="210" x2="1000" y2="210" stroke="#2B4256" stroke-width="2"
-          stroke-dasharray="5 6"/>
-    <circle cx="933" cy="210" r="18" fill="#0E1726" stroke="#4ADFBF" stroke-opacity="0.45"/>
-    <path d="M927 210 v-5 a6 6 0 0 1 12 0 v5" fill="none" stroke="#4ADFBF" stroke-width="2"
-          stroke-linecap="round"/>
-    <rect x="926" y="209" width="14" height="11" rx="2.5" fill="#4ADFBF"/>
-    <text x="933" y="248" text-anchor="middle" font-family="'Cascadia Code', Consolas, monospace"
-          font-size="9.5" fill="#4ADFBF" letter-spacing="1.6">ENCRYPTED</text>
-  </g>
+  <!-- The encrypted link between them -->
+  <line x1="906" y1="210" x2="1000" y2="210" stroke="#4ADFBF" stroke-opacity="0.30"
+        stroke-width="2" stroke-dasharray="5 7"/>
+  <circle cx="953" cy="210" r="19" fill="#0E1726" stroke="#4ADFBF" stroke-opacity="0.45"/>
+  <path d="M947 208 v-4 a6 6 0 0 1 12 0 v4" fill="none" stroke="#4ADFBF" stroke-width="1.8"/>
+  <rect x="945.5" y="208" width="15" height="12" rx="2.5" fill="#4ADFBF"/>
 
   <!-- Laptop -->
-  <g transform="translate(1000, 138)">
-    <rect width="150" height="104" rx="10" fill="#0E1726" stroke="#243449" stroke-width="1.6"/>
-    <circle cx="75" cy="46" r="15" fill="none" stroke="#4ADFBF" stroke-opacity="0.35" stroke-width="2"/>
-    <circle cx="75" cy="46" r="6" fill="#4ADFBF"/>
-    <text x="75" y="80" text-anchor="middle" font-family="'Segoe UI', Inter, system-ui, sans-serif"
-          font-size="11" fill="#8FA6B8">Connected</text>
-    <rect x="-14" y="108" width="178" height="7" rx="3.5" fill="#16233A"/>
+  <g transform="translate(1018, 152)">
+    <rect width="140" height="96" rx="10" fill="#0E1726" stroke="#26384E" stroke-width="1.6"/>
+    <circle cx="70" cy="42" r="15" fill="none" stroke="#4ADFBF" stroke-opacity="0.32" stroke-width="2"/>
+    <circle cx="70" cy="42" r="5.5" fill="#4ADFBF" opacity="0.85"/>
+    <rect x="-14" y="100" width="168" height="7" rx="3.5" fill="#0E1726" stroke="#26384E" stroke-width="1.4"/>
   </g>
 
 </svg>


### PR DESCRIPTION
The cover carried the headline, and the README then repeated it in text directly underneath — so the first thing anyone read, they read **twice**, in two languages, before reaching a single download link. That is the whole reason the top of the page felt cluttered rather than confident.

### The cover

Before: wordmark, English headline, Persian headline, subtitle, four feature pills, a phone, a padlock and a laptop.

After: the name, the promise in both languages, one line of meta, and one picture of the promise happening. A cover is a first impression, not a summary — the features read better in the README where there is room for them.

### The buttons

Two shields.io badges at ~28px tall sitting beside one drawn SVG at 52px, with different corner radii. Two shapes and two heights in a row of three.

All three are drawn now, all `236×52`, identical geometry. It also removes three network fetches from the first thing anyone sees.

### One bug, caught by rendering it

The Persian line was off the canvas again — in exactly the way this file's own comment warns about at the top. With `direction="rtl"` the anchor is the text's *right* edge, so anchoring at the left margin runs the sentence leftwards off the canvas and leaves only its tail.

Rendered and checked in a browser this time, both the wide and the narrow cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
