### PR TITLE
Make the log answer the question instead of raising it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ reason and an ADR.
 | What goes in the QR? | `shared/qr-payload.schema.json` |
 | What are the legal states? | `shared/connection-states.json` |
 | What does error X tell the user? | `docs/errors.md` |
+| How do I read a user's log? | `docs/diagnostics.md` |
 | What has hardware still not proven? | `docs/testing.md` |
 | How does a release get cut? | `docs/release.md` |
 

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ if it is killed. A dead Relay cannot leave your machine unable to resolve names.
 | **Start with Windows** | A switch in Advanced, using the per-user key — no elevation |
 | **Live statistics** | Speed, totals, tunnel latency and connection duration, read from the adapter |
 | **Connect notification** | When the tunnel comes up — and a warning instead if it came up unprotected |
-| **Diagnostic report** | One button, copies what a bug report needs — and nothing is uploaded |
+| **Diagnostic report** | One button, copies what a bug report needs — levelled, with every interface the phone had at the moment it failed, and nothing uploaded ([how to read one](docs/diagnostics.md)) |
 
 </details>
 

--- a/android/app/src/main/kotlin/io/relay/app/net/LinkSnapshot.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/LinkSnapshot.kt
@@ -1,0 +1,120 @@
+package io.relay.app.net
+
+import java.net.Inet4Address
+import java.net.NetworkInterface
+
+/**
+ * Every network link the phone has, and what Relay made of each one.
+ *
+ * Written after reading a real user's diagnostic log. It said, seven times:
+ *
+ * ```
+ * No usable Wi-Fi or hotspot interface found
+ * ```
+ *
+ * which is true, and tells whoever reads it nothing. Was the cable not plugged
+ * in? Plugged in with tethering off? Tethering on but the interface still
+ * negotiating? Was there a Wi-Fi link that got rejected for looking like a VPN?
+ * Four completely different faults with four different fixes, and the log could
+ * not distinguish them. It took a round trip to the person, in another country,
+ * on Telegram, to learn that they had turned tethering on and pressed the button
+ * immediately — which was the answer, and which one line here would have given.
+ *
+ * So this enumerates everything, including the links [LocalAddress] deliberately
+ * refuses, and records the refusal. A line like
+ *
+ * ```
+ * rndis0(no-ipv4) wlan0(192.168.1.5 wifi score-3) tun0(10.8.0.2 vpn)
+ * ```
+ *
+ * answers all four at a glance.
+ *
+ * The formatting is pure and unit-tested; only [take] touches the platform.
+ */
+object LinkSnapshot {
+
+    /**
+     * One interface as Relay saw it.
+     *
+     * @param ipv4 its site-local IPv4, or null when it has none yet — which is
+     *   exactly what USB tethering looks like for the first few seconds.
+     * @param verdict why it was or was not advertisable. See [verdictFor].
+     * @param score [LocalAddress.score], for the links that had one. Two usable
+     *   links and a surprising choice is a fault that has happened twice.
+     */
+    data class Link(
+        val name: String,
+        val ipv4: String?,
+        val verdict: String,
+        val score: Int? = null,
+    )
+
+    /** What the phone's links look like right now. Never throws. */
+    fun take(): List<Link> = try {
+        NetworkInterface.getNetworkInterfaces()?.toList().orEmpty()
+            .filter { runCatching { !it.isLoopback }.getOrDefault(false) }
+            .map { nic ->
+                val name = nic.name.lowercase()
+                val up = runCatching { nic.isUp }.getOrDefault(false)
+                val ipv4 = runCatching {
+                    nic.inetAddresses.toList()
+                        .filterIsInstance<Inet4Address>()
+                        .firstOrNull { it.isSiteLocalAddress }
+                        ?.hostAddress
+                }.getOrNull()
+                val verdict = verdictFor(name, ipv4, up)
+                Link(
+                    name = name,
+                    ipv4 = ipv4,
+                    verdict = verdict,
+                    score = if (verdict == USABLE && ipv4 != null) {
+                        LocalAddress.score(name, ipv4)
+                    } else {
+                        null
+                    },
+                )
+            }
+    } catch (_: Exception) {
+        emptyList()
+    }
+
+    /**
+     * What Relay decided about one link, in the order the decisions are made.
+     *
+     * Order matters and is the point: a `tun0` that is down is reported as down,
+     * not as a VPN, because "the VPN is not running" and "the VPN is running and
+     * we ignored it" send a reader to different places.
+     */
+    internal fun verdictFor(name: String, ipv4: String?, up: Boolean): String = when {
+        !up -> "down"
+        ipv4 == null -> NO_IPV4
+        else -> LocalAddress.rejection(name) ?: LocalAddress.linkKind(name) ?: USABLE
+    }
+
+    /**
+     * One line naming every link, its address and its verdict.
+     *
+     * One line on purpose. The log is a ring buffer a person scrolls on a phone
+     * and then pastes into a chat; a block of six lines per failure pushes the
+     * thing that failed off the top of what anybody reads.
+     */
+    fun summarise(links: List<Link>): String =
+        if (links.isEmpty()) "no interfaces at all"
+        else links.joinToString(" ") { link ->
+            val detail = listOfNotNull(
+                link.ipv4,
+                link.verdict.takeIf { it != USABLE },
+                link.score?.let { "score-$it" },
+            ).joinToString(" ")
+            if (detail.isEmpty()) link.name else "${link.name}($detail)"
+        }
+
+    /** Advertisable, and of a kind [LocalAddress.linkKind] has no name for. */
+    private const val USABLE = "usable"
+
+    /**
+     * Up, and no site-local IPv4 yet. The one that mattered: a cable whose
+     * tethering was switched on a second ago looks exactly like this.
+     */
+    private const val NO_IPV4 = "no-ipv4"
+}

--- a/android/app/src/main/kotlin/io/relay/app/net/LocalAddress.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/LocalAddress.kt
@@ -122,15 +122,42 @@ object LocalAddress {
     private val AP_HINTS = listOf("ap", "swlan", "softap", "wlan1", "wigig")
 
     /**
-     * Substrings (not prefixes — 464XLAT names its link `v4-rmnet_data0`) of
-     * interfaces whose addresses are unreachable from the client. See issue #18:
-     * with hotspot and Wi-Fi both off, `rmnet_data0`'s carrier address was the only
-     * candidate left and got advertised, producing a QR that could never connect.
+     * Why a link was rejected, or null when it was not.
+     *
+     * Exists so a diagnostic log can say *which* kind of unreachable a link was.
+     * "No usable Wi-Fi, hotspot or USB link" is true and unhelpful on a phone
+     * that had four interfaces up; "the cable was there and had no address yet"
+     * is the same fact in a form somebody can act on. See [LinkSnapshot].
      */
-    private val UNREACHABLE_HINTS = listOf(
-        "rmnet", "ccmni", "pdp", "seth", "wwan", "qmi", "ppp", // cellular
-        "tun", "ipsec", "dummy",                               // VPN / placeholder
-        // No "tap" here: it is a substring of the legitimate `softap0` hotspot,
-        // and Android VPNs land on tun anyway.
-    )
+    internal fun rejection(interfaceName: String): String? = when {
+        CELLULAR_HINTS.any { interfaceName.contains(it) } -> "cellular"
+        VPN_HINTS.any { interfaceName.contains(it) } -> "vpn"
+        else -> null
+    }
+
+    /** Substrings of the carrier's own links. 464XLAT names one `v4-rmnet_data0`. */
+    private val CELLULAR_HINTS = listOf("rmnet", "ccmni", "pdp", "seth", "wwan", "qmi", "ppp")
+
+    /**
+     * VPN tunnels and placeholders.
+     *
+     * No "tap" here: it is a substring of the legitimate `softap0` hotspot, and
+     * Android VPNs land on tun anyway.
+     */
+    private val VPN_HINTS = listOf("tun", "ipsec", "dummy")
+
+    /**
+     * Substrings (not prefixes) of interfaces whose addresses are unreachable
+     * from the client. Both halves hand out site-local IPv4 — a carrier commonly
+     * uses 10.0.0.0/8, a tun sits on 10.x or 172.16.x — so `isSiteLocalAddress`
+     * alone will happily advertise an address no PC can reach. See issue #18:
+     * with hotspot and Wi-Fi both off, `rmnet_data0`'s carrier address was the
+     * only candidate left and got advertised, producing a QR that could never
+     * connect.
+     *
+     * Derived from the two named lists rather than written out again, so the
+     * reason a link is rejected and the fact that it is rejected cannot drift
+     * apart.
+     */
+    private val UNREACHABLE_HINTS = CELLULAR_HINTS + VPN_HINTS
 }

--- a/android/app/src/main/kotlin/io/relay/app/net/PairingServer.kt
+++ b/android/app/src/main/kotlin/io/relay/app/net/PairingServer.kt
@@ -123,20 +123,30 @@ class PairingServer(
                 // reporting the phone as unreachable.
                 Request.WRONG_VERSION -> {
                     writer.appendLine(error(ERR_VERSION)); writer.flush()
-                    LocalLog.add("A PC at $address asked in a newer pairing version")
+                    LocalLog.warn(
+                        LocalLog.Area.PAIRING, "A PC asked in a newer pairing version",
+                        "pc" to address,
+                    )
                 }
 
                 Request.PAIR -> {
-                    LocalLog.add("A PC at $address asked to pair")
+                    LocalLog.info(LocalLog.Area.PAIRING, "A PC asked to pair", "pc" to address)
                     val allowed = gate.authorize(address)
                     val config = configuration(address)
                     if (!allowed || config == null) {
                         writer.appendLine(error(ERR_DENIED)); writer.flush()
-                        LocalLog.add("Refused $address")
+                        // Warn, not error: the overwhelmingly common reason is
+                        // that the person tapped Deny, which is the feature
+                        // working. A reader still wants to find it quickly.
+                        LocalLog.warn(
+                            LocalLog.Area.PAIRING, "Refused a PC",
+                            "pc" to address,
+                            "reason" to if (!allowed) "not-allowed" else "no-configuration",
+                        )
                         return
                     }
                     writer.appendLine(accepted(config)); writer.flush()
-                    LocalLog.add("Sent the configuration to $address")
+                    LocalLog.info(LocalLog.Area.PAIRING, "Sent the configuration", "pc" to address)
                 }
             }
         } catch (_: IOException) {

--- a/android/app/src/main/kotlin/io/relay/app/service/DiagnosticReport.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/DiagnosticReport.kt
@@ -50,14 +50,26 @@ object DiagnosticReport {
         appendLine("ABIs:     ${Build.SUPPORTED_ABIS?.joinToString(", ") ?: UNKNOWN}")
         appendLine("State:    ${describe(state)}")
         appendLine()
-        appendLine("Log (most recent last, times in seconds since sharing started)")
-        appendLine("-------------------------------------------------------------")
+        // "since sharing started" is what this said, and it was wrong: the clock
+        // runs from the moment the app's process started, so a report from a
+        // phone that had been open for an hour and a half opened at 4999.58 and
+        // read like a timestamp from a different machine. A log's own header
+        // being wrong is a special kind of expensive — it is the one line a
+        // reader trusts before they have read anything else.
+        appendLine("Log (most recent last, seconds since the app started)")
+        appendLine("----------------------------------------------------")
         if (entries.isEmpty()) {
             appendLine("(empty)")
         } else {
             for (entry in entries) {
-                appendLine("%8.2f  %s".format(entry.elapsedMs / 1000.0, entry.message))
+                appendLine(entry.render())
             }
+            appendLine()
+            val errors = entries.count { it.level == LocalLog.Level.ERROR }
+            val warnings = entries.count { it.level == LocalLog.Level.WARN }
+            // Read first, and often the only thing read. A report is pasted into
+            // a chat where whoever answers it is scrolling on a phone.
+            appendLine("$errors error(s), $warnings warning(s) in ${entries.size} line(s).")
         }
         appendLine()
         appendLine("This report was assembled on the device and shared by hand.")

--- a/android/app/src/main/kotlin/io/relay/app/service/LocalLog.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/LocalLog.kt
@@ -4,26 +4,138 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.util.ArrayDeque
+import java.util.Locale
 
 /**
  * In-memory, local-only diagnostic log (zero-telemetry: never persisted, never
  * leaves the device). A bounded ring buffer surfaced in Advanced settings so a
  * user can see what happened without any data going anywhere.
+ *
+ * Every line used to be a bare sentence. That is readable and close to useless
+ * once a report is eighty lines long and the person who has to read it is not
+ * the person who wrote the sentences: there was no way to find the failures
+ * without reading all of it, no way to tell a networking line from an update
+ * line, and every value was buried inside prose where it could not be searched
+ * for. A real report arrived with four `Reply path check:` lines disagreeing
+ * with each other and nothing to sort them by.
+ *
+ * So a line now carries a [Level], an [Area] and named [Entry.fields]. The
+ * levels are what make a long report skimmable; the fields are what make a
+ * value greppable instead of quotable.
  */
 object LocalLog {
     private const val CAPACITY = 200
 
-    data class Entry(val elapsedMs: Long, val message: String)
+    /** How much attention a line deserves. */
+    enum class Level {
+        /** Something happened. Most lines. */
+        INFO,
+
+        /** Working, but not the way it should be, or not for long. */
+        WARN,
+
+        /** This is why it did not work. The line someone is looking for. */
+        ERROR,
+    }
+
+    /** Which part of Relay is speaking, so one concern can be followed through. */
+    enum class Area {
+        /** Starting, stopping, the foreground service, state changes. */
+        SERVICE,
+
+        /** Interfaces, addresses, which way the PC is reached. */
+        LINK,
+
+        /** The beacon, the pairing server, approving a PC. */
+        PAIRING,
+
+        /** The WireGuard endpoint and its peer. */
+        TUNNEL,
+
+        /** Checking for, fetching and installing a new version. */
+        UPDATE,
+    }
+
+    /**
+     * @param fields values a reader might want to search for or compare across
+     *   lines, kept out of the prose. Rendered as `key=value`, so an address
+     *   that appears in four places can be found by looking for one string.
+     */
+    data class Entry(
+        val elapsedMs: Long,
+        val message: String,
+        val level: Level = Level.INFO,
+        val area: Area = Area.SERVICE,
+        val fields: Map<String, String> = emptyMap(),
+    ) {
+        /**
+         * The line as a person reads it, in a report or on the Advanced screen.
+         *
+         * Fixed-width columns, because the reason for having levels at all is
+         * being able to run an eye down them. A value with a space in it is
+         * quoted so `key=value` stays one token to a reader and to a grep.
+         */
+        fun render(): String {
+            val head = "%8.2f  %-5s %-7s %s".format(
+                Locale.ROOT, elapsedMs / 1000.0, level.name, area.name.lowercase(Locale.ROOT), message,
+            )
+            return head + tail()
+        }
+
+        /**
+         * The short form, for the list on the Advanced screen.
+         *
+         * That list is a 160dp box on a phone, where the level and area columns
+         * would cost most of a line's width and push the message into wrapping.
+         * On screen the level is shown as colour instead; the full form is what
+         * goes into a shared report, where width is not scarce and whoever is
+         * reading it is not the person who was there.
+         */
+        fun renderCompact(): String =
+            "%6.1fs  %s".format(Locale.ROOT, elapsedMs / 1000.0, message) + tail()
+
+        private fun tail(): String {
+            if (fields.isEmpty()) return ""
+            return "  " + fields.entries.joinToString(" ") { (key, value) ->
+                if (value.any { it.isWhitespace() }) "$key=\"$value\"" else "$key=$value"
+            }
+        }
+    }
 
     private val start = System.currentTimeMillis()
     private val buffer = ArrayDeque<Entry>(CAPACITY)
     private val _entries = MutableStateFlow<List<Entry>>(emptyList())
     val entries: StateFlow<List<Entry>> = _entries.asStateFlow()
 
+    fun info(area: Area, message: String, vararg fields: Pair<String, String>) =
+        add(Level.INFO, area, message, fields)
+
+    fun warn(area: Area, message: String, vararg fields: Pair<String, String>) =
+        add(Level.WARN, area, message, fields)
+
+    fun error(area: Area, message: String, vararg fields: Pair<String, String>) =
+        add(Level.ERROR, area, message, fields)
+
     @Synchronized
-    fun add(message: String) {
+    private fun add(
+        level: Level,
+        area: Area,
+        message: String,
+        fields: Array<out Pair<String, String>>,
+    ) {
         if (buffer.size >= CAPACITY) buffer.removeFirst()
-        buffer.addLast(Entry(System.currentTimeMillis() - start, message))
+        buffer.addLast(
+            Entry(
+                elapsedMs = System.currentTimeMillis() - start,
+                message = message,
+                level = level,
+                area = area,
+                // Last one wins rather than throwing: a duplicate key is a
+                // typo at a call site, and a log must never be the thing that
+                // crashes while something else is already going wrong.
+                fields = fields.toMap(),
+            )
+        )
         _entries.value = buffer.toList()
     }
 

--- a/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/SharingService.kt
@@ -26,6 +26,7 @@ import io.relay.app.core.QrPayload
 import io.relay.app.core.ReconnectPolicy
 import io.relay.app.core.WarningCode
 import io.relay.app.core.WgConfig
+import io.relay.app.net.LinkSnapshot
 import io.relay.app.net.LocalAddress
 import io.relay.app.core.PairingCode
 import io.relay.app.net.Beacon
@@ -224,7 +225,7 @@ class SharingService : Service() {
 
     private suspend fun startSharing() {
         if (!ConnectionRepository.dispatch("start") { ConnectionState.Preparing }) return
-        LocalLog.add("Starting sharing")
+        LocalLog.info(LocalLog.Area.SERVICE, "Starting sharing")
         ConnectionRepository.clearWarnings()
 
         // Non-blocking advisory: sharing works either way, but the user may have
@@ -236,9 +237,17 @@ class SharingService : Service() {
         // Works on the phone's hotspot, a shared Wi-Fi/LAN, or a USB cable.
         val host = awaitAdvertisableIpv4()
         if (host == null) {
-            LocalLog.add(
-                "No usable Wi-Fi, hotspot or USB link after ${LinkWait.totalBoundMs} ms " +
-                    "(${LinkWait.looks} looks)"
+            // The links themselves, not just the conclusion. A report saying
+            // only "no usable link" cannot tell a cable that is not plugged in
+            // from one whose tethering is off from one that is still getting an
+            // address -- three faults, three different things to tell someone,
+            // and answering that used to take a message to the user and a day.
+            LocalLog.error(
+                LocalLog.Area.LINK, "No usable Wi-Fi, hotspot or USB link",
+                "waited_ms" to LinkWait.totalBoundMs.toString(),
+                "looks" to LinkWait.looks.toString(),
+                "vpn" to VpnStatus.isVpnActive(this).toString(),
+                "links" to LinkSnapshot.summarise(LinkSnapshot.take()),
             )
             fail(ErrorCode.HOTSPOT_OFF)
             return
@@ -280,10 +289,15 @@ class SharingService : Service() {
         val announced = announcer.canAnnounce
         pairingCode = code
         shortCode = code.takeIf { announced }
-        LocalLog.add(
-            if (announced) "Pairing code: $code"
-            else "Cannot announce on this network; showing the 8-character code instead",
-        )
+        if (announced) {
+            LocalLog.info(LocalLog.Area.PAIRING, "Pairing code issued", "code" to code)
+        } else {
+            LocalLog.warn(
+                LocalLog.Area.PAIRING,
+                "Cannot announce on this network; showing the 8-character code instead",
+                "code" to code,
+            )
+        }
 
         ConnectionRepository.dispatch("ready") {
             ConnectionState.Advertising(payload, pairing.issueTypedCode(payload), shortCode)
@@ -295,7 +309,7 @@ class SharingService : Service() {
     private fun prepareFull(host: String): QrPayload? {
         val forwarder = wgForwarder
         if (forwarder == null) {
-            LocalLog.add("WireGuard forwarder unavailable")
+            LocalLog.error(LocalLog.Area.TUNNEL, "No WireGuard forwarder in this build")
             fail(ErrorCode.WG_START_FAILED)
             return null
         }
@@ -303,12 +317,18 @@ class SharingService : Service() {
         try {
             forwarder.start(WgConfig.serverConfig(keys))
         } catch (e: WgForwarderException) {
-            LocalLog.add("WireGuard endpoint failed: ${e.message}")
+            LocalLog.error(
+                LocalLog.Area.TUNNEL, "The WireGuard endpoint would not start",
+                "error" to (e.message ?: "no message"),
+            )
             fail(ErrorCode.WG_START_FAILED)
             return null
         }
         wgKeys = keys
-        LocalLog.add("WireGuard endpoint up on $host:${keys.endpointPort}")
+        LocalLog.info(
+            LocalLog.Area.TUNNEL, "WireGuard endpoint up",
+            "host" to host, "port" to keys.endpointPort.toString(),
+        )
         startPeerWatcher(forwarder)
         startPairingServer()
         return pairing.issuePayload(
@@ -337,7 +357,12 @@ class SharingService : Service() {
             if (host != null) {
                 // Only worth a line when waiting actually did something. On the
                 // common path this says nothing at all.
-                if (waited > 0) LocalLog.add("A usable link appeared after $waited ms")
+                if (waited > 0) {
+                    LocalLog.info(
+                        LocalLog.Area.LINK, "A usable link appeared",
+                        "waited_ms" to waited.toString(), "host" to host,
+                    )
+                }
                 return host
             }
         }
@@ -361,9 +386,11 @@ class SharingService : Service() {
     private fun noteReplyPath(host: String) {
         val peer = VpnCapture.aPeerOn(host) ?: return
         val swallowed = VpnCapture.wouldSwallow(client = peer, advertisedHost = host)
-        LocalLog.add(
-            if (swallowed) "Reply path check: a reply to $peer would leave by the VPN, not by $host"
-            else "Reply path check: replies to $peer leave by $host, as they should"
+        LocalLog.info(
+            LocalLog.Area.LINK, "Reply path checked before any PC asked",
+            "probe" to peer,
+            "advertised" to host,
+            "verdict" to if (swallowed) "would-leave-by-vpn" else "leaves-by-the-link",
         )
     }
 
@@ -398,9 +425,11 @@ class SharingService : Service() {
                 // and not worth alarming anyone with.
                 if (host != null) {
                     val swallowed = VpnCapture.wouldSwallow(client = client, advertisedHost = host)
-                    LocalLog.add(
-                        if (swallowed) "Reply path to $client: would leave by the VPN, not by $host"
-                        else "Reply path to $client: leaves by $host, as it should"
+                    LocalLog.info(
+                        LocalLog.Area.LINK, "Reply path checked for the PC that asked",
+                        "pc" to client,
+                        "advertised" to host,
+                        "verdict" to if (swallowed) "would-leave-by-vpn" else "leaves-by-the-link",
                     )
                 }
                 if (keys == null || host == null) null
@@ -413,10 +442,16 @@ class SharingService : Service() {
         )
         pairingServer = try {
             server.start()
-            LocalLog.add("Pairing by code available on ${server.boundPort}")
+            LocalLog.info(
+                LocalLog.Area.PAIRING, "Pairing by code available",
+                "port" to server.boundPort.toString(),
+            )
             server
         } catch (e: IOException) {
-            LocalLog.add("Pairing port busy; this phone is QR-only: ${e.message}")
+            LocalLog.warn(
+                LocalLog.Area.PAIRING, "Pairing port busy; this phone is QR-only",
+                "error" to (e.message ?: "no message"),
+            )
             null
         }
     }
@@ -458,9 +493,12 @@ class SharingService : Service() {
                     saidNoReply = noReply
                     ConnectionRepository.setWarning(WarningCode.PC_GOT_NO_REPLY, noReply)
                     if (noReply) {
-                        LocalLog.add(
-                            "A PC took the settings ${HandshakeWatch.GRACE_MS / 1000} s ago and " +
-                                "the tunnel never handshaked; replies are not leaving this phone"
+                        LocalLog.warn(
+                            LocalLog.Area.TUNNEL,
+                            "A PC took the settings and the tunnel never handshaked; " +
+                                "replies are not leaving this phone",
+                            "waited_s" to (HandshakeWatch.GRACE_MS / 1000).toString(),
+                            "vpn" to VpnStatus.isVpnActive(this@SharingService).toString(),
                         )
                     }
                 }
@@ -508,7 +546,11 @@ class SharingService : Service() {
                     // without this a laptop that scans the QR over the new cable
                     // is handed the Wi-Fi address it has no route to.
                     if (ShouldRetarget.now(advertised = currentHost, best = host, connected = state is ConnectionState.Connected)) {
-                        LocalLog.add("A better address appeared: $host")
+                        LocalLog.info(
+                            LocalLog.Area.LINK, "A better address appeared",
+                            "host" to host,
+                            "links" to LinkSnapshot.summarise(LinkSnapshot.take()),
+                        )
                         rebind(host)
                     }
                     continue
@@ -520,19 +562,28 @@ class SharingService : Service() {
 
     /** Returns true when the hotspot came back (session restored), false when the budget was exhausted. */
     private suspend fun runReconnect(): Boolean {
-        LocalLog.add("Hotspot dropped — reconnecting")
+        LocalLog.warn(
+            LocalLog.Area.LINK, "The link dropped; reconnecting",
+            "links" to LinkSnapshot.summarise(LinkSnapshot.take()),
+        )
         ConnectionRepository.annotateReconnecting(true)
         for ((attempt, wait) in ReconnectPolicy.attemptDelaysMs.withIndex()) {
             delay(wait)
             val host = LocalAddress.findAdvertisableIpv4()
             if (host != null) {
-                LocalLog.add("Network back after attempt ${attempt + 1}")
+                LocalLog.info(
+                    LocalLog.Area.LINK, "The link came back",
+                    "attempt" to (attempt + 1).toString(),
+                )
                 ConnectionRepository.annotateReconnecting(false)
                 if (host != currentHost) rebind(host)
                 return true
             }
         }
-        LocalLog.add("Reconnect budget exhausted")
+        LocalLog.error(
+            LocalLog.Area.LINK, "Reconnect budget exhausted",
+            "links" to LinkSnapshot.summarise(LinkSnapshot.take()),
+        )
         fail(ErrorCode.HOTSPOT_LOST)
         return false
     }
@@ -547,7 +598,10 @@ class SharingService : Service() {
     private fun rebind(host: String) {
         currentHost = host
         val keys = wgKeys ?: return
-        LocalLog.add("Re-advertising WireGuard on $host:${keys.endpointPort}")
+        LocalLog.info(
+            LocalLog.Area.TUNNEL, "Re-advertising WireGuard",
+            "host" to host, "port" to keys.endpointPort.toString(),
+        )
         val payload = pairing.issuePayload(
             mode = QrPayload.MODE_WIREGUARD, host = host, port = keys.endpointPort,
             deviceName = Build.MODEL.take(64), wg = WgConfig.toWgParams(keys),
@@ -576,10 +630,18 @@ class SharingService : Service() {
             // old one could not, or the other way round. Re-ask rather than
             // keeping an answer that was true of a network we have left.
             shortCode = code.takeIf { announcer.canAnnounce }
-            LocalLog.add(
-                if (announcer.canAnnounce) "Re-announcing $code on ${payload.host}:${payload.port}"
-                else "Cannot announce on this network; showing the 8-character code instead",
-            )
+            if (announcer.canAnnounce) {
+                LocalLog.info(
+                    LocalLog.Area.PAIRING, "Re-announcing on the new network",
+                    "code" to code, "host" to payload.host, "port" to payload.port.toString(),
+                )
+            } else {
+                LocalLog.warn(
+                    LocalLog.Area.PAIRING,
+                    "Cannot announce on this network; showing the 8-character code instead",
+                    "code" to code, "host" to payload.host,
+                )
+            }
         }
 
         // Present the fresh payload in place; the client count (if any) is stale
@@ -655,7 +717,10 @@ class SharingService : Service() {
      * because a separate class used to raise these.
      */
     private fun onClientsChanged(devices: Int) {
-        LocalLog.add("Clients: $devices")
+        LocalLog.info(
+            LocalLog.Area.TUNNEL, "Connected client count changed",
+            "clients" to devices.toString(),
+        )
         if (devices > 0) {
             acquireWakeLock()
             ConnectionRepository.dispatch("clientConnected") { current ->

--- a/android/app/src/main/kotlin/io/relay/app/service/UpdateFetcher.kt
+++ b/android/app/src/main/kotlin/io/relay/app/service/UpdateFetcher.kt
@@ -117,17 +117,26 @@ object UpdateFetcher {
 
         when (val verdict = UpdateDownload.verify(target, checksums)) {
             is UpdateDownload.Result.Ready -> {
-                LocalLog.add("Update $apkName verified; opening the installer")
+                LocalLog.info(
+                    LocalLog.Area.UPDATE, "Update verified; opening the installer",
+                    "file" to apkName,
+                )
                 launchInstaller(context, verdict.file)
                 Result.Installing
             }
             UpdateDownload.Result.ChecksumMismatch -> {
                 // Loud, because this is the case that must never be shrugged off.
-                LocalLog.add("Update REJECTED: $apkName did not match the published checksum")
+                LocalLog.error(
+                    LocalLog.Area.UPDATE, "Update REJECTED: it did not match the published checksum",
+                    "file" to apkName,
+                )
                 Result.ChecksumMismatch
             }
             UpdateDownload.Result.Unverifiable -> {
-                LocalLog.add("Update rejected: no published checksum for $apkName")
+                LocalLog.error(
+                    LocalLog.Area.UPDATE, "Update rejected: the release published no checksum for it",
+                    "file" to apkName,
+                )
                 Result.Unverifiable
             }
             UpdateDownload.Result.Unavailable -> Result.Unavailable

--- a/android/app/src/main/kotlin/io/relay/app/ui/HomeScreen.kt
+++ b/android/app/src/main/kotlin/io/relay/app/ui/HomeScreen.kt
@@ -788,9 +788,18 @@ private fun AdvancedSection(
                         } else {
                             logs.asReversed().forEach { entry ->
                                 Text(
-                                    text = "%6.1fs  %s".format(Locale.US, entry.elapsedMs / 1000.0, entry.message),
+                                    text = entry.renderCompact(),
                                     style = MaterialTheme.typography.labelSmall,
-                                    color = glass.textTertiary,
+                                    // The level as colour rather than as a
+                                    // column: this box is 160dp on a phone, and
+                                    // the whole reason for having levels is
+                                    // being able to find the failure without
+                                    // reading every line.
+                                    color = when (entry.level) {
+                                        LocalLog.Level.ERROR -> glass.error
+                                        LocalLog.Level.WARN -> glass.warning
+                                        LocalLog.Level.INFO -> glass.textTertiary
+                                    },
                                     fontFamily = FontFamily.Monospace,
                                 )
                             }

--- a/android/app/src/main/kotlin/io/relay/app/ui/MainViewModel.kt
+++ b/android/app/src/main/kotlin/io/relay/app/ui/MainViewModel.kt
@@ -57,7 +57,10 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
             if (!UpdateCheck.isNewer(latest, currentVersion)) return@launch
 
             val version = latest.trimStart('v')
-            LocalLog.add("Update available: $latest")
+            LocalLog.info(
+                LocalLog.Area.UPDATE, "A newer release is available",
+                "latest" to latest, "current" to currentVersion,
+            )
             _updateAvailable.value = version
             // The banner only reaches someone already opening the app, which is
             // the person least likely to be on an old build.
@@ -93,11 +96,18 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                     UpdateNotice.clear(getApplication())
                 }
                 UpdateFetcher.Result.ChecksumMismatch ->
-                    LocalLog.add("Update refused: the download did not match the published checksum")
+                    LocalLog.error(
+                        LocalLog.Area.UPDATE,
+                        "Update refused: the download did not match the published checksum",
+                    )
                 UpdateFetcher.Result.Unverifiable ->
-                    LocalLog.add("Update refused: that release published no checksums")
+                    LocalLog.error(
+                        LocalLog.Area.UPDATE, "Update refused: that release published no checksums",
+                    )
                 UpdateFetcher.Result.Unavailable ->
-                    LocalLog.add("Update could not be downloaded; try again later")
+                    LocalLog.warn(
+                        LocalLog.Area.UPDATE, "Update could not be downloaded; try again later",
+                    )
             }
         }
     }

--- a/android/app/src/test/kotlin/io/relay/app/DiagnosticReportTest.kt
+++ b/android/app/src/test/kotlin/io/relay/app/DiagnosticReportTest.kt
@@ -76,6 +76,34 @@ class DiagnosticReportTest {
     }
 
     @Test
+    fun `counts the failures so they do not have to be found by reading`() {
+        val report = DiagnosticReport.build(
+            ConnectionState.Error(ErrorCode.HOTSPOT_OFF),
+            listOf(
+                LocalLog.Entry(0, "Starting sharing"),
+                LocalLog.Entry(1000, "no link", LocalLog.Level.ERROR, LocalLog.Area.LINK),
+                LocalLog.Entry(2000, "port busy", LocalLog.Level.WARN, LocalLog.Area.PAIRING),
+            ),
+        )
+
+        // A report is pasted into a chat and answered by somebody scrolling on a
+        // phone. The first line they need is how much of it is worth reading.
+        assertTrue(report, report.contains("1 error(s), 1 warning(s) in 3 line(s)"))
+    }
+
+    @Test
+    fun `does not claim the clock starts when sharing does`() {
+        // It said "seconds since sharing started" and counted from process
+        // start, so a report from a phone that had been open ninety minutes
+        // opened at 4999.58 and read like it came from another machine. A log's
+        // own header is the one line a reader trusts before reading anything.
+        val report = DiagnosticReport.build(ConnectionState.Idle, entries("Starting sharing"))
+
+        assertFalse(report, report.contains("since sharing started"))
+        assertTrue(report, report.contains("since the app started"))
+    }
+
+    @Test
     fun `describes a connected session with its client count`() {
         val payload = QrPayload(
             v = 1, mode = QrPayload.MODE_SOCKS5, host = "192.168.1.5", port = 1080,

--- a/android/app/src/test/kotlin/io/relay/app/LinkSnapshotTest.kt
+++ b/android/app/src/test/kotlin/io/relay/app/LinkSnapshotTest.kt
@@ -1,0 +1,91 @@
+package io.relay.app
+
+import io.relay.app.net.LinkSnapshot
+import io.relay.app.net.LinkSnapshot.Link
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * The line that answers "so what *was* plugged in?".
+ *
+ * Written from a real report in which the phone said, seven times, that there
+ * was no usable link — and it took a message to the user, in another country,
+ * to find out that a cable was plugged in with tethering just switched on and
+ * still negotiating its address. Every assertion here is one of the four
+ * different faults that line used to flatten into the same sentence.
+ */
+class LinkSnapshotTest {
+
+    @Test
+    fun `a cable still getting its address is not the same as no cable`() {
+        // The exact case that cost the round trip. rndis0 is up and has no
+        // address yet; if this collapsed to "nothing usable" the log would be
+        // back where it started.
+        assertEquals("no-ipv4", LinkSnapshot.verdictFor("rndis0", ipv4 = null, up = true))
+    }
+
+    @Test
+    fun `a cable that is not plugged in says so differently`() {
+        assertEquals("down", LinkSnapshot.verdictFor("rndis0", ipv4 = null, up = false))
+    }
+
+    @Test
+    fun `a VPN that is down reads as down, not as a VPN`() {
+        // "The VPN is not running" and "the VPN is running and we ignored it"
+        // send whoever reads this to opposite ends of the problem.
+        assertEquals("down", LinkSnapshot.verdictFor("tun0", "10.8.0.2", up = false))
+        assertEquals("vpn", LinkSnapshot.verdictFor("tun0", "10.8.0.2", up = true))
+    }
+
+    @Test
+    fun `the carrier's own link is named as cellular, not lumped in with the VPN`() {
+        // Both are refused, for the same reason and by the same list, but they
+        // mean completely different things to someone reading a report: one is
+        // "turn on Wi-Fi", the other is "your VPN is in the way".
+        assertEquals("cellular", LinkSnapshot.verdictFor("rmnet_data0", "10.66.4.1", up = true))
+    }
+
+    @Test
+    fun `464XLAT's prefixed name is still recognised as the carrier`() {
+        // Named v4-rmnet_data0, which is why the hints are substrings rather
+        // than prefixes. A prefix match would advertise a carrier address.
+        assertEquals("cellular", LinkSnapshot.verdictFor("v4-rmnet_data0", "10.66.4.1", up = true))
+    }
+
+    @Test
+    fun `a usable link is named by its kind`() {
+        assertEquals("wifi", LinkSnapshot.verdictFor("wlan0", "192.168.1.5", up = true))
+        assertEquals("hotspot", LinkSnapshot.verdictFor("ap0", "192.168.43.1", up = true))
+        assertEquals("usb", LinkSnapshot.verdictFor("rndis0", "192.168.42.129", up = true))
+    }
+
+    @Test
+    fun `the summary is one line and names every link`() {
+        val line = LinkSnapshot.summarise(
+            listOf(
+                Link("rndis0", ipv4 = null, verdict = "no-ipv4"),
+                Link("wlan0", "192.168.1.5", verdict = "wifi", score = 3),
+                Link("tun0", "10.8.0.2", verdict = "vpn"),
+            )
+        )
+
+        // One line, because this goes into a ring buffer somebody scrolls on a
+        // phone and then pastes into a chat. Six lines per failure pushes the
+        // failure itself off the top of what anyone reads.
+        assertTrue("summary spans lines: $line", !line.contains("\n"))
+
+        // And it has to actually carry the three facts, or none of the above
+        // reaches a report.
+        assertTrue(line, line.contains("rndis0(no-ipv4)"))
+        assertTrue(line, line.contains("wlan0(192.168.1.5 wifi score-3)"))
+        assertTrue(line, line.contains("tun0(10.8.0.2 vpn)"))
+    }
+
+    @Test
+    fun `no interfaces at all is said out loud`() {
+        // An empty string in a report reads as a bug in the reporting, and
+        // sends whoever is reading it looking in the wrong place.
+        assertEquals("no interfaces at all", LinkSnapshot.summarise(emptyList()))
+    }
+}

--- a/android/app/src/test/kotlin/io/relay/app/LocalLogRenderingTest.kt
+++ b/android/app/src/test/kotlin/io/relay/app/LocalLogRenderingTest.kt
@@ -1,0 +1,92 @@
+package io.relay.app
+
+import io.relay.app.service.LocalLog
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.util.Locale
+
+/**
+ * How a log line reaches the person who has to read it.
+ *
+ * A diagnostic log is only worth its space if a stranger can skim it. These
+ * assert the two properties that make that possible — that failures can be
+ * found without reading every line, and that values can be searched for rather
+ * than quoted — plus one that nearly shipped broken.
+ */
+class LocalLogRenderingTest {
+
+    private fun entry(
+        level: LocalLog.Level = LocalLog.Level.INFO,
+        area: LocalLog.Area = LocalLog.Area.LINK,
+        message: String = "something happened",
+        fields: Map<String, String> = emptyMap(),
+    ) = LocalLog.Entry(12_340L, message, level, area, fields)
+
+    @Test
+    fun `the level and the area are columns, not prose`() {
+        val line = entry(level = LocalLog.Level.ERROR, area = LocalLog.Area.TUNNEL).render()
+
+        // Fixed columns are the whole point: the reason for having levels is
+        // being able to run an eye down one place and find the failures.
+        assertTrue(line, line.contains("ERROR"))
+        assertTrue(line, line.contains("tunnel"))
+        assertEquals("   12.34  ERROR tunnel  something happened", line)
+    }
+
+    @Test
+    fun `fields are rendered as key=value`() {
+        val line = entry(fields = mapOf("host" to "192.168.1.5", "port" to "51820")).render()
+
+        // So an address that appears in four places can be found by searching
+        // for one string, instead of being reworded into four sentences.
+        assertTrue(line, line.contains("host=192.168.1.5"))
+        assertTrue(line, line.contains("port=51820"))
+    }
+
+    @Test
+    fun `a value with a space in it stays one token`() {
+        val line = entry(fields = mapOf("links" to "wlan0(192.168.1.5) tun0(vpn)")).render()
+
+        // The link snapshot is exactly this shape, and unquoted it would look
+        // like two fields, the second of which has no name.
+        assertTrue(line, line.contains("""links="wlan0(192.168.1.5) tun0(vpn)""""))
+    }
+
+    @Test
+    fun `no fields means no trailing clutter`() {
+        assertFalse(entry().render().endsWith(" "))
+        assertFalse(entry().render().contains("="))
+    }
+
+    @Test
+    fun `times do not follow the phone's locale`() {
+        // This one nearly shipped. String.format uses the default locale, so on
+        // a phone set to Persian -- which is most of the people this app is
+        // built for -- every timestamp in a shared report would have come out in
+        // Persian-Indic digits with a different decimal separator. A report the
+        // maintainer cannot read is a report that was not sent.
+        val default = Locale.getDefault()
+        try {
+            Locale.setDefault(Locale.forLanguageTag("fa-IR"))
+            val line = entry().render()
+            assertTrue("locale leaked into the timestamp: $line", line.contains("12.34"))
+        } finally {
+            Locale.setDefault(default)
+        }
+    }
+
+    @Test
+    fun `the compact form drops the columns and keeps the fields`() {
+        val compact = entry(
+            level = LocalLog.Level.ERROR,
+            fields = mapOf("host" to "192.168.1.5"),
+        ).renderCompact()
+
+        // On the Advanced screen the level is shown as colour instead, because
+        // that list is a 160dp box and the columns would cost most of a line.
+        assertFalse(compact, compact.contains("ERROR"))
+        assertTrue(compact, compact.contains("host=192.168.1.5"))
+    }
+}

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,73 @@
+# Reading a diagnostic report
+
+Relay's log never leaves the phone unless its owner sends it. When one arrives,
+this is how to read it — and, for anyone adding a log line, what the format is
+promising.
+
+## The line
+
+```
+    0.00  INFO  service Starting sharing
+    0.01  INFO  link    Reply path checked before any PC asked  probe=192.168.1.1 advertised=192.168.1.5 verdict=leaves-by-the-link
+    8.01  ERROR link    No usable Wi-Fi, hotspot or USB link  waited_ms=8000 looks=8 vpn=true links="rndis0(no-ipv4) wlan0(192.168.1.5 wifi score-3) tun0(10.8.0.2 vpn)"
+```
+
+| Column | Meaning |
+|---|---|
+| time | Seconds **since the app's process started** — not since sharing started, whatever an older build's header claimed |
+| level | `INFO` · `WARN` · `ERROR` |
+| area | `service` · `link` · `pairing` · `tunnel` · `update` |
+| message | A sentence, with no values in it |
+| fields | `key=value`, quoted when the value contains a space |
+
+The last line of the report counts the errors and warnings, because a report is
+usually read by somebody scrolling a chat on a phone.
+
+## Why values live in fields
+
+A value in a sentence has to be reworded every time it appears, so it cannot be
+searched for. `advertised=192.168.1.5` is the same string in every line that
+mentions it; "the address we advertised was 192.168.1.5" is not.
+
+## The `links` field
+
+The single most useful thing in a report about a connection that will not start.
+It names **every** interface, including the ones Relay deliberately refuses, with
+why:
+
+| Verdict | Meaning | What to tell the user |
+|---|---|---|
+| `no-ipv4` | Up, no address yet | **Wait and retry** — USB tethering looks exactly like this for a few seconds after it is switched on |
+| `down` | Present, not up | Plug the cable in / turn the hotspot on |
+| `cellular` | The carrier's own link | No PC can route to it; join a Wi-Fi or turn the hotspot on |
+| `vpn` | A tun interface | Ignored by design; a PC cannot reach the phone through it |
+| `wifi` `hotspot` `usb` | Advertisable, with its `score-N` | The highest score is the one in the QR |
+
+This exists because a report once said `No usable Wi-Fi or hotspot interface
+found` seven times, and answering it took a message to the user in another
+country. Their cable was plugged in with tethering just switched on — the
+`no-ipv4` case — which one line would have said.
+
+## Two lines that look like each other
+
+`Reply path checked …` appears twice: once at start-up against a stand-in
+address, once for the real PC once it asks. Both are **informational only**.
+
+The probe asks the kernel which interface a datagram *would* leave by. It cannot
+ask whether the packet arrives, and it has been observed saying
+`verdict=would-leave-by-vpn` on a session that paired a PC and carried traffic
+sixty seconds later. Triage with it; never conclude from it. What *does* mean the
+replies are lost is the `PC_GOT_NO_REPLY` warning — see
+[`vpn-compat.md`](vpn-compat.md).
+
+## Adding a line
+
+- Pick the **level** by what a reader should do: `ERROR` is "this is why it did
+  not work", `WARN` is "working, but not the way it should be", `INFO` is the
+  rest.
+- Put every value in a **field**, not in the sentence.
+- Where a failure has context worth capturing, capture it **at the moment of the
+  failure** — `LinkSnapshot.take()` costs one enumeration and is the difference
+  between a report that can be answered and one that needs a conversation.
+- Do not log anything that is not already on the device. Nothing here is
+  uploaded, and the report says so; keep that true.

--- a/docs/vpn-compat.md
+++ b/docs/vpn-compat.md
@@ -44,7 +44,7 @@ interface, the handshake never completes: no `accept()`, no prompt, and no
 warning either. **The case that most needs the message is the only case that
 cannot produce it.**
 
-Since 2.8.1 the diagnostic log carries a `Reply path check:` line written when
+Since 2.8.1 the diagnostic log carries a `Reply path checked` line written when
 sharing starts, before any PC is involved, so a report from a group-3 phone
 still says which way replies would leave.
 


### PR DESCRIPTION
## The line that started this

A real diagnostic report said this, seven times in a row:

```
No usable Wi-Fi or hotspot interface found
```

True, and useless. Was the cable not plugged in? Plugged in with tethering off?
Tethering on and the interface still negotiating an address? Was there a link
that got refused for looking like a VPN? **Four faults, four different things to
tell someone, one sentence covering all of them.**

Answering it took a message to the user, in another country, on Telegram, and a
day. The answer was the third one.

## What a failure records now

```
    8.01  ERROR link    No usable Wi-Fi, hotspot or USB link  waited_ms=8000 looks=8 vpn=true links="rndis0(no-ipv4) wlan0(192.168.1.5 wifi score-3) tun0(10.8.0.2 vpn)"
```

`LinkSnapshot` enumerates **every** interface — including the ones
`LocalAddress` deliberately refuses — and records the refusal:

| Verdict | Meaning |
|---|---|
| `no-ipv4` | Up, no address yet — **what USB tethering looks like for its first few seconds** |
| `down` | Present, not up |
| `cellular` | The carrier's own link |
| `vpn` | A tun interface |
| `wifi` `hotspot` `usb` | Advertisable, with the `score-N` that decides the QR |

`rndis0(no-ipv4)` is the answer that cost the round trip.

It is also attached to "the link dropped", "reconnect budget exhausted" and "a
better address appeared" — the other three places where knowing what was
actually there changes the reply.

## Structure, so a long report can be skimmed

Every line now carries a **level** (`INFO` / `WARN` / `ERROR`), an **area**
(`service` / `link` / `pairing` / `tunnel` / `update`), and named **fields**.

A value inside a sentence has to be reworded every time it appears and so cannot
be searched for. `advertised=192.168.1.5` is the same string in every line that
mentions it; *"the address we advertised was 192.168.1.5"* is not.

All **30 call sites were rewritten one at a time**, not by a regex — choosing the
level is the entire point of having levels, and a default would have made every
line `INFO`. The report ends with a count of errors and warnings, because it is
read by somebody scrolling a chat on a phone and that is the first thing they
need. On the Advanced screen the level is shown as colour instead of a column;
that list is a 160dp box and the columns would push the message into wrapping.

## Two bugs found on the way past

**The header was wrong.** It said *"seconds since sharing started"* and the clock
runs from **process** start. A report from a phone that had been open ninety
minutes opened at `4999.58` and read like it came from a different machine. A
log's own header is the one line a reader trusts before they have read anything
else.

**Timestamps followed the phone's locale.** `String.format` with no locale uses
the default one. On a device set to Persian — which is most of the people this
app is built for — every timestamp in a shared report would have come out in
Persian-Indic digits with a different decimal separator. A report the maintainer
cannot read is a report that was not sent.

`LocalLogRenderingTest` sets the default locale to `fa-IR` and asserts the
timestamp survives it. That test fails on the code as it stood this morning.

## Also

- `LocalAddress`'s unreachable list is now **derived** from a named cellular half
  and a named VPN half rather than written out once, so the fact that a link is
  refused and the reason it is refused cannot drift apart. A test asserts the
  464XLAT-prefixed `v4-rmnet_data0` is still caught, which is why those hints are
  substrings and not prefixes.
- [`docs/diagnostics.md`](../blob/feat/a-log-you-can-diagnose-from/docs/diagnostics.md)
  — how to read a report, and what a new log line is expected to do.

## Tests

| assertion | what it catches |
|---|---|
| a cable still getting its address ≠ no cable | **the fault that cost the round trip**, flattened back into one sentence |
| a VPN that is down reads as `down`, not `vpn` | "not running" and "running and ignored" sending a reader to opposite ends |
| the carrier is `cellular`, not lumped with the VPN | one means "turn on Wi-Fi", the other "your VPN is in the way" |
| `v4-rmnet_data0` is still the carrier | hints turning back into prefixes and a carrier address reaching a QR |
| the summary is one line | six lines per failure pushing the failure off the top of what anyone reads |
| `no interfaces at all` is said out loud | an empty string reading as a bug in the reporting |
| the level and area are fixed columns | levels that cannot be skimmed, which is the only reason to have them |
| a field value with a space stays one token | the link snapshot rendering as two fields, the second unnamed |
| **times do not follow the phone's locale** | the Persian-digits report |
| the header does not claim the wrong clock | `4999.58` reading as a timestamp from elsewhere |
| the report counts its own errors | a reader having to read all of it to find out if any of it matters |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
