### PR TITLE
Finish the update at a moment that is certain to arrive

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ Nothing else to install, and no account to make.
 | **Follows a moving phone** | A changed address — DHCP renewal, Wi-Fi change, NAT rebinding — re-points the tunnel instead of killing it |
 | **Survives a bad network** | Tested against 5% packet loss, a full outage, and a mid-transfer path change |
 | **Leak protection** | DNS and IPv6 cannot leave outside the tunnel. Costs 22 µs per connection and nothing per byte |
-| **Updates itself** | Windows installs quietly at the next idle moment; Android offers, because the platform forbids more |
+| **Updates itself** | Windows installs quietly when you close it, or at the next idle moment; Android offers, because the platform forbids more |
 
 <details>
 <summary><b>Pairing, in detail</b></summary>
@@ -289,8 +289,14 @@ if it is killed. A dead Relay cannot leave your machine unable to resolve names.
 
 **Windows updates itself.** It checks shortly after launch and then daily, tells
 you what it found, and installs at the next moment the tunnel is down — because
-installing means stopping Relay, and doing that mid-call would drop the call. It
-closes, updates, and comes back.
+installing means stopping Relay, and doing that mid-call would drop the call.
+
+If that moment does not arrive while you are using it, the verified download is
+kept and goes in **when you close Relay**, or **the next time you open it** if
+the app never got a clean exit. Nothing is downloaded twice, and there is no
+session you have to remember to leave running. Closing costs you nothing, so
+that is the one it prefers; an update applied at start-up closes Relay and
+brings it straight back.
 
 **Android checks when you open it and when sharing starts**, so the tile and the
 widget reach you too, then offers the update. Android does not let a sideloaded

--- a/windows/Relay.App.Tests/PendingUpdateTests.cs
+++ b/windows/Relay.App.Tests/PendingUpdateTests.cs
@@ -1,0 +1,95 @@
+using Relay.Core;
+using Xunit;
+
+namespace Relay.App.Tests;
+
+/// <summary>
+/// The note an update leaves for the next launch to find.
+///
+/// It lives in a temp directory and it names something the app will execute, so
+/// half of what follows is about refusing a note that is not one this app wrote.
+/// </summary>
+public class PendingUpdateTests
+{
+    private static string Fresh()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(), "relay-pending-tests", Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    private static void Write(string directory, string json) =>
+        File.WriteAllText(Path.Combine(directory, PendingUpdate.FileName), json);
+
+    [Fact]
+    public void RoundTrips()
+    {
+        var directory = Fresh();
+        var saved = new PendingUpdate("2.8.1", "Relay-Setup-x64.exe", new string('a', 64));
+
+        PendingUpdate.Save(directory, saved);
+
+        // Two sides written independently -- a writer and a hand-rolled reader --
+        // so a renamed field would pass every other test in this file by making
+        // Load return null, which reads as "nothing pending" and is exactly the
+        // bug this class exists to fix.
+        Assert.Equal(saved, PendingUpdate.Load(directory));
+    }
+
+    [Fact]
+    public void NothingPendingWhenNothingWasSaved()
+    {
+        Assert.Null(PendingUpdate.Load(Fresh()));
+    }
+
+    [Fact]
+    public void ClearMeansNothingPending()
+    {
+        var directory = Fresh();
+        PendingUpdate.Save(directory, new PendingUpdate("2.8.1", "s.exe", "ab"));
+
+        PendingUpdate.Clear(directory);
+
+        // Cleared before the installer runs, so a launch that fails to start it
+        // does not sit in a loop retrying the same bytes on every launch after.
+        Assert.Null(PendingUpdate.Load(directory));
+    }
+
+    [Fact]
+    public void RefusesAnInstallerNameThatIsAPath()
+    {
+        var directory = Fresh();
+        Write(directory, """
+            {"version":"99.0.0","installer":"..\\..\\Windows\\System32\\cmd.exe","sha256":"ab"}
+            """);
+
+        // This file sits in a world-writable temp directory and names a program
+        // Relay will start. Combining a name with separators in it against the
+        // download directory is how that becomes "Relay runs whatever was put
+        // in front of it".
+        Assert.Null(PendingUpdate.Load(directory));
+    }
+
+    [Fact]
+    public void RefusesANoteThatDoesNotSayEverything()
+    {
+        var directory = Fresh();
+        Write(directory, """{"version":"99.0.0","installer":"Relay-Setup-x64.exe"}""");
+
+        // No hash means nothing can be checked before running it, which is the
+        // one thing that must never be skipped.
+        Assert.Null(PendingUpdate.Load(directory));
+    }
+
+    [Fact]
+    public void RefusesRubbish()
+    {
+        var directory = Fresh();
+        Write(directory, "not json at all");
+
+        // A truncated write, a disk that filled, a file someone edited. None of
+        // them should throw on a path that runs while the app is starting up.
+        Assert.Null(PendingUpdate.Load(directory));
+    }
+}

--- a/windows/Relay.App.Tests/UpdateAcrossLaunchesTests.cs
+++ b/windows/Relay.App.Tests/UpdateAcrossLaunchesTests.cs
@@ -1,0 +1,242 @@
+using System.Net;
+using System.Security.Cryptography;
+using Relay.Core;
+using Xunit;
+
+namespace Relay.App.Tests;
+
+/// <summary>
+/// That an update which could not be installed *now* still gets installed.
+///
+/// This is the regression suite for a bug that was found on a real laptop
+/// rather than in CI. That machine was running 1.9.3-test from 16 August while
+/// 2.8.1 was published, and the reason was in <c>%TEMP%\Relay-update</c>: a
+/// 48,536,231-byte installer, downloaded on 9 September and checksum-verified —
+/// an unverified one is deleted — still sitting there, unrun, on 12 September.
+///
+/// Installing used to be attempted only inside one run of the process: start,
+/// wait, check, download, then wait for the state to be Idle. Relay is opened
+/// in order to be connected to, so someone who opens it, connects, and closes
+/// it when they are done is never Idle inside that window. Every launch found
+/// the release again, downloaded it again, and abandoned it again.
+///
+/// So these are about the bytes surviving the process that fetched them.
+/// <see cref="UpdateServiceTests"/> still owns "never while a tunnel is up";
+/// nothing here is allowed to weaken that.
+/// </summary>
+public class UpdateAcrossLaunchesTests
+{
+    private const string Installer = "Relay-Setup-x64.exe";
+    private static readonly byte[] Payload = "pretend installer"u8.ToArray();
+
+    private static string Sha => Convert.ToHexString(SHA256.HashData(Payload)).ToLowerInvariant();
+
+    private const string NewerRelease = """
+        {"tag_name":"v99.0.0","draft":false,"prerelease":false,
+         "assets":[
+           {"name":"Relay-Setup-x64.exe","browser_download_url":"https://x/Relay-Setup-x64.exe"},
+           {"name":"SHA256SUMS.txt","browser_download_url":"https://x/SHA256SUMS.txt"}]}
+        """;
+
+    /// <summary>A release that is real and self-consistent: the listing matches the bytes.</summary>
+    private sealed class Servable : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken token)
+        {
+            var url = request.RequestUri!.ToString();
+            HttpContent content = url.EndsWith("SHA256SUMS.txt", StringComparison.Ordinal)
+                ? new StringContent($"{Sha}  {Installer}")
+                : url.Contains("api.github.com", StringComparison.Ordinal)
+                    ? new StringContent(NewerRelease)
+                    : new ByteArrayContent(Payload);
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) { Content = content });
+        }
+    }
+
+    private sealed class Notices
+    {
+        public readonly List<UpdateNotice> Kinds = [];
+        public void Add(UpdateNotice kind, string version) => Kinds.Add(kind);
+    }
+
+    private static string Fresh()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(), "relay-launch-tests", Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+
+    /// <summary>
+    /// One run of the app. <paramref name="state"/> is what the app is doing;
+    /// <paramref name="ran"/> collects the installers it would have started.
+    /// </summary>
+    private static UpdateService Launch(
+        string directory, string state, List<string> ran, Notices notices, string version = "1.0.0") =>
+        new(version, () => state, notices.Add,
+            () => new UpdateCheck(version, new HttpClient(new Servable())),
+            new UpdateInstaller(new HttpClient(new Servable())),
+            idleWait: TimeSpan.Zero,
+            downloadDirectory: directory,
+            runInstaller: ran.Add);
+
+    [Fact]
+    public async Task AnUpdateFetchedWhileConnectedIsInstalledOnTheNextLaunch()
+    {
+        var directory = Fresh();
+        var ran = new List<string>();
+        var notices = new Notices();
+
+        // Session one: the user is connected the whole time, which is the normal
+        // way Relay is used. Nothing may install.
+        await Launch(directory, "Connected", ran, notices).CheckAndMaybeInstallAsync();
+        Assert.Empty(ran);
+
+        // Session two: a fresh process, and nothing has been checked or fetched
+        // in it. Before this existed, that meant starting from nothing.
+        var installed = await Launch(directory, "Idle", ran, notices)
+            .InstallPendingAsync(relaunch: true);
+
+        Assert.True(installed, "the verified installer from the first session was not run");
+        Assert.Single(ran);
+        Assert.Equal(Path.Combine(directory, Installer), ran[0]);
+        Assert.Contains(UpdateNotice.Installing, notices.Kinds);
+    }
+
+    [Fact]
+    public async Task StillWillNotInstallWhileATunnelIsUp()
+    {
+        var directory = Fresh();
+        var ran = new List<string>();
+
+        await Launch(directory, "Connected", ran, new Notices()).CheckAndMaybeInstallAsync();
+
+        // A second connected session must not take the new path as permission.
+        // The installer stops Relay to replace it; doing that mid-call is the
+        // one thing the whole idle rule exists to prevent.
+        var installed = await Launch(directory, "Connected", ran, new Notices())
+            .InstallPendingAsync(relaunch: true);
+
+        Assert.False(installed);
+        Assert.Empty(ran);
+    }
+
+    [Fact]
+    public async Task ForgetsAPendingUpdateThisBuildAlreadyIs()
+    {
+        var directory = Fresh();
+        var ran = new List<string>();
+
+        // Fetched while connected, so it is pending...
+        await Launch(directory, "Connected", ran, new Notices()).CheckAndMaybeInstallAsync();
+
+        // ...and then it installed, so the next launch *is* 99.0.0. Without the
+        // version check that launch would reinstall the build it is already
+        // running, on every start, forever.
+        var installed = await Launch(directory, "Idle", ran, new Notices(), version: "99.0.0")
+            .InstallPendingAsync(relaunch: true);
+
+        Assert.False(installed);
+        Assert.Empty(ran);
+        Assert.Null(PendingUpdate.Load(directory));
+        Assert.False(File.Exists(Path.Combine(directory, Installer)));
+    }
+
+    [Fact]
+    public async Task RefusesAPendingInstallerThatChangedOnDisk()
+    {
+        var directory = Fresh();
+        var ran = new List<string>();
+        var notices = new Notices();
+
+        await Launch(directory, "Connected", ran, new Notices()).CheckAndMaybeInstallAsync();
+
+        // It was verified when it was fetched. Since then it has sat in a
+        // directory anything running as this user can write to, across a launch
+        // and possibly a reboot — and what it does when run is replace the
+        // program that carries the user's entire connection. Verifying once is
+        // not the same as verifying.
+        await File.WriteAllBytesAsync(Path.Combine(directory, Installer), "something else"u8.ToArray());
+
+        var installed = await Launch(directory, "Idle", ran, notices).InstallPendingAsync(relaunch: true);
+
+        Assert.False(installed);
+        Assert.Empty(ran);
+        Assert.Contains(UpdateNotice.Refused, notices.Kinds);
+        Assert.Null(PendingUpdate.Load(directory));
+    }
+
+    [Fact]
+    public async Task SaysNothingWhenTheDownloadDirectoryWasSweptAway()
+    {
+        var directory = Fresh();
+        var ran = new List<string>();
+        var notices = new Notices();
+
+        await Launch(directory, "Connected", ran, new Notices()).CheckAndMaybeInstallAsync();
+        File.Delete(Path.Combine(directory, Installer));
+
+        var installed = await Launch(directory, "Idle", ran, notices).InstallPendingAsync(relaunch: true);
+
+        // Windows is allowed to clean %TEMP%, and that is a feature rather than
+        // a fault: the next check fetches it again. Nobody needs telling.
+        Assert.False(installed);
+        Assert.Empty(notices.Kinds);
+    }
+
+    [Fact]
+    public async Task NothingPendingIsNotAnError()
+    {
+        var notices = new Notices();
+
+        var installed = await Launch(Fresh(), "Idle", [], notices).InstallPendingAsync(relaunch: true);
+
+        // The overwhelmingly common launch.
+        Assert.False(installed);
+        Assert.Empty(notices.Kinds);
+    }
+
+    [Fact]
+    public void AnUpdateLandsOnTheAppThatIsRunning()
+    {
+        var arguments = UpdateInstaller.ArgumentsFor(@"E:\Programs\Relay", relaunch: true);
+
+        // Inno remembers the previous install's folder in the registry and, with
+        // /SILENT, accepts it with no dialog for anyone to correct. The laptop
+        // this was found on still had InstallLocation=C:\RelayTest\ from a test
+        // install whose folder had been deleted, while the real app lived
+        // elsewhere and every shortcut pointed there. Without /DIR the update
+        // would have installed flawlessly into a folder nobody launches from and
+        // reported success.
+        Assert.Contains(@"/DIR=""E:\Programs\Relay""", arguments);
+        Assert.Contains("/SILENT", arguments);
+    }
+
+    [Fact]
+    public void AnUpdateOnTheWayOutDoesNotReopenTheApp()
+    {
+        var onClose = UpdateInstaller.ArgumentsFor(@"C:\Relay", relaunch: false);
+        var onStart = UpdateInstaller.ArgumentsFor(@"C:\Relay", relaunch: true);
+
+        // Closing is the free moment to update, and it stays free only if the
+        // app does not come back afterwards: the user asked it to close.
+        Assert.DoesNotContain(UpdateInstaller.Relaunch, onClose);
+
+        // And the start-up path must still relaunch, or the app the user just
+        // opened vanishes, which reads as a crash.
+        Assert.Contains(UpdateInstaller.Relaunch, onStart);
+    }
+
+    [Fact]
+    public void TheFirstCheckHappensInsideAnOrdinarySession()
+    {
+        // It was two minutes, and plenty of sessions are shorter than that end
+        // to end — open Relay, connect, finish, close. For those the check never
+        // ran once, on any launch. The delay was never what keeps the launch
+        // fast; the check has always been on a background thread.
+        Assert.True(
+            UpdateService.FirstCheckDelay <= TimeSpan.FromMinutes(1),
+            $"first check waits {UpdateService.FirstCheckDelay}, longer than many whole sessions");
+    }
+}

--- a/windows/Relay.App.Tests/UpdateServiceTests.cs
+++ b/windows/Relay.App.Tests/UpdateServiceTests.cs
@@ -83,7 +83,26 @@ public class UpdateServiceTests
     private static UpdateService Connected(Notices notices) =>
         new("1.0.0", () => "Connected", notices.Add, Check,
             new UpdateInstaller(new HttpClient(new Servable())),
-            idleWait: TimeSpan.Zero);
+            idleWait: TimeSpan.Zero,
+            downloadDirectory: Isolated());
+
+    /// <summary>
+    /// A download directory of this test's own.
+    ///
+    /// These used to share the app's real one. That was untidy and became
+    /// dangerous the moment a verified download started leaving a note behind
+    /// for the next launch to act on: a test run would have written a note
+    /// claiming version 99.0.0, pointing at seventeen bytes reading "pretend
+    /// installer", into the exact directory the installed Relay reads at
+    /// start-up.
+    /// </summary>
+    private static string Isolated()
+    {
+        var directory = Path.Combine(
+            Path.GetTempPath(), "relay-service-tests", Guid.NewGuid().ToString("n"));
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
 
     [Fact]
     public async Task AnnouncesAnUpdateAsSoonAsItIsFound()
@@ -132,10 +151,17 @@ public class UpdateServiceTests
     [Fact]
     public async Task FetchesTheUpdateEvenWhileTheTunnelIsUp()
     {
-        var target = Path.Combine(Path.GetTempPath(), "Relay-update", "Relay-Setup-x64.exe");
+        // The one test that deliberately uses the app's real download
+        // directory, because where the bytes land is what it is asserting.
+        var directory = PendingUpdate.DefaultDirectory;
+        var target = Path.Combine(directory, "Relay-Setup-x64.exe");
         if (File.Exists(target)) File.Delete(target);
+        PendingUpdate.Clear(directory);
 
-        await Connected(new Notices()).CheckAndMaybeInstallAsync();
+        await new UpdateService(
+            "1.0.0", () => "Connected", new Notices().Add, Check,
+            new UpdateInstaller(new HttpClient(new Servable())),
+            idleWait: TimeSpan.Zero).CheckAndMaybeInstallAsync();
 
         // The reason this matters is not speed. Relay is used where the tunnel
         // is the only working route to GitHub's release CDN, so waiting for
@@ -143,7 +169,11 @@ public class UpdateServiceTests
         // which the bytes cannot be reached — and the update never landed at
         // all. Installing still waits; fetching must not.
         Assert.True(File.Exists(target));
+
+        // Both halves: the note left here would otherwise tell an installed
+        // Relay, on its next launch, that "pretend installer" is version 99.0.0.
         File.Delete(target);
+        PendingUpdate.Clear(directory);
     }
 
     [Fact]

--- a/windows/Relay.App/App.xaml.cs
+++ b/windows/Relay.App/App.xaml.cs
@@ -245,7 +245,12 @@ public partial class App : Application
                 // already down. It still goes through the ordinary tray exit
                 // rather than Environment.Exit, so the proxy rollback and the
                 // three-second backstop both still apply.
-                if (notice == UpdateNotice.Installing)
+                //
+                // Not when the exit is already under way: the install-on-close
+                // path below raises this same notice from inside
+                // ExitFromTrayAsync, and re-entering it there would have the
+                // app trying to close itself twice.
+                if (notice == UpdateNotice.Installing && Volatile.Read(ref _exiting) == 0)
                 {
                     _window?.DispatcherQueue.TryEnqueue(() => _ = ExitFromTrayAsync());
                 }
@@ -342,8 +347,16 @@ public partial class App : Application
         }
     }
 
+    /// <summary>
+    /// Non-zero once <see cref="ExitFromTrayAsync"/> has begun, so the update
+    /// notification handler does not ask it to begin again.
+    /// </summary>
+    private int _exiting;
+
     private async Task ExitFromTrayAsync()
     {
+        Interlocked.Exchange(ref _exiting, 1);
+
         var clean = await DisconnectWithTimeoutAsync();
 
         // Exiting after a failed rollback would strand the system proxy pointing
@@ -353,8 +366,32 @@ public partial class App : Application
         // to close on "we know nothing" is how the app became unclosable.
         if (clean && AppController.Instance.ErrorCode == "ERR_ROLLBACK_INCOMPLETE")
         {
+            // Staying, so this is not an exit after all — and an update that
+            // lands later still needs to be able to close the app.
+            Interlocked.Exchange(ref _exiting, 0);
             _window?.DispatcherQueue.TryEnqueue(() => _window?.ShowNearTray());
             return;
+        }
+
+        // Going anyway, so this is the free moment: an update that was already
+        // downloaded and verified goes in now, and the next launch is current.
+        //
+        // Closing is the half of the fix that costs the user nothing. The other
+        // half runs at start-up, for the times this is never reached — a crash,
+        // a sign-out, a laptop that simply loses power. Before either existed,
+        // installing needed the app to be open, to have been open a while, and
+        // to be idle, all at once; the machine this was written on had a
+        // verified 48 MB installer sitting unrun in %TEMP% for three days while
+        // the app went on reporting a version four months old.
+        //
+        // No relaunch: they asked for it to close.
+        try
+        {
+            if (_updates is not null) await _updates.InstallPendingAsync(relaunch: false);
+        }
+        catch (Exception)
+        {
+            // An update must never be the reason the app cannot be closed.
         }
 
         _window?.DispatcherQueue.TryEnqueue(() =>

--- a/windows/Relay.Core/PendingUpdate.cs
+++ b/windows/Relay.Core/PendingUpdate.cs
@@ -1,0 +1,127 @@
+using System.Text.Json;
+
+namespace Relay.Core;
+
+/// <summary>
+/// A verified installer left on disk, so that a <em>later launch</em> can be
+/// the one that runs it.
+///
+/// This exists because of a bug found on a real machine rather than in a test.
+/// The laptop this was written on was running 1.9.3-test from 16 August while
+/// 2.8.1 was published, and the reason was sitting in <c>%TEMP%\Relay-update</c>:
+/// a 48,536,231-byte <c>Relay-Setup-x64.exe</c>, downloaded on 9 September and
+/// checksum-verified — it would have been deleted otherwise — still there,
+/// unrun, three days later.
+///
+/// <see cref="UpdateService"/> could only install inside a single run of the
+/// process: start, wait two minutes, check, download, then wait for the state
+/// to be Idle. Someone who opens Relay, connects straight away, and closes it
+/// when they are done is never Idle during that window, and the next launch
+/// began again from nothing. The installer was re-found, re-downloaded, and
+/// re-abandoned, forever, and the app could not tell it had already fetched
+/// the very bytes it needed.
+///
+/// So the fact is written down. With this record on disk, installing can happen
+/// at two moments that are guaranteed to arrive — the app closing, and the app
+/// starting — instead of at a coincidence.
+///
+/// Read and written with <see cref="JsonDocument"/> and <see cref="Utf8JsonWriter"/>
+/// rather than a serializer: the file lives in a world-writable temp directory
+/// and names something this app is about to execute, so every field is checked
+/// explicitly and anything unexpected reads as "no pending update".
+/// </summary>
+/// <param name="Version">The release this installer is, e.g. "2.8.1".</param>
+/// <param name="Installer">Its file name — never a path. See <see cref="Load"/>.</param>
+/// <param name="Sha256">
+/// The hash the release published, which the download already matched. Kept so
+/// it can be matched <em>again</em> before the file is run: by then it has been
+/// sitting in a temp directory across at least one reboot.
+/// </param>
+public sealed record PendingUpdate(string Version, string Installer, string Sha256)
+{
+    /// <summary>Beside the installer it describes, so both are cleaned up together.</summary>
+    public const string FileName = "pending-update.json";
+
+    /// <summary>
+    /// Where downloads land. The same directory <see cref="UpdateInstaller"/>
+    /// defaults to; a temp directory on purpose, so a half-finished update the
+    /// app never got around to is something Windows is allowed to sweep away.
+    /// </summary>
+    public static string DefaultDirectory => Path.Combine(Path.GetTempPath(), "Relay-update");
+
+    /// <summary>Records a verified download. Never throws: losing the note is not worth a crash.</summary>
+    public static void Save(string directory, PendingUpdate pending)
+    {
+        try
+        {
+            Directory.CreateDirectory(directory);
+            using var stream = new FileStream(
+                Path.Combine(directory, FileName), FileMode.Create, FileAccess.Write, FileShare.None);
+            using var writer = new Utf8JsonWriter(stream);
+            writer.WriteStartObject();
+            writer.WriteString("version", pending.Version);
+            writer.WriteString("installer", pending.Installer);
+            writer.WriteString("sha256", pending.Sha256);
+            writer.WriteEndObject();
+        }
+        catch (Exception)
+        {
+            // Worst case the update is downloaded again next cycle, which is
+            // where this was before the file existed.
+        }
+    }
+
+    /// <summary>
+    /// The recorded update, or null when there is none, the file is unreadable,
+    /// or it does not say all three things.
+    ///
+    /// <paramref name="directory"/> plus the recorded name is a path this app
+    /// will hand to <c>Process.Start</c>, so a name that is not a bare file name
+    /// is rejected outright rather than combined and hoped about.
+    /// </summary>
+    public static PendingUpdate? Load(string directory)
+    {
+        try
+        {
+            var path = Path.Combine(directory, FileName);
+            if (!File.Exists(path)) return null;
+
+            using var document = JsonDocument.Parse(File.ReadAllText(path));
+            var root = document.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return null;
+
+            var version = Text(root, "version");
+            var installer = Text(root, "installer");
+            var sha256 = Text(root, "sha256");
+            if (version is null || installer is null || sha256 is null) return null;
+
+            // Not a path, not a traversal, not empty.
+            if (installer != Path.GetFileName(installer)) return null;
+
+            return new PendingUpdate(version, installer, sha256);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Forgets the record. Never throws.</summary>
+    public static void Clear(string directory)
+    {
+        try
+        {
+            var path = Path.Combine(directory, FileName);
+            if (File.Exists(path)) File.Delete(path);
+        }
+        catch (Exception)
+        {
+        }
+    }
+
+    private static string? Text(JsonElement root, string name) =>
+        root.TryGetProperty(name, out var element) && element.ValueKind == JsonValueKind.String
+        && !string.IsNullOrWhiteSpace(element.GetString())
+            ? element.GetString()
+            : null;
+}

--- a/windows/Relay.Core/UpdateInstaller.cs
+++ b/windows/Relay.Core/UpdateInstaller.cs
@@ -65,7 +65,7 @@ public sealed class UpdateInstaller(HttpClient? http = null)
         Action<string>? run = null,
         CancellationToken token = default)
     {
-        var (outcome, path) = await DownloadAsync(update, downloadDirectory, token)
+        var (outcome, path, _) = await DownloadAsync(update, downloadDirectory, token)
             .ConfigureAwait(false);
         return path is null ? outcome : Run(path, run);
     }
@@ -87,19 +87,22 @@ public sealed class UpdateInstaller(HttpClient? http = null)
     /// better of the two mistakes.
     /// </summary>
     /// <returns>
-    /// The verified installer's path, or null with the reason it is not there.
+    /// The verified installer's path and the hash it matched, or nulls with the
+    /// reason it is not there. The hash comes back so the caller can write it
+    /// down — see <see cref="PendingUpdate"/> — and check the file again before
+    /// running it on some later launch.
     /// </returns>
-    public async Task<(Outcome Outcome, string? Path)> DownloadAsync(
+    public async Task<(Outcome Outcome, string? Path, string? Sha256)> DownloadAsync(
         UpdateCheck.Available update,
         string? downloadDirectory = null,
         CancellationToken token = default)
     {
-        if (string.IsNullOrWhiteSpace(update.ChecksumsUrl)) return (Outcome.Unverifiable, null);
+        if (string.IsNullOrWhiteSpace(update.ChecksumsUrl)) return (Outcome.Unverifiable, null, null);
 
         var name = FileName(update.Url);
-        if (!name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) return (Outcome.Unavailable, null);
+        if (!name.EndsWith(".exe", StringComparison.OrdinalIgnoreCase)) return (Outcome.Unavailable, null, null);
 
-        var directory = downloadDirectory ?? Path.Combine(Path.GetTempPath(), "Relay-update");
+        var directory = downloadDirectory ?? PendingUpdate.DefaultDirectory;
         var target = Path.Combine(directory, name);
         // Downloaded under a name nothing will run, then renamed once the hash
         // matches. A rejected or half-finished download must never be left on
@@ -113,7 +116,7 @@ public sealed class UpdateInstaller(HttpClient? http = null)
             Directory.CreateDirectory(directory);
             var sums = await _http.GetStringAsync(update.ChecksumsUrl, token).ConfigureAwait(false);
             var found = HashFor(sums, name);
-            if (found is null) return (Outcome.Unverifiable, null);
+            if (found is null) return (Outcome.Unverifiable, null, null);
             expected = found;
 
             actual = await DownloadAndHashAsync(update.Url, partial, token).ConfigureAwait(false);
@@ -121,14 +124,13 @@ public sealed class UpdateInstaller(HttpClient? http = null)
         catch (Exception)
         {
             Discard(partial);
-            return (Outcome.Unavailable, null);
+            return (Outcome.Unavailable, null, null);
         }
 
-        if (!CryptographicOperations.FixedTimeEquals(
-                Convert.FromHexString(actual), Convert.FromHexString(expected)))
+        if (!Matches(actual, expected))
         {
             Discard(partial);
-            return (Outcome.ChecksumMismatch, null);
+            return (Outcome.ChecksumMismatch, null, null);
         }
 
         try
@@ -138,23 +140,78 @@ public sealed class UpdateInstaller(HttpClient? http = null)
         catch (Exception)
         {
             Discard(partial);
-            return (Outcome.Unavailable, null);
+            return (Outcome.Unavailable, null, null);
         }
 
-        return (Outcome.Started, target);
+        return (Outcome.Started, target, expected);
     }
 
-    /// <summary>Runs an installer that <see cref="DownloadAsync"/> already verified.</summary>
-    public Outcome Run(string path, Action<string>? run = null)
+    /// <summary>
+    /// Runs an installer whose hash has been checked.
+    /// </summary>
+    /// <param name="relaunch">
+    /// Whether Setup should start Relay again when it finishes. True for an
+    /// update that closed a running app — leaving the tray empty reads as a
+    /// crash. False when the app is already on its way out because the user
+    /// asked it to close: reopening it then is not an update, it is a refusal
+    /// to quit.
+    /// </param>
+    public Outcome Run(string path, Action<string>? run = null, bool relaunch = true)
     {
         try
         {
-            (run ?? Launch)(path);
+            if (run is not null) run(path);
+            else Launch(path, relaunch);
             return Outcome.Started;
         }
         catch (Exception)
         {
             return Outcome.Unavailable;
+        }
+    }
+
+    /// <summary>
+    /// The SHA-256 of a file already on disk, lower-case hex.
+    ///
+    /// Used to check a download again before running it. Between being verified
+    /// and being run it may have sat in a temp directory across a reboot, and
+    /// that directory is writable by anything running as this user. Re-reading
+    /// fifty megabytes costs a fraction of a second, once, and only when there
+    /// is something pending; running unverified bytes that replace a program
+    /// which routes a phone's entire connection costs rather more.
+    /// </summary>
+    public static async Task<string> HashFileAsync(string path, CancellationToken token = default)
+    {
+        using var hash = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        await using var file = new FileStream(
+            path, FileMode.Open, FileAccess.Read, FileShare.Read,
+            bufferSize: 128 * 1024, useAsync: true);
+
+        var buffer = new byte[128 * 1024];
+        int read;
+        while ((read = await file.ReadAsync(buffer, token).ConfigureAwait(false)) > 0)
+        {
+            hash.AppendData(buffer, 0, read);
+        }
+        return Convert.ToHexString(hash.GetHashAndReset()).ToLowerInvariant();
+    }
+
+    /// <summary>
+    /// Constant-time comparison of two hex hashes, false for anything that is
+    /// not a pair of well-formed hex strings of the same length.
+    /// </summary>
+    public static bool Matches(string? actual, string? expected)
+    {
+        if (actual is null || expected is null) return false;
+        if (actual.Length != expected.Length || actual.Length == 0) return false;
+        try
+        {
+            return CryptographicOperations.FixedTimeEquals(
+                Convert.FromHexString(actual), Convert.FromHexString(expected));
+        }
+        catch (FormatException)
+        {
+            return false;
         }
     }
 
@@ -214,15 +271,48 @@ public sealed class UpdateInstaller(HttpClient? http = null)
     /// itself would have sat on a dialog nobody was there to answer. The caller
     /// has to leave, and <see cref="Relaunch"/> is how it gets to come back.
     /// </summary>
-    private static void Launch(string installer) =>
+    private static void Launch(string installer, bool relaunch) =>
         System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(installer)
         {
-            // Not /VERYSILENT: a person who did not press anything should still
-            // see that something is installing. /SILENT shows progress and no
-            // questions, which is the honest middle.
-            Arguments = $"/SILENT /NORESTART {Relaunch}",
+            Arguments = ArgumentsFor(InstallDirectory, relaunch),
             UseShellExecute = true,
         });
+
+    /// <summary>
+    /// Where this build of Relay is installed — the folder the running
+    /// executable sits in, with no trailing separator.
+    /// </summary>
+    public static string InstallDirectory =>
+        AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+    /// <summary>
+    /// The command line an update is run with. Pure, so the decisions in it can
+    /// be asserted without starting anything.
+    ///
+    /// <c>/DIR</c> is the one that is not obvious, and it is here because of a
+    /// failure seen on a real machine. Inno remembers the previous install's
+    /// location in <c>{AppId}_is1</c> and, under <c>/SILENT</c>, silently
+    /// accepts it as the default — there is no dialog for anyone to correct.
+    /// On the laptop this was found on, that registry entry still read
+    /// <c>InstallLocation=C:\RelayTest\</c> from a test install whose folder had
+    /// long since been deleted, while the real Relay lived somewhere else
+    /// entirely and the Start Menu shortcut pointed there. A silent update would
+    /// have recreated <c>C:\RelayTest</c>, installed 2.8.1 into it perfectly,
+    /// and left every way the user actually starts Relay pointing at the old
+    /// build. It would have reported success and changed nothing.
+    ///
+    /// Naming the running app's own folder makes an update land on the app being
+    /// updated, whatever the registry remembers.
+    ///
+    /// Not <c>/VERYSILENT</c>: a person who did not press anything should still
+    /// see that something is installing. <c>/SILENT</c> shows progress and asks
+    /// no questions, which is the honest middle.
+    /// </summary>
+    public static string ArgumentsFor(string installDirectory, bool relaunch)
+    {
+        var arguments = $"/SILENT /NORESTART /DIR=\"{installDirectory}\"";
+        return relaunch ? $"{arguments} {Relaunch}" : arguments;
+    }
 
     /// <summary>
     /// Asks Setup to start Relay again when it is done.

--- a/windows/Relay.Core/UpdateService.cs
+++ b/windows/Relay.Core/UpdateService.cs
@@ -39,13 +39,33 @@ public sealed class UpdateService(
     Action<UpdateNotice, string> notify,
     Func<UpdateCheck>? checkFactory = null,
     UpdateInstaller? installer = null,
-    TimeSpan? idleWait = null)
+    TimeSpan? idleWait = null,
+    string? downloadDirectory = null,
+    Action<string>? runInstaller = null)
 {
     /// <summary>
-    /// Long enough that launching Relay never waits on GitHub, short enough
-    /// that someone who opens it and leaves it running finds out today.
+    /// Long enough that launching Relay is not competing with a download while
+    /// someone is trying to connect, short enough that a session which lasts a
+    /// couple of minutes still checks at all.
+    ///
+    /// It was two minutes, and that turned out to be most of a bug. Relay is
+    /// opened to be connected to, and plenty of sessions are shorter than two
+    /// minutes end to end — for those the check never ran once, on any launch,
+    /// ever. The delay is not what keeps the launch fast; the check has always
+    /// been on a background thread.
     /// </summary>
-    public static readonly TimeSpan FirstCheckDelay = TimeSpan.FromMinutes(2);
+    public static readonly TimeSpan FirstCheckDelay = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// How long to let a launch settle before installing something that was
+    /// downloaded on an earlier one.
+    ///
+    /// Short, because this is the moment the whole design turns on. Not zero,
+    /// because the app closing itself before its window has finished appearing
+    /// looks like a crash rather than an update, and the toast that explains it
+    /// needs somewhere to land.
+    /// </summary>
+    public static readonly TimeSpan PendingInstallDelay = TimeSpan.FromSeconds(3);
 
     /// <summary>
     /// A day. Relay is a tray app that can run for weeks, so checking only at
@@ -68,6 +88,7 @@ public sealed class UpdateService(
     private const string Idle = "Idle";
 
     private readonly UpdateInstaller _installer = installer ?? new UpdateInstaller();
+    private readonly string _directory = downloadDirectory ?? PendingUpdate.DefaultDirectory;
     private CancellationTokenSource? _loop;
 
     /// <summary>The version already announced, so a daily check does not nag.</summary>
@@ -92,6 +113,19 @@ public sealed class UpdateService(
     {
         try
         {
+            // Before anything is checked or fetched: an installer this app
+            // already downloaded and verified on some earlier launch.
+            //
+            // This is the moment the previous design never had. Installing was
+            // only ever attempted inside one run of the process — start, wait,
+            // check, download, wait for Idle — so it depended on a coincidence:
+            // the app had to still be open, long enough, and idle at the right
+            // time. Someone who opens Relay, connects immediately and closes it
+            // when they are done satisfies that never. Start-up satisfies it by
+            // definition, because nothing is connected yet.
+            await Task.Delay(PendingInstallDelay, token).ConfigureAwait(false);
+            if (await InstallPendingAsync(relaunch: true, token).ConfigureAwait(false)) return;
+
             await Task.Delay(FirstCheckDelay, token).ConfigureAwait(false);
             while (!token.IsCancellationRequested)
             {
@@ -131,6 +165,20 @@ public sealed class UpdateService(
             notify(UpdateNotice.Available, update.Version);
         }
 
+        // Already on disk, from this launch or an earlier one.
+        //
+        // Without this the daily check pulls fifty megabytes again to arrive at
+        // exactly the bytes already sitting in the download directory — every
+        // day, for as long as the install has nowhere to happen. On the
+        // connections Relay is built for, that traffic is the user's phone data.
+        var pending = PendingUpdate.Load(_directory);
+        if (pending is not null && pending.Version == update.Version &&
+            File.Exists(Path.Combine(_directory, pending.Installer)))
+        {
+            await InstallPendingAsync(relaunch: true, token).ConfigureAwait(false);
+            return;
+        }
+
         // Fetch first, connected or not.
         //
         // This used to wait for idle before downloading, and on the networks
@@ -141,8 +189,8 @@ public sealed class UpdateService(
         // api.github.com in under a second and cannot open the asset host at
         // all. Only running the installer has to wait, because only running it
         // costs someone their connection.
-        var (outcome, installer) = await _installer
-            .DownloadAsync(update, token: token).ConfigureAwait(false);
+        var (outcome, installer, sha256) = await _installer
+            .DownloadAsync(update, _directory, token).ConfigureAwait(false);
 
         if (installer is null)
         {
@@ -156,6 +204,16 @@ public sealed class UpdateService(
             // and neither is worth interrupting anyone about.
             return;
         }
+
+        // Write down what is on disk before trying to use it.
+        //
+        // Everything below can fail to install for perfectly ordinary reasons —
+        // a tunnel that stays up all day, the app being closed mid-wait — and
+        // before this line those bytes were simply forgotten, then fetched
+        // again on the next launch and forgotten again. Recording them is what
+        // lets the app closing, or opening, be the thing that finishes the job.
+        PendingUpdate.Save(_directory, new PendingUpdate(
+            update.Version, Path.GetFileName(installer), sha256 ?? string.Empty));
 
         // Now wait for a moment where replacing the app costs nothing —
         // bounded, so a machine that stays connected all day tries again next
@@ -175,9 +233,100 @@ public sealed class UpdateService(
         }
         if (currentState() != Idle) return;
 
-        if (_installer.Run(installer) == UpdateInstaller.Outcome.Started)
+        // Cleared first: if Run fails, the next cycle should find out for itself
+        // rather than a later launch retrying bytes that already would not go.
+        PendingUpdate.Clear(_directory);
+        if (_installer.Run(installer, runInstaller) == UpdateInstaller.Outcome.Started)
         {
             notify(UpdateNotice.Installing, update.Version);
         }
+    }
+
+    /// <summary>
+    /// Runs an update that an earlier session downloaded and verified, if there
+    /// is one and this is a moment where running it costs nothing.
+    ///
+    /// Called at two points, both chosen because they are certain to happen
+    /// rather than likely to: when the app starts, and when the app is closing.
+    /// Between them they cover the case this was written for — a person who
+    /// opens Relay, connects straight away, and quits when they are finished,
+    /// who under the old design never updated at all.
+    ///
+    /// Public so the app can call it on the way out, and so a test can drive it
+    /// without a launch.
+    /// </summary>
+    /// <param name="relaunch">
+    /// Whether Setup should start Relay again afterwards. True at start-up, so
+    /// the app the user just opened comes back. False on the way out: they
+    /// asked it to close.
+    /// </param>
+    /// <returns>True when an installer was actually started.</returns>
+    public async Task<bool> InstallPendingAsync(bool relaunch, CancellationToken token = default)
+    {
+        var pending = PendingUpdate.Load(_directory);
+        if (pending is null) return false;
+
+        var path = Path.Combine(_directory, pending.Installer);
+
+        // Already current. The ordinary way here is the happy one: the update
+        // installed, this build *is* that version, and the note is stale. Also
+        // covers someone who installed a newer build by hand in the meantime.
+        var pendingVersion = UpdateCheck.Parse(pending.Version);
+        var current = UpdateCheck.Parse(currentVersion);
+        if (pendingVersion is null || current is null ||
+            UpdateCheck.Compare(pendingVersion, current) <= 0)
+        {
+            Forget(path);
+            return false;
+        }
+
+        if (!File.Exists(path))
+        {
+            // A temp directory that Windows swept, most likely. Nothing is
+            // wrong; the next check downloads it again.
+            PendingUpdate.Clear(_directory);
+            return false;
+        }
+
+        // Verified once at download time, and again here. In between it has sat
+        // in a directory anything running as this user can write to, across at
+        // least one launch and possibly a reboot, and what it does when run is
+        // replace the program that carries the user's whole connection.
+        string actual;
+        try
+        {
+            actual = await UpdateInstaller.HashFileAsync(path, token).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            return false; // unreadable right now; say nothing, try next launch
+        }
+
+        if (!UpdateInstaller.Matches(actual, pending.Sha256))
+        {
+            // Never quietly retried: these are not the bytes the release
+            // published, whatever the reason.
+            Forget(path);
+            notify(UpdateNotice.Refused, pending.Version);
+            return false;
+        }
+
+        // Start-up is Idle by construction and so is a close that has already
+        // disconnected, but neither is worth assuming — an auto-connect at login
+        // would make the first one false.
+        if (currentState() != Idle) return false;
+
+        PendingUpdate.Clear(_directory);
+        if (_installer.Run(path, runInstaller, relaunch) != UpdateInstaller.Outcome.Started) return false;
+
+        notify(UpdateNotice.Installing, pending.Version);
+        return true;
+    }
+
+    /// <summary>Drops the record and the installer it names. Never throws.</summary>
+    private void Forget(string installerPath)
+    {
+        PendingUpdate.Clear(_directory);
+        try { if (File.Exists(installerPath)) File.Delete(installerPath); } catch (Exception) { }
     }
 }


### PR DESCRIPTION
## The evidence

Found on a laptop, not in CI.

| | |
|---|---|
| Installed build | **`1.9.3-test`**, 16 August |
| Published release | **2.8.1** |
| `%TEMP%\Relay-update\Relay-Setup-x64.exe` | **48,536,231 bytes, downloaded 9 September 01:42** |
| Its state on 12 September | **still there, never run** |

Its SHA-256 is `5ce66a8c…558b6d2d5`, which is **2.8.0's published hash, to the
byte**. So the check ran, the release was found, the bytes were fetched, and
they were proved — an unverified download is deleted, not kept.

Then nothing used them. For long enough that 2.8.1 shipped on 10 September and
the installer the app was sitting on went stale.

## Why

Installing was only ever attempted inside **one run of the process**:

```
start → wait 2 min → check → download → wait for state == Idle → install
```

Relay is opened in order to be connected to. Someone who opens it, connects, and
closes it when they are finished is **never Idle inside that window**. Every
launch started over: found the release again, downloaded it again, abandoned it
again — and the app had no way to tell it had already fetched the exact bytes it
needed.

## Three things were wrong

**1. Nothing survived the process.** A verified download now leaves a note
beside itself — version, file name, hash — so a later launch can find it.
`PendingUpdate` reads that note with `JsonDocument` and checks every field
explicitly: it lives in a world-writable temp directory and names something this
app will execute, so an installer name that is not a bare file name is refused
outright rather than combined with a path and hoped about. **The hash is checked
again before the file runs.** It has been on disk across at least one launch and
possibly a reboot; verifying once is not the same as verifying.

**2. Installing waited for a coincidence.** It now happens at two moments that
are certain rather than likely:

- **when the app closes** — costs the user nothing, so it is the preferred one,
  and it does not pass `/relaunch`: they asked for it to close;
- **three seconds after it starts** — for the times a clean exit never came
  (a crash, a sign-out, a laptop losing power). Start-up is idle by definition.

This is the difference from Telegram Desktop, which was the ask.

**3. The daily check refetched what was already there.** Fifty megabytes a day
to arrive at the same bytes is not a check. On the connections Relay exists for,
that traffic is the user's phone data.

And `FirstCheckDelay` was two minutes — longer than plenty of whole sessions, for
which the check had **never run once, on any launch**. Now thirty seconds. The
delay was never what keeps launching fast; the check has always been on a
background thread.

## A second, independent bug

The update now passes **`/DIR` for the folder the running app is in**.

Inno remembers the previous install's location in `{AppId}_is1` and, under
`/SILENT`, accepts it with no dialog for anyone to correct. On this same laptop
that entry still read:

```
DisplayName     : Relay version 2.5.11
InstallLocation : C:\RelayTest\
UninstallString : "C:\RelayTest\unins000.exe"
```

`C:\RelayTest` **does not exist** — it was a test install, deleted months ago —
while the real Relay lives on another drive and every shortcut points there.

A silent update would have recreated `C:\RelayTest`, installed 2.8.1 into it
flawlessly, reported success, and changed nothing the user could see. Naming the
running app's own folder makes an update land on the app being updated, whatever
the registry remembers.

## Tests

`UpdateAcrossLaunchesTests` — the regression suite. Each is a way the bug comes
back:

| assertion | what it catches |
|---|---|
| an update fetched while connected installs on the **next launch** | **the bug itself** |
| still will not install while a tunnel is up | the fix being taken as permission to interrupt a call |
| forgets a pending update this build already is | reinstalling the running version on every start, forever |
| refuses a pending installer that changed on disk | trusting a verify that happened in another process |
| silence when the temp directory was swept | telling people about something that is not wrong |
| `/DIR` names the app's own folder | the `C:\RelayTest` class of failure |
| the close path does not pass `/relaunch` | an app that will not stay closed |
| the first check fits inside an ordinary session | a delay longer than the session it runs in |

`PendingUpdateTests` — the note itself, including that a name with separators in
it is refused and that rubbish reads as "nothing pending" rather than throwing on
a path that runs during start-up.

`UpdateServiceTests` now download into directories of their own. Sharing the
app's real one was untidy before and became **dangerous** the moment a download
started leaving a note behind: a test run would have told an installed Relay that
seventeen bytes reading `pretend installer` were version 99.0.0.

## Not proven here

CI builds and runs the unit tests. That an update actually installs end to end
on a real machine is checked separately — see the comment on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
