### PR TITLE
Wait for the link instead of losing the race to it

### DIFF
--- a/android/app/src/main/kotlin/io/relay/app/core/LinkWait.kt
+++ b/android/app/src/main/kotlin/io/relay/app/core/LinkWait.kt
@@ -1,0 +1,40 @@
+package io.relay.app.core
+
+/**
+ * How long to wait for a usable link before saying there isn't one.
+ *
+ * Sharing used to fail the instant [io.relay.app.net.LocalAddress] found no
+ * advertisable address. That is the wrong answer for the most common way people
+ * start: they turn USB tethering on, or join a Wi-Fi network, and then open
+ * Relay. `rndis0` takes a few seconds to come up and get an address; a Wi-Fi
+ * reassociation takes longer. In between, the phone has no advertisable address
+ * and the old code called that a failure.
+ *
+ * A real report (2.8.1) shows what that felt like: seven "no usable interface"
+ * failures in eighteen seconds, one per tap, before the interface finally
+ * appeared and the eighth tap worked. The phone knew how to do this all along —
+ * it just refused to wait two seconds for it.
+ *
+ * Unlike [ReconnectPolicy] this is not a contract: nothing on the Windows side
+ * can observe it. It is one platform's answer to "how long is a link allowed to
+ * take to show up".
+ */
+object LinkWait {
+    /**
+     * Delay *before* each look, in order. The first is zero, so a phone that is
+     * already on Wi-Fi starts sharing with no added latency at all — which is
+     * the common case and must not be made slower to fix the uncommon one.
+     *
+     * The gaps widen because the two failure shapes are different: a link that
+     * is nearly up appears within a few hundred milliseconds, and one that is
+     * still negotiating takes seconds. Eight looks spread over eight seconds
+     * covers both without holding the screen on "Preparing…" long enough to
+     * read as a hang.
+     */
+    val lookDelaysMs = longArrayOf(0, 300, 500, 700, 1000, 1500, 2000, 2000)
+
+    val looks: Int get() = lookDelaysMs.size
+
+    /** The whole window. After this, "there is no link" is an honest answer. */
+    val totalBoundMs: Long get() = lookDelaysMs.sum()
+}

--- a/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
@@ -20,6 +20,7 @@ import io.relay.app.core.ShouldRetarget
 import io.relay.app.core.UpdateCheck
 import io.relay.app.core.DirectPairingStrategy
 import io.relay.app.core.ErrorCode
+import io.relay.app.core.LinkWait
 import io.relay.app.core.QrPayload
 import io.relay.app.core.ReconnectPolicy
 import io.relay.app.core.WarningCode
@@ -212,7 +213,7 @@ class SharingService : Service() {
         )
     }
 
-    private fun startSharing() {
+    private suspend fun startSharing() {
         if (!ConnectionRepository.dispatch("start") { ConnectionState.Preparing }) return
         LocalLog.add("Starting sharing")
         ConnectionRepository.clearWarnings()
@@ -223,10 +224,13 @@ class SharingService : Service() {
             WarningCode.NO_VPN_ACTIVE, !VpnStatus.isVpnActive(this),
         )
 
-        // Works on the phone's hotspot OR a shared Wi-Fi/LAN the laptop is also on.
-        val host = LocalAddress.findAdvertisableIpv4()
+        // Works on the phone's hotspot, a shared Wi-Fi/LAN, or a USB cable.
+        val host = awaitAdvertisableIpv4()
         if (host == null) {
-            LocalLog.add("No usable Wi-Fi/hotspot interface found")
+            LocalLog.add(
+                "No usable Wi-Fi, hotspot or USB link after ${LinkWait.totalBoundMs} ms " +
+                    "(${LinkWait.looks} looks)"
+            )
             fail(ErrorCode.HOTSPOT_OFF)
             return
         }
@@ -302,6 +306,33 @@ class SharingService : Service() {
             mode = QrPayload.MODE_WIREGUARD, host = host, port = keys.endpointPort,
             deviceName = Build.MODEL.take(64), wg = WgConfig.toWgParams(keys),
         )
+    }
+
+    /**
+     * Looks for an advertisable address, giving a link that is still coming up
+     * a few seconds to appear. See [LinkWait] for why, and for the report that
+     * showed what failing instantly felt like.
+     *
+     * The first look is immediate, so a phone already on Wi-Fi pays nothing.
+     * Only a phone that would previously have failed waits at all — and waiting
+     * is what it should have been doing.
+     */
+    private suspend fun awaitAdvertisableIpv4(): String? {
+        var waited = 0L
+        for (delayMs in LinkWait.lookDelaysMs) {
+            if (delayMs > 0) {
+                delay(delayMs)
+                waited += delayMs
+            }
+            val host = LocalAddress.findAdvertisableIpv4()
+            if (host != null) {
+                // Only worth a line when waiting actually did something. On the
+                // common path this says nothing at all.
+                if (waited > 0) LocalLog.add("A usable link appeared after $waited ms")
+                return host
+            }
+        }
+        return null
     }
 
     /**

--- a/android/app/src/test/kotlin/io/relay/app/LinkWaitTest.kt
+++ b/android/app/src/test/kotlin/io/relay/app/LinkWaitTest.kt
@@ -1,0 +1,66 @@
+package io.relay.app
+
+import io.relay.app.core.LinkWait
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * How long the phone is willing to wait for a link to appear.
+ *
+ * The numbers themselves are a judgement call. What is not a judgement call is
+ * the shape around them, and each of these asserts a way the shape could be
+ * broken without anyone noticing until a real phone was in someone's hand.
+ */
+class LinkWaitTest {
+
+    @Test
+    fun `the first look costs nothing`() {
+        // The whole common case: a phone already on Wi-Fi. If the first delay is
+        // ever nudged above zero, every single start gets slower to fix a case
+        // that most people never hit — and nothing else here would catch it.
+        assertEquals(0L, LinkWait.lookDelaysMs.first())
+    }
+
+    @Test
+    fun `waits long enough for USB tethering to come up`() {
+        // rndis0 takes a few seconds to get an address after the toggle. A
+        // window under about five seconds would still fail the report this was
+        // written for, which is the only reason any of this exists.
+        assertTrue(
+            "window is ${LinkWait.totalBoundMs} ms, too short for a link that is still negotiating",
+            LinkWait.totalBoundMs >= 5_000,
+        )
+    }
+
+    @Test
+    fun `does not hold the screen long enough to read as a hang`() {
+        // The other half of the trade. "Preparing…" for fifteen seconds is not
+        // patience, it is a frozen app — and someone will force-quit before it
+        // ever gets to answer.
+        assertTrue(
+            "window is ${LinkWait.totalBoundMs} ms, long enough to look broken",
+            LinkWait.totalBoundMs <= 10_000,
+        )
+    }
+
+    @Test
+    fun `looks more than once`() {
+        // A single look is the old behaviour wearing a new name: it would pass
+        // every other assertion here while changing nothing.
+        assertTrue("only ${LinkWait.looks} look(s)", LinkWait.looks >= 4)
+    }
+
+    @Test
+    fun `gaps never shrink`() {
+        // Early looks are cheap and catch a link that is nearly up; later ones
+        // are for a link that is still negotiating. A schedule that tightened
+        // toward the end would spend its attempts in the wrong place.
+        val gaps = LinkWait.lookDelaysMs.toList()
+        assertEquals(
+            "delays should be non-decreasing, got $gaps",
+            gaps.sorted(),
+            gaps,
+        )
+    }
+}

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -14,7 +14,7 @@ Codes are **never renamed or reused**. This is the complete Phase 2 taxonomy; ne
 
 | Code | Severity | Condition | Next action shown to user |
 |---|---|---|---|
-| `HOTSPOT_OFF` | Error | No usable IPv4 interface when starting. A shared Wi-Fi/LAN and a USB tethering link both count, not only the phone's hotspot. Mobile-data and VPN interfaces don't — the client cannot route to them | Connect the phone to Wi-Fi, turn on its hotspot, or plug in a cable and turn on USB tethering, then try again |
+| `HOTSPOT_OFF` | Error | No usable IPv4 interface **after waiting ~8 s for one to appear** (`LinkWait`). A shared Wi-Fi/LAN and a USB tethering link both count, not only the phone's hotspot. Mobile-data and VPN interfaces don't — the client cannot route to them. Before 2.8.2 this failed on the first look, so turning USB tethering on and opening Relay raced the interface coming up | Connect the phone to Wi-Fi, turn on its hotspot, or plug in a cable and turn on USB tethering, then try again |
 | `HOTSPOT_LOST` | Transient → Error | Hotspot interface dropped and did not return within the reconnect bound | Check the hotspot is still on, then start sharing again |
 | `PORT_IN_USE` | Error | Every candidate SOCKS port is bound by another app | Close the other app using those ports, then try again |
 | `SERVICE_FAILED` | Error | Foreground service stopped unexpectedly | Start sharing again |


### PR DESCRIPTION
Row **A1** and **A2** of the agreed checklist.

## The report

A 2.8.1 diagnostic log, from someone on a USB cable:

```
 11.64  Starting sharing
 11.66  No usable Wi-Fi/hotspot interface found
 13.20  Starting sharing
 13.20  No usable Wi-Fi/hotspot interface found
 ... five more ...
 30.34  Starting sharing
 30.45  WireGuard endpoint up on 10.202.154.104:51820
```

Seven failures in eighteen seconds, one per tap, then the eighth worked. Nothing was wrong with the phone — `rndis0` takes a few seconds to come up after the tethering toggle, and every tap inside that window was told there was no interface at all.

## A1 — wait

`startSharing` failed on the first look. It now takes eight looks over eight seconds (`LinkWait`), then gives an honest answer.

The first look is immediate, so a phone already on Wi-Fi pays **nothing** — that is the common case and it must not get slower to fix the uncommon one. Gaps widen because the failure shapes differ: a link nearly up appears in a few hundred ms, one still negotiating takes seconds.

`startSharing` becomes `suspend`; its only caller was already inside `scope.launch`.

## A2 — the failure line was lying

It said `No usable Wi-Fi/hotspot interface found` — no mention of USB, three releases after USB tethering shipped, to someone connected by exactly that. Now:

```
No usable Wi-Fi, hotspot or USB link after 8000 ms (8 looks)
```

## The test

`LinkWait` is pure so the two silent breakages are catchable: a first delay above zero taxes every start forever, and a single look is the old behaviour renamed. Ran the suite against three wrong schedules before committing:

| wrong schedule | caught by |
|---|---|
| old behaviour — single immediate look | `too-short`, `too-few-looks` |
| first look delayed 500 ms | `first-look` |
| 30-second window | `too-long` |

## Testing

| | |
|---|---|
| `LinkWait` shape — 5 assertions | in this PR, **CI** |
| Suite proven able to fail | 3 wrong schedules, before commit |
| Kotlin compiles | **CI** — no local Android toolchain (ADR-0004) |
| That a real USB-tethering start now succeeds first time | **NOT TESTED** — needs hardware with a cable |

## Not in this PR

A3 (splitting `HOTSPOT_OFF` into distinct causes), B1 (the disproven `wouldSwallow` — a log in the same report shows it calling a link swallowed 64 s before that link paired successfully), C1/C2 (structured logging). D still blocked on the Windows update symptom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)