### PR TITLE
Warn about a reply that was lost, not one that might be

### DIFF
--- a/android/app/src/main/kotlin/io/relay/app/core/ConnectionState.kt
+++ b/android/app/src/main/kotlin/io/relay/app/core/ConnectionState.kt
@@ -64,10 +64,10 @@ enum class WarningCode {
     BATTERY_UNRESTRICTED_DENIED,
 
     /**
-     * The phone's own VPN is routing Relay's replies into itself, so a PC can
-     * reach this phone but never hear back. See [io.relay.app.net.VpnCapture].
+     * A PC took Relay's settings and the tunnel never handshaked, so replies
+     * are not leaving this phone. See [io.relay.app.core.HandshakeWatch].
      */
-    VPN_CAPTURES_RELAY,
+    PC_GOT_NO_REPLY,
 }
 
 /**

--- a/android/app/src/main/kotlin/io/relay/app/core/HandshakeWatch.kt
+++ b/android/app/src/main/kotlin/io/relay/app/core/HandshakeWatch.kt
@@ -1,0 +1,59 @@
+package io.relay.app.core
+
+/**
+ * Whether a PC that took Relay's settings ever got an answer back.
+ *
+ * This replaces a check that *predicted* the fault instead of observing it. The
+ * old one asked the kernel, at pairing time, which interface a reply **would**
+ * leave by, and raised a banner whenever the answer was not the advertised
+ * link. A diagnostic log from a phone running 2.8.1 settled that question: in
+ * one session the probe flipped its verdict four times, said "a reply would
+ * leave by the VPN", and sixty-four seconds later that same phone completed a
+ * pairing and carried traffic. A warning that fires on a connection which is
+ * working is worse than no warning at all, because it is the reason the next
+ * real one is not believed.
+ *
+ * What is left is two things the phone genuinely knows. A PC asked it for a
+ * configuration — which only happens when someone pressed Connect on that PC —
+ * and the WireGuard endpoint has seen no completed handshake since. Inbound
+ * packets still arrive when a VPN captures the phone; what the capture eats is
+ * the *reply*. So "it asked, and nothing came back" is the exact shape of the
+ * fault [#126](https://github.com/Mahdi-mortazavi/relay/issues/126) describes,
+ * and it is not the shape of anything else.
+ *
+ * Pure and free of Android types so the decision is testable on the JVM, which
+ * is the only place any of this gets exercised before a phone is holding it.
+ */
+object HandshakeWatch {
+
+    /**
+     * How long the PC is given before the phone says anything.
+     *
+     * Matched to `handshakeTimeout` in `wg/cmd/relaywg-client/main.go`, which is
+     * when the laptop gives up and shows `ERR_WG_NO_HANDSHAKE` — whose text
+     * promises the user that "the phone will say on its own screen". Both are
+     * timing the same wait, started within a fraction of a second of each other,
+     * so they have to be the same number or that promise is only sometimes kept.
+     * Change one and change the other.
+     */
+    const val GRACE_MS = 20_000L
+
+    /**
+     * True once a PC has waited [GRACE_MS] for a handshake that never arrived.
+     *
+     * @param configuredAtMs when a PC last took a configuration, or null when
+     *   none ever has. Null is the ordinary case — a phone that is advertising
+     *   and has not been asked yet — and it must never warn.
+     * @param lastHandshakeUnix the endpoint's last completed handshake, in
+     *   seconds since the epoch, or 0 for never. Any non-zero value means a
+     *   reply did reach a PC during this sharing session: the endpoint and its
+     *   keys are minted per session, so there is no handshake here left over
+     *   from an earlier one. A session that once worked therefore stays quiet
+     *   afterwards, which is right — a laptop closing its lid is not a fault.
+     */
+    fun replyLost(configuredAtMs: Long?, lastHandshakeUnix: Long, nowMs: Long): Boolean {
+        if (configuredAtMs == null) return false
+        if (lastHandshakeUnix > 0L) return false
+        return nowMs - configuredAtMs >= GRACE_MS
+    }
+}

--- a/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
@@ -20,6 +20,7 @@ import io.relay.app.core.ShouldRetarget
 import io.relay.app.core.UpdateCheck
 import io.relay.app.core.DirectPairingStrategy
 import io.relay.app.core.ErrorCode
+import io.relay.app.core.HandshakeWatch
 import io.relay.app.core.LinkWait
 import io.relay.app.core.QrPayload
 import io.relay.app.core.ReconnectPolicy
@@ -84,6 +85,14 @@ class SharingService : Service() {
     // The session's forwarder and this pairing's keys (ADR-0008).
     private var wgForwarder: WgForwarder? = WgForwarderProvider.create()
     private var wgKeys: WgConfig.KeySet? = null
+
+    /**
+     * When a PC last took a configuration, which is when a handshake starts
+     * being owed. Written on the pairing server's accept thread and read by the
+     * peer watcher's coroutine, hence volatile. See [HandshakeWatch].
+     */
+    @Volatile
+    private var configuredAtMs: Long? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
@@ -376,21 +385,23 @@ class SharingService : Service() {
             configuration = { client ->
                 val keys = wgKeys
                 val host = currentHost
-                // Now that a PC has actually asked, its address is known, so the
-                // reply path can be checked rather than guessed at. This is the
-                // only moment the phone can tell that its own VPN will swallow
-                // the tunnel's handshake -- and saying so here beats the laptop
-                // reporting an unanswered tunnel and sending someone to look at
-                // their QR code.
+                // A PC only reaches this line because someone pressed Connect on
+                // it, so from this instant a handshake is owed. [startPeerWatcher]
+                // holds the other half of the check: if none arrives within
+                // HandshakeWatch.GRACE_MS, replies are not leaving this phone,
+                // and that is an observation rather than the prediction this
+                // used to raise a banner on. See [HandshakeWatch].
+                configuredAtMs = System.currentTimeMillis()
+                // Log-only, for the same reason as the one at start-up: the probe
+                // has been seen to say "swallowed" on a link that then carried a
+                // pairing and 35 MB of traffic, so it is worth having in a report
+                // and not worth alarming anyone with.
                 if (host != null) {
                     val swallowed = VpnCapture.wouldSwallow(client = client, advertisedHost = host)
-                    ConnectionRepository.setWarning(WarningCode.VPN_CAPTURES_RELAY, swallowed)
-                    if (swallowed) {
-                        LocalLog.add(
-                            "This phone's VPN is routing replies to $client into itself; " +
-                                "the tunnel will not answer"
-                        )
-                    }
+                    LocalLog.add(
+                        if (swallowed) "Reply path to $client: would leave by the VPN, not by $host"
+                        else "Reply path to $client: leaves by $host, as it should"
+                    )
                 }
                 if (keys == null || host == null) null
                 else PairingServer.Configuration(
@@ -424,10 +435,35 @@ class SharingService : Service() {
         peerWatcher?.cancel()
         peerWatcher = scope.launch {
             var present = false
+            var saidNoReply = false
             while (isActive) {
                 delay(PEER_POLL_MS)
                 val handshake = forwarder.lastHandshakeUnix()
                 val age = System.currentTimeMillis() / 1000 - handshake
+
+                // The one fault the phone can see that the laptop can only
+                // guess at: a PC asked for the settings and the endpoint was
+                // never handshaked, so the replies are not getting out. The
+                // laptop reaches its own verdict at the same moment and its
+                // message promises this banner is here, so it has to be.
+                val noReply = HandshakeWatch.replyLost(
+                    configuredAtMs = configuredAtMs,
+                    lastHandshakeUnix = handshake,
+                    nowMs = System.currentTimeMillis(),
+                )
+                // Raised on the edge, not every tick. Pushing it once a second
+                // would put the banner back a second after anyone dismissed it,
+                // which is the whole of the dismiss button's job.
+                if (noReply != saidNoReply) {
+                    saidNoReply = noReply
+                    ConnectionRepository.setWarning(WarningCode.PC_GOT_NO_REPLY, noReply)
+                    if (noReply) {
+                        LocalLog.add(
+                            "A PC took the settings ${HandshakeWatch.GRACE_MS / 1000} s ago and " +
+                                "the tunnel never handshaked; replies are not leaving this phone"
+                        )
+                    }
+                }
                 // Three minutes is what wg(8)'s own tooling treats as alive:
                 // rekeying happens at two, so this leaves a minute of margin
                 // without holding "connected" on screen long after the laptop
@@ -603,6 +639,8 @@ class SharingService : Service() {
         runCatching { wgForwarder?.stop() }
         wgKeys = null
         currentHost = null
+        // Nobody is owed a handshake once there is no endpoint to give them one.
+        configuredAtMs = null
         releaseWakeLock()
         ConnectionRepository.clearWarnings()
     }

--- a/android/app/src/main/kotlin/io/relay/app/ui/HomeScreen.kt
+++ b/android/app/src/main/kotlin/io/relay/app/ui/HomeScreen.kt
@@ -268,8 +268,8 @@ private fun WarningBanners(warnings: Set<WarningCode>, onDismiss: (WarningCode) 
                 R.string.warning_no_vpn_title to R.string.warning_no_vpn_body
             WarningCode.BATTERY_UNRESTRICTED_DENIED ->
                 R.string.battery_banner_title to R.string.battery_banner_body
-            WarningCode.VPN_CAPTURES_RELAY ->
-                R.string.warning_vpn_captures_title to R.string.warning_vpn_captures_body
+            WarningCode.PC_GOT_NO_REPLY ->
+                R.string.warning_no_reply_title to R.string.warning_no_reply_body
         }
         Row(
             modifier = Modifier

--- a/android/app/src/main/res/values-fa/strings.xml
+++ b/android/app/src/main/res/values-fa/strings.xml
@@ -25,8 +25,8 @@
     <string name="mode_full_unavailable">این نسخه بخش تونل را ندارد و نمی‌تواند چیزی به اشتراک بگذارد. رله را دوباره از صفحهٔ انتشارها نصب کنید.</string>
 
     <!-- Warnings (non-blocking banners) -->
-    <string name="warning_vpn_captures_title">وی‌پی‌ان شما جلوی رله را گرفته</string>
-    <string name="warning_vpn_captures_body">برنامهٔ وی‌پی‌ان شما ترافیک خودِ رله را به داخل خودش می‌فرستد، برای همین کامپیوترتان به این گوشی می‌رسد ولی جوابی نمی‌شنود. در تنظیمات هر-برنامهٔ وی‌پی‌ان، رله را مستثنا کنید.</string>
+    <string name="warning_no_reply_title">کامپیوترتان جوابی نمی‌گیرد</string>
+    <string name="warning_no_reply_body">یک کامپیوتر تنظیمات رله را گرفت و تونلش را شروع کرد، ولی هیچ جوابی از این گوشی بیرون نرفت. در فهرست هر-برنامهٔ وی‌پی‌ان، رله را مستثنا کنید، یا «Block connections without VPN» را در تنظیمات → شبکه → VPN خاموش کنید.</string>
     <string name="warning_no_vpn_title">هیچ VPN فعالی نیست</string>
     <string name="warning_no_vpn_body">در حال اشتراک اتصال معمولی خود هستید. اگر می‌خواستید VPN را به‌اشتراک بگذارید، ابتدا آن را روشن کنید.</string>
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -25,8 +25,8 @@
     <string name="mode_full_unavailable">This build is missing the tunnel component, so it cannot share. Reinstall Relay from the releases page.</string>
 
     <!-- Warnings (non-blocking banners) -->
-    <string name="warning_vpn_captures_title">Your VPN is blocking Relay</string>
-    <string name="warning_vpn_captures_body">Your VPN app is routing Relay\'s own traffic into itself, so your PC can reach this phone but never hears back. Exclude Relay in the VPN app\'s per-app settings.</string>
+    <string name="warning_no_reply_title">Your PC is not getting an answer</string>
+    <string name="warning_no_reply_body">A PC took Relay\'s settings and started its tunnel, but no reply ever left this phone. Exclude Relay in your VPN app\'s per-app list, or turn off “Block connections without VPN” in Settings → Network → VPN.</string>
     <string name="warning_no_vpn_title">No VPN is active</string>
     <string name="warning_no_vpn_body">You\'re sharing your regular connection. Turn on your VPN first if you meant to share it.</string>
 

--- a/android/app/src/test/kotlin/io/relay/app/HandshakeWatchTest.kt
+++ b/android/app/src/test/kotlin/io/relay/app/HandshakeWatchTest.kt
@@ -1,0 +1,88 @@
+package io.relay.app
+
+import io.relay.app.core.HandshakeWatch
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The banner this drives replaced one that fired on working connections.
+ *
+ * Every assertion here is a way of getting that wrong again. The two that
+ * matter most are the quiet ones: a warning that appears when nothing is
+ * broken is the reason nobody reads the next one.
+ */
+class HandshakeWatchTest {
+
+    private val now = 1_700_000_000_000L
+
+    @Test
+    fun `stays quiet until a PC has actually asked`() {
+        // The ordinary case — a phone advertising, nobody connected yet. An
+        // implementation that warns on "no handshake" alone would light the
+        // banner on every phone that has been sharing for half a minute.
+        assertFalse(
+            HandshakeWatch.replyLost(
+                configuredAtMs = null,
+                lastHandshakeUnix = 0L,
+                nowMs = now + 10 * HandshakeWatch.GRACE_MS,
+            )
+        )
+    }
+
+    @Test
+    fun `a session that handshaked never warns, however long ago`() {
+        // This is the regression that produced the old false positive. On the
+        // 2.8.1 log this was written for, the phone had paired and carried
+        // traffic while the banner said its VPN was blocking Relay. A handshake
+        // is proof a reply got out; nothing after it can un-prove that.
+        assertFalse(
+            "a phone that answered a PC must never be told its replies are lost",
+            HandshakeWatch.replyLost(
+                configuredAtMs = now,
+                lastHandshakeUnix = 1_699_999_000L,
+                nowMs = now + 10 * HandshakeWatch.GRACE_MS,
+            )
+        )
+    }
+
+    @Test
+    fun `does not warn while the PC is still within its own deadline`() {
+        // The laptop is still trying. Warning here would put the banner up
+        // during a handshake that is about to succeed on a slow link.
+        assertFalse(
+            HandshakeWatch.replyLost(
+                configuredAtMs = now,
+                lastHandshakeUnix = 0L,
+                nowMs = now + HandshakeWatch.GRACE_MS - 1,
+            )
+        )
+    }
+
+    @Test
+    fun `warns once the PC has waited out the whole grace with nothing back`() {
+        // And it has to actually fire: ERR_WG_NO_HANDSHAKE on the laptop tells
+        // the user in so many words that the phone is saying this on its screen.
+        assertTrue(
+            HandshakeWatch.replyLost(
+                configuredAtMs = now,
+                lastHandshakeUnix = 0L,
+                nowMs = now + HandshakeWatch.GRACE_MS,
+            )
+        )
+    }
+
+    @Test
+    fun `waits exactly as long as the client does`() {
+        // wg/cmd/relaywg-client/main.go: handshakeTimeout = 20 * time.Second.
+        // Nothing mechanical couples the two -- one is Go, one is Kotlin -- so
+        // this assertion is the coupling. If the client's deadline is ever
+        // changed, this fails and says where the other half lives.
+        assertEquals(
+            "must match handshakeTimeout in wg/cmd/relaywg-client/main.go",
+            20_000L,
+            HandshakeWatch.GRACE_MS,
+        )
+    }
+}

--- a/docs/errors.md
+++ b/docs/errors.md
@@ -20,6 +20,7 @@ Codes are **never renamed or reused**. This is the complete Phase 2 taxonomy; ne
 | `SERVICE_FAILED` | Error | Foreground service stopped unexpectedly | Start sharing again |
 | `WG_START_FAILED` | Error | The WireGuard endpoint could not start on the phone | Start sharing again |
 | `NO_VPN_ACTIVE` | Warning | No VPN is active on the phone when sharing starts | Informational: you're sharing your regular connection. Turn on your VPN first if you meant to share it |
+| `PC_GOT_NO_REPLY` | Warning | A PC took a configuration and the WireGuard endpoint saw no completed handshake in the 20 s that followed (`HandshakeWatch`). Fires at the same moment the PC shows `ERR_WG_NO_HANDSHAKE`. Replaces 2.8.1's `VPN_CAPTURES_RELAY`, which predicted the fault from a route lookup and was seen announcing it on a session that then paired and carried traffic — see [vpn-compat.md](vpn-compat.md) | Exclude Relay in the VPN app's per-app list, or turn off "Block connections without VPN" in Settings → Network → VPN |
 | `BATTERY_UNRESTRICTED_DENIED` | Warning | Battery-optimization exemption not granted | Allow it so sharing survives screen-off (button opens the exemption dialog) |
 
 ## Windows (client device)

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -337,7 +337,15 @@ the whole installer buffered in memory under one deadline).
 
 Closing it needs a route on the laptop that can carry fifty megabytes, which on
 that network means going through Relay itself. That attempt was blocked by a
-third thing: the phone had another VPN holding `tun0`, so Relay's replies would
-have left by the wrong interface. Relay detected exactly that and said so —
-`VPN_CAPTURES_RELAY`, correct, and still unfixable from inside the app. So the
-last leg of the Windows update waits on a phone whose VPN slot is free.
+third thing: the phone had another VPN holding `tun0`, and Relay said its
+replies would leave by the wrong interface.
+
+**That reading has since been withdrawn.** A diagnostic log from a 2.8.1 phone
+shows the same probe flipping its verdict four times in one session, announcing
+that a reply "would leave by the VPN", and sixty-four seconds later pairing a PC
+and carrying traffic. The probe is a prediction, not an observation, and it was
+wrong here too. The banner it drove is gone; what took its place watches for a
+PC that took the settings and never handshaked, which is a fact — see
+[`vpn-compat.md`](vpn-compat.md). So the last leg of the Windows update is not
+waiting on a free VPN slot; it is waiting on a laptop that can pull fifty
+megabytes from GitHub.

--- a/docs/vpn-compat.md
+++ b/docs/vpn-compat.md
@@ -46,20 +46,63 @@ cannot produce it.**
 
 Since 2.8.1 the diagnostic log carries a `Reply path check:` line written when
 sharing starts, before any PC is involved, so a report from a group-3 phone
-still says which way replies would leave. It is log-only on purpose — the same
-probe has said "swallowed" on a link that then carried 35 MB without trouble, so
-it is trustworthy enough to triage with and not to alarm anyone with.
+still says which way replies would leave.
+
+### The probe predicts; it does not observe
+
+A log from a 2.8.1 phone settled what that line is worth. In one session the
+probe flipped its verdict **four times**, and at 4999 s said:
+
+```
+4999.58  Reply path check: a reply to 192.168.1.1 would leave by the VPN, not by 192.168.1.5
+5063.84  A PC at 192.168.1.4 asked to pair
+5068.53  Sent the configuration to 192.168.1.4
+5073.74  Clients: 1
+```
+
+Sixty-four seconds after announcing that replies were lost, that phone paired a
+PC and carried its traffic. The probe asks the kernel which interface a datagram
+*would* take; it cannot ask whether the packet arrives. So it is kept for triage
+and it is **log-only** — a banner that fires on a connection which is working is
+the reason the next real warning is not believed.
+
+### What raises the banner instead
+
+From 2.8.2 the warning is `PC_GOT_NO_REPLY`, and it is built out of two things
+the phone actually observes:
+
+1. a PC took a configuration — which only happens when someone pressed Connect;
+2. the WireGuard endpoint has recorded **no completed handshake** in the
+   20 seconds since.
+
+Inbound still arrives under a capture; what a capture eats is the reply. "It
+asked and nothing came back" is therefore the exact signature of this fault and
+of nothing else. The 20 seconds are `handshakeTimeout` in
+`wg/cmd/relaywg-client/main.go`, so the phone's banner appears at the same
+moment the laptop shows `ERR_WG_NO_HANDSHAKE` — whose text tells the user the
+phone is saying so on its own screen. `HandshakeWatchTest` asserts the two
+numbers stay equal.
+
+This still does not help group 3, where `accept()` never returns and so no
+configuration is ever taken. Nothing inside the app can: the fix there is one of
+the two settings below.
 
 ### Two settings worth trying before anything else
 
-Both are on the VPN app's side, and either one alone can produce group 3:
+Either one alone can produce group 3. **They live in different places, and
+asking about the wrong one gets a confident wrong answer** — a user asked about
+lockdown looked inside FlClash X and NekoBox, because that is where a setting
+called "block connections" sounds like it would be:
 
-- **"Block connections without VPN"** (Android's lockdown mode, in
-  *Settings → Network → VPN → ⚙*). It drops everything that is not the tunnel,
-  **including replies to your own LAN**. Turn it off and retry.
-- **Per-app / split tunnelling** — exclude Relay in the VPN app's own app list.
-  This is what the in-app warning already tells people to do, and it is the
-  reliable fix when it is available.
+- **"Block connections without VPN"** — Android's lockdown mode. **Not in the
+  VPN app.** It is in *Settings → Network & internet → VPN → the ⚙ beside the
+  app's name*, and the toggle only appears at all once **Always-on VPN** is on,
+  so an app that does not support always-on shows nothing there. It drops
+  everything that is not the tunnel, **including replies to your own LAN**.
+  Turn it off and retry.
+- **Per-app / split tunnelling** — this one *is* in the VPN app's own app list;
+  exclude Relay there. It is what the in-app warning tells people to do, and it
+  is the reliable fix when the app offers it.
 
 Neither is a Relay setting; Android gives an app inside a VPN no way to opt out
 of either (`Network.bindSocket` fails `EPERM`, `SO_BINDTODEVICE` needs


### PR DESCRIPTION
## What it was

`VPN_CAPTURES_RELAY` raised **"Your VPN is blocking Relay"** from a route lookup
performed at pairing time — a forecast of which interface a reply *would* take.

## Why it had to go

A diagnostic log from a phone on 2.8.1, same session, same two addresses:

```
4999.58  Reply path check: a reply to 192.168.1.1 would leave by the VPN, not by 192.168.1.5
5063.84  A PC at 192.168.1.4 asked to pair
5068.53  Sent the configuration to 192.168.1.4
5073.74  Clients: 1
```

Sixty-four seconds after announcing that replies were lost, the phone paired a
PC and carried its traffic. In that one session the probe flipped its verdict
four times.

The probe can ask the kernel which way a datagram leaves. It cannot ask whether
the packet arrives. A banner that fires on a working connection is worse than no
banner, because it is why the next real warning is not believed.

## What replaces it

`PC_GOT_NO_REPLY`, built from two things the phone observes:

1. a PC took a configuration — which only happens when someone pressed Connect;
2. the WireGuard endpoint has recorded **no completed handshake** in the 20 s
   since.

A capture eats the *reply*, not the inbound packet, so "it asked and nothing came
back" is this fault's signature and nothing else's. A session that once handshaked
never warns afterwards — keys are minted per session, so a non-zero handshake is
proof a reply got out, and a laptop closing its lid is not a fault.

The probe survives as a log line. It is worth having in a report and not worth
alarming anyone with.

## The 20 seconds are not arbitrary

`handshakeTimeout` in `wg/cmd/relaywg-client/main.go` is when the laptop gives up
and shows `ERR_WG_NO_HANDSHAKE` — whose own text reads *"…or a VPN on the phone is
swallowing Relay's replies, **which the phone will say on its own screen**."*

That sentence has been shipping while the banner behind it fired on the wrong
sessions. Now the two fire together. Nothing mechanical couples a Go constant to a
Kotlin one, so `HandshakeWatchTest` asserts they are equal and names the file the
other half lives in.

## Also

- Raised on the edge, not every poll — pushing it once a second put the banner
  back a second after anyone dismissed it.
- `docs/errors.md` gains the row this warning never had. `VPN_CAPTURES_RELAY`
  reached the enum, the UI and both string files without ever entering the
  taxonomy that is meant to define it.
- `docs/vpn-compat.md` corrects a claim that both fixes "are on the VPN app's
  side". **"Block connections without VPN" is an Android setting, not an app
  setting**, and its toggle only appears once Always-on VPN is on — which is why
  a user asked about it looked inside their VPN apps and reported it missing.
- `docs/testing.md` withdraws its reading of the same probe.

## Tests

`HandshakeWatchTest` — five assertions, each a way of reintroducing the bug:

| assertion | what it catches |
|---|---|
| quiet until a PC has asked | warning on "no handshake" alone, i.e. every idle phone |
| a session that handshaked never warns | **the exact 2.8.1 false positive** |
| quiet inside the PC's own deadline | firing during a handshake that is about to succeed |
| warns once the grace is spent | a banner the laptop's copy promises and that never appears |
| grace equals the client's timeout | the Go and Kotlin halves drifting apart |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
