### PR TITLE
See the reply path before a PC ever knocks

### DIFF
--- a/android/app/src/main/kotlin/io/relay/app/net/VpnCapture.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/VpnCapture.kt
@@ -52,6 +52,34 @@ object VpnCapture {
         false
     }
 
+    /**
+     * A stand-in for "some laptop on the same network as [advertisedHost]", so
+     * the reply path can be asked about *before* any PC has connected.
+     *
+     * Why this is needed at all: [wouldSwallow] is called from the pairing
+     * server's configuration step, which only runs once a PC has completed a
+     * TCP connection. When the capture is severe enough to stop that handshake
+     * completing, `accept()` never returns — so the phone shows no prompt *and*
+     * no warning. The one case that most needs the message is the case that
+     * cannot produce it. Reported as #126, third category.
+     *
+     * The routing decision is per-destination-prefix, not per-host, so any
+     * address on the same /24 answers the same question. `.1` is the usual
+     * gateway; when this phone *is* `.1` (its own hotspot) `.2` is used instead,
+     * because a route lookup to our own address answers a different question.
+     *
+     * Returns null for anything that is not a dotted IPv4 quad — an address
+     * this cannot parse is one it should not guess about.
+     */
+    fun aPeerOn(advertisedHost: String): String? {
+        val parts = advertisedHost.split(".")
+        if (parts.size != 4) return null
+        val octets = parts.map { it.toIntOrNull() ?: return null }
+        if (octets.any { it !in 0..255 }) return null
+        val last = if (octets[3] == 1) 2 else 1
+        return "${octets[0]}.${octets[1]}.${octets[2]}.$last"
+    }
+
     /** Any port will do; connect() only performs the lookup, nothing is sent. */
     private const val DISCARD_PORT = 9
 }

--- a/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
@@ -235,6 +235,7 @@ class SharingService : Service() {
         val payload = prepareFull(host) ?: return
 
         currentHost = host
+        noteReplyPath(host)
 
         // Drawn once per sharing session and kept for its life, so the number on
         // screen never changes under someone who is mid-way through typing it.
@@ -300,6 +301,29 @@ class SharingService : Service() {
         return pairing.issuePayload(
             mode = QrPayload.MODE_WIREGUARD, host = host, port = keys.endpointPort,
             deviceName = Build.MODEL.take(64), wg = WgConfig.toWgParams(keys),
+        )
+    }
+
+    /**
+     * Writes the reply path into the diagnostic log at the moment sharing
+     * starts, before any PC is involved.
+     *
+     * This does **not** raise the warning banner, deliberately. The same probe
+     * has been seen to say "swallowed" on a link that then carried 35 MB
+     * without trouble, so acting on it would put an alarming message in front
+     * of people whose connection is working. What it is good for is triage: it
+     * costs one route lookup, and it means a diagnostic report carries the
+     * answer even when the session never got far enough to produce one.
+     *
+     * The warning itself still comes from the pairing path, where a real client
+     * address is known — see [startPairingServer].
+     */
+    private fun noteReplyPath(host: String) {
+        val peer = VpnCapture.aPeerOn(host) ?: return
+        val swallowed = VpnCapture.wouldSwallow(client = peer, advertisedHost = host)
+        LocalLog.add(
+            if (swallowed) "Reply path check: a reply to $peer would leave by the VPN, not by $host"
+            else "Reply path check: replies to $peer leave by $host, as they should"
         )
     }
 

--- a/android/app/src/test/kotlin/io/relay/app/VpnCapturePeerTest.kt
+++ b/android/app/src/test/kotlin/io/relay/app/VpnCapturePeerTest.kt
@@ -1,0 +1,54 @@
+package io.relay.app
+
+import io.relay.app.net.VpnCapture
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+/**
+ * Choosing an address to ask the routing question about.
+ *
+ * The reply-path probe needs somewhere to aim before any PC has connected. Any
+ * address on the same /24 gives the same answer, because the kernel decides by
+ * prefix — but two specific choices would give the *wrong* answer, and both are
+ * easy to write by accident.
+ */
+class VpnCapturePeerTest {
+
+    @Test
+    fun `picks an address on the same network`() {
+        // Same prefix or the probe measures a different route entirely.
+        assertEquals("192.168.1.1", VpnCapture.aPeerOn("192.168.1.14"))
+        assertEquals("10.0.5.1", VpnCapture.aPeerOn("10.0.5.77"))
+        assertEquals("192.168.43.1", VpnCapture.aPeerOn("192.168.43.128"))
+    }
+
+    @Test
+    fun `never returns the phone's own address`() {
+        // The trap. A phone acting as its own hotspot *is* 192.168.43.1, and a
+        // route lookup to yourself resolves to loopback — which would answer
+        // "not swallowed" on every hotspot, in every case, forever. A check
+        // that cannot fail is worse than no check.
+        val ownHotspot = "192.168.43.1"
+        assertNotEquals(ownHotspot, VpnCapture.aPeerOn(ownHotspot))
+        assertEquals("192.168.43.2", VpnCapture.aPeerOn(ownHotspot))
+
+        // Same for any other network whose gateway slot we occupy.
+        assertEquals("10.0.0.2", VpnCapture.aPeerOn("10.0.0.1"))
+    }
+
+    @Test
+    fun `refuses to guess about anything that is not a dotted quad`() {
+        // An address it cannot parse is one it must not invent a peer for:
+        // probing a made-up address would produce a confident line in the
+        // diagnostic log about a route nobody asked about.
+        assertNull(VpnCapture.aPeerOn(""))
+        assertNull(VpnCapture.aPeerOn("192.168.1"))
+        assertNull(VpnCapture.aPeerOn("192.168.1.14.9"))
+        assertNull(VpnCapture.aPeerOn("fe80::1"))
+        assertNull(VpnCapture.aPeerOn("192.168.1.abc"))
+        assertNull(VpnCapture.aPeerOn("192.168.1.999"))
+        assertNull(VpnCapture.aPeerOn("not an address at all"))
+    }
+}

--- a/docs/vpn-compat.md
+++ b/docs/vpn-compat.md
@@ -21,6 +21,51 @@ transport is active when sharing starts, Relay shows the non-blocking
 `NO_VPN_ACTIVE` advisory (`VpnStatus` checks `NetworkCapabilities.TRANSPORT_VPN`),
 because the user may have intended to share a VPN that is off.
 
+## What people actually report
+
+Three reports on 2.7.1 — [#124](https://github.com/Mahdi-mortazavi/relay/issues/124),
+[#125](https://github.com/Mahdi-mortazavi/relay/issues/125),
+[#126](https://github.com/Mahdi-mortazavi/relay/issues/126) — all say the same
+thing from different angles: with a VPN on the phone, the PC finds the phone and
+then cannot connect. #126 sorted the VPN apps into three groups, which is the
+most useful framing anyone has given this problem:
+
+| گروه | نشانه | معنی |
+|---|---|---|
+| ۱ | همه‌چیز کار می‌کند (FSecure) | VPN ترافیک LAN را رها می‌کند |
+| ۲ | برنامه می‌گوید نمی‌تواند تونل کند (TLS Tunnel) | تشخیص داده شد و گفته شد |
+| ۳ | **پیام تایید اصلاً نمی‌آید** (Seed 4 me) | تشخیص داده شد ولی گفته نشد |
+
+**Group 3 is the one to fix, and its cause is structural.** `VpnCapture.wouldSwallow`
+is called from the pairing server's `configuration` step, which runs only after
+`accept()` has returned — i.e. after a PC has completed a TCP connection. When
+the capture is severe enough that the phone's SYN-ACK never leaves by the LAN
+interface, the handshake never completes: no `accept()`, no prompt, and no
+warning either. **The case that most needs the message is the only case that
+cannot produce it.**
+
+Since 2.8.1 the diagnostic log carries a `Reply path check:` line written when
+sharing starts, before any PC is involved, so a report from a group-3 phone
+still says which way replies would leave. It is log-only on purpose — the same
+probe has said "swallowed" on a link that then carried 35 MB without trouble, so
+it is trustworthy enough to triage with and not to alarm anyone with.
+
+### Two settings worth trying before anything else
+
+Both are on the VPN app's side, and either one alone can produce group 3:
+
+- **"Block connections without VPN"** (Android's lockdown mode, in
+  *Settings → Network → VPN → ⚙*). It drops everything that is not the tunnel,
+  **including replies to your own LAN**. Turn it off and retry.
+- **Per-app / split tunnelling** — exclude Relay in the VPN app's own app list.
+  This is what the in-app warning already tells people to do, and it is the
+  reliable fix when it is available.
+
+Neither is a Relay setting; Android gives an app inside a VPN no way to opt out
+of either (`Network.bindSocket` fails `EPERM`, `SO_BINDTODEVICE` needs
+`CAP_NET_RAW`). Saying so plainly is better than implying Relay can route around
+a policy the system is enforcing on purpose.
+
 ## Hardware verification checklist (per VPN app)
 
 Since there is no local device loop, run this from an installable CI artifact


### PR DESCRIPTION
Closes nothing on its own — it makes the next report from these people useful.

## The pattern in the three reports

[#124](https://github.com/Mahdi-mortazavi/relay/issues/124), [#125](https://github.com/Mahdi-mortazavi/relay/issues/125) and [#126](https://github.com/Mahdi-mortazavi/relay/issues/126) are all 2.7.1, all say the PC **finds** the phone and then cannot connect, and all involve a VPN on the phone.

@shit2live did the work that made this tractable, by sorting the VPN apps into three groups:

1. works fine (FSecure)
2. the app says it cannot tunnel that traffic (TLS Tunnel)
3. **the approval prompt never appears at all** (Seed 4 me) — "much worse and more annoying than group 2"

They are right that group 3 is worse, and right that 2.7.1 did not fix it. 2.7.1 fixed a *different* prompt bug: the prompt only lived inside the app's own screen, and a missed prompt was remembered as a refusal.

## Why group 3 produces silence

`VpnCapture.wouldSwallow` is called from the pairing server's `configuration` step. That step runs only after `accept()` has returned:

```
PairingServer.kt:82    server.accept()          ← TCP handshake must complete
PairingServer.kt:131   gate.authorize(address)  ← the prompt
PairingServer.kt:132   configuration(address)   ← wouldSwallow lives here
```

When the capture is severe enough that the phone's SYN-ACK never leaves by the LAN interface, the handshake never completes. No `accept()`, so no prompt — and no warning either, because the only code that raises it sits further down the same dead path.

**The case that most needs the message is the only case that cannot produce it.** That is a bug in this repo, not in anyone's VPN.

## What this changes

A `Reply path check:` line, written to the diagnostic log when sharing starts, before any PC is involved:

```
Reply path check: a reply to 192.168.1.1 would leave by the VPN, not by 192.168.1.14
```

Two of the three reports arrived with an **empty** diagnostic log, because the session never got far enough to produce one. This is what fills it.

**Log-only, on purpose.** This same probe reported "swallowed" on a USB link that then carried 35.5 MB three times without trouble — so its premise is not yet trustworthy enough to put an alarming banner in front of someone whose connection is working. Good enough to triage with; not good enough to alarm with. The banner still comes from the pairing path, where a real client address is known.

## The test

`aPeerOn` is split out and pure, because one specific mistake would silently ruin the probe: **asking the route to our own address.** A phone on its own hotspot *is* `192.168.43.1`, and a route lookup to yourself resolves to loopback — which would answer "not swallowed" on every hotspot, in every case, forever. A check that cannot fail is worse than no check.

Proved the test is not vacuous by running a naive always-`.1` implementation against it first: it returns `192.168.43.1` for a phone that *is* `192.168.43.1`, and the test catches it.

## Docs

`docs/vpn-compat.md` gains the two settings that actually fix this on the user's side, neither of which it mentioned before, and either of which can produce group 3 alone:

- **"Block connections without VPN"** — Android's lockdown mode. Drops everything that is not the tunnel, including replies to your own LAN.
- **Per-app / split tunnelling** — exclude Relay. This is what the in-app warning already advises, and it is the reliable fix where it exists.

Neither is a Relay setting. An app inside a VPN has no way to opt out of either — `Network.bindSocket` fails `EPERM`, `SO_BINDTODEVICE` needs `CAP_NET_RAW`. Saying that plainly beats implying Relay can route around a policy the system is enforcing deliberately.

## Testing

| | |
|---|---|
| `aPeerOn` — same-subnet, own-address trap, malformed input | in this PR, **CI** |
| Test proven able to fail | naive impl run against it before committing |
| Kotlin compiles | **CI** — no local Android toolchain (ADR-0004) |
| That the log line appears on a phone whose VPN captures Relay | **NOT TESTED** — needs one of the named group-3 VPNs on real hardware |
| That this makes group 3 *connect* | **it does not, and does not claim to.** It makes the failure legible. The fix for group 3 is still gated on the experiment below |

## Still open

Whether `wouldSwallow`'s premise holds at all. The deciding experiment: the same connected session over **Wi-Fi** instead of USB, on a phone with a capturing VPN.

- answers over Wi-Fi too → the unbound-socket route lookup does not predict what the endpoint does, and the check needs rebuilding
- does not answer over Wi-Fi but does over USB → the rule is "a client on a directly-connected subnet is never swallowed", and that is one condition

Until one of those is measured, nothing here should get more confident than a log line.
